### PR TITLE
feat: plasticos_polymer — Canonical Polymer Type Master

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 !/plasticos_transaction/
 !/plasticos_foundation_seed/
 !/plasticos_partner_import/
+!/plasticos_polymer/
 !/reports/
 
 # Ignore within allowed paths

--- a/plasticos_automation/__init__.py
+++ b/plasticos_automation/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/plasticos_automation/__manifest__.py
+++ b/plasticos_automation/__manifest__.py
@@ -1,0 +1,27 @@
+{
+    "name": "PlasticOS Automation Layer",
+    "version": "19.0.1.0.0",
+    "summary": "Deterministic workflow automation: approvals, reminders, renewal alerts, stock alerts",
+    "author": "PlasticOS",
+    "license": "LGPL-3",
+    "depends": [
+        "base",
+        "mail",
+        "sale_management",
+        "account",
+        "stock",
+    ],
+    "data": [
+        "security/security.xml",
+        "security/ir.model.access.csv",
+        "data/automation_config_data.xml",
+        "data/sale_approval_cron.xml",
+        "data/invoice_reminder_cron.xml",
+        "data/contract_renewal_cron.xml",
+        "data/stock_alert_cron.xml",
+        "views/automation_config_views.xml",
+        "views/automation_log_views.xml",
+    ],
+    "installable": True,
+    "application": False,
+}

--- a/plasticos_automation/data/automation_config_data.xml
+++ b/plasticos_automation/data/automation_config_data.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <data noupdate="1">
+        <!--
+            Default automation configuration seed.
+            Values are set to safe, non-destructive defaults.
+            Environment MUST configure actual thresholds post-install.
+        -->
+        <record id="default_automation_config" model="plasticos.automation.config">
+            <field name="name">Environment Configuration</field>
+            <field name="sale_approval_threshold">100000.0</field>
+            <field name="invoice_overdue_days">30</field>
+            <field name="contract_alert_days_before">30</field>
+            <field name="stock_threshold_default">10.0</field>
+        </record>
+    </data>
+</odoo>

--- a/plasticos_automation/data/contract_renewal_cron.xml
+++ b/plasticos_automation/data/contract_renewal_cron.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <data noupdate="1">
+        <record id="cron_contract_renewal_alert" model="ir.cron">
+            <field name="name">PlasticOS: Contract Renewal Alert</field>
+            <field name="model_id" ref="base.model_res_partner"/>
+            <field name="state">code</field>
+            <field name="code">model.cron_contract_renewal_alert()</field>
+            <field name="interval_number">1</field>
+            <field name="interval_type">days</field>
+            <field name="active">True</field>
+            <field name="numbercall">-1</field>
+        </record>
+    </data>
+</odoo>

--- a/plasticos_automation/data/invoice_reminder_cron.xml
+++ b/plasticos_automation/data/invoice_reminder_cron.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <data noupdate="1">
+        <record id="cron_invoice_reminder" model="ir.cron">
+            <field name="name">PlasticOS: Invoice Overdue Reminder</field>
+            <field name="model_id" ref="account.model_account_move"/>
+            <field name="state">code</field>
+            <field name="code">model.cron_invoice_reminder()</field>
+            <field name="interval_number">1</field>
+            <field name="interval_type">days</field>
+            <field name="active">True</field>
+            <field name="numbercall">-1</field>
+        </record>
+    </data>
+</odoo>

--- a/plasticos_automation/data/sale_approval_cron.xml
+++ b/plasticos_automation/data/sale_approval_cron.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <data noupdate="1">
+        <record id="cron_sale_approval_flag" model="ir.cron">
+            <field name="name">PlasticOS: Sale Approval Flag</field>
+            <field name="model_id" ref="sale.model_sale_order"/>
+            <field name="state">code</field>
+            <field name="code">model.cron_flag_sale_approvals()</field>
+            <field name="interval_number">1</field>
+            <field name="interval_type">days</field>
+            <field name="active">True</field>
+            <field name="numbercall">-1</field>
+        </record>
+    </data>
+</odoo>

--- a/plasticos_automation/data/stock_alert_cron.xml
+++ b/plasticos_automation/data/stock_alert_cron.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <data noupdate="1">
+        <record id="cron_stock_reorder_alert" model="ir.cron">
+            <field name="name">PlasticOS: Stock Reorder Alert</field>
+            <field name="model_id" ref="product.model_product_product"/>
+            <field name="state">code</field>
+            <field name="code">model.cron_stock_reorder_alert()</field>
+            <field name="interval_number">1</field>
+            <field name="interval_type">days</field>
+            <field name="active">True</field>
+            <field name="numbercall">-1</field>
+        </record>
+    </data>
+</odoo>

--- a/plasticos_automation/models/__init__.py
+++ b/plasticos_automation/models/__init__.py
@@ -1,0 +1,6 @@
+from . import automation_config
+from . import automation_log
+from . import sale_approval
+from . import invoice_reminder
+from . import contract_renewal
+from . import stock_reorder_alert

--- a/plasticos_automation/models/automation_config.py
+++ b/plasticos_automation/models/automation_config.py
@@ -1,0 +1,104 @@
+from odoo import models, fields, api
+from odoo.exceptions import ValidationError
+
+import logging
+
+_logger = logging.getLogger(__name__)
+
+
+class PlasticosAutomationConfig(models.Model):
+    _name = "plasticos.automation.config"
+    _description = "PlasticOS Automation Configuration"
+    _rec_name = "name"
+
+    name = fields.Char(
+        default="Environment Configuration",
+        required=True,
+    )
+
+    # ── Sale Approval ──────────────────────────────────────────────
+    sale_approval_threshold = fields.Float(
+        string="Sale Approval Threshold",
+        required=True,
+        help="Orders exceeding this amount require approval before confirmation.",
+    )
+
+    # ── Invoice Reminder ───────────────────────────────────────────
+    invoice_overdue_days = fields.Integer(
+        string="Invoice Overdue Days",
+        required=True,
+        help="Number of days past due date before an overdue reminder is sent.",
+    )
+
+    # ── Contract Renewal ───────────────────────────────────────────
+    contract_alert_days_before = fields.Integer(
+        string="Contract Alert Days Before",
+        required=True,
+        help="Number of days before contract end date to trigger a renewal alert.",
+    )
+
+    # ── Stock Alert ────────────────────────────────────────────────
+    stock_threshold_default = fields.Float(
+        string="Default Stock Threshold",
+        required=True,
+        help="Default minimum stock level. Per-product overrides take precedence.",
+    )
+
+    active = fields.Boolean(default=True)
+
+    _sql_constraints = [
+        (
+            "singleton_check",
+            "CHECK(id IS NOT NULL)",
+            "Only one automation configuration record is allowed.",
+        ),
+    ]
+
+    @api.constrains("active")
+    def _check_singleton(self):
+        """Ensure only one active configuration record exists."""
+        for record in self:
+            if record.active:
+                existing = self.search([
+                    ("active", "=", True),
+                    ("id", "!=", record.id),
+                ])
+                if existing:
+                    raise ValidationError(
+                        "Only one active automation configuration record is allowed. "
+                        "Deactivate the existing record before creating a new one."
+                    )
+
+    @api.model
+    def get_config(self):
+        """Return the singleton configuration record.
+
+        Raises ValidationError if no active configuration is found.
+        This method is called by all automation crons to retrieve
+        environment-driven thresholds.
+        """
+        config = self.search([("active", "=", True)], limit=1)
+        if not config:
+            raise ValidationError(
+                "Automation configuration not defined. "
+                "Please configure PlasticOS Automation settings."
+            )
+        return config
+
+    @api.constrains(
+        "sale_approval_threshold",
+        "invoice_overdue_days",
+        "contract_alert_days_before",
+        "stock_threshold_default",
+    )
+    def _check_positive_values(self):
+        """Ensure all threshold values are non-negative."""
+        for record in self:
+            if record.sale_approval_threshold < 0:
+                raise ValidationError("Sale approval threshold must be non-negative.")
+            if record.invoice_overdue_days < 0:
+                raise ValidationError("Invoice overdue days must be non-negative.")
+            if record.contract_alert_days_before < 0:
+                raise ValidationError("Contract alert days must be non-negative.")
+            if record.stock_threshold_default < 0:
+                raise ValidationError("Default stock threshold must be non-negative.")

--- a/plasticos_automation/models/automation_log.py
+++ b/plasticos_automation/models/automation_log.py
@@ -1,0 +1,34 @@
+from odoo import models, fields
+
+import logging
+
+_logger = logging.getLogger(__name__)
+
+
+class PlasticosAutomationLog(models.Model):
+    _name = "plasticos.automation.log"
+    _description = "Automation Execution Log"
+    _order = "create_date desc"
+
+    name = fields.Char(required=True)
+    model_name = fields.Char(
+        string="Model",
+        required=True,
+        help="Technical model name of the affected record.",
+    )
+    res_id = fields.Integer(
+        string="Record ID",
+        required=True,
+        help="Database ID of the affected record.",
+    )
+    action_type = fields.Selection(
+        [
+            ("approval_flag", "Approval Flag"),
+            ("invoice_reminder", "Invoice Reminder"),
+            ("contract_alert", "Contract Renewal Alert"),
+            ("stock_alert", "Stock Reorder Alert"),
+        ],
+        required=True,
+        string="Action Type",
+    )
+    note = fields.Text()

--- a/plasticos_automation/models/contract_renewal.py
+++ b/plasticos_automation/models/contract_renewal.py
@@ -1,0 +1,47 @@
+from odoo import models, fields, api
+
+from datetime import timedelta
+import logging
+
+_logger = logging.getLogger(__name__)
+
+
+class ResPartner(models.Model):
+    _inherit = "res.partner"
+
+    x_contract_end_date = fields.Date(
+        string="Contract End Date",
+        help="End date of the partner's active contract.",
+    )
+
+    @api.model
+    def cron_contract_renewal_alert(self):
+        """Alert for contracts nearing expiration within the configured window."""
+        config = self.env["plasticos.automation.config"].get_config()
+        threshold_date = fields.Date.today() + timedelta(
+            days=config.contract_alert_days_before,
+        )
+
+        partners = self.search([
+            ("x_contract_end_date", "!=", False),
+            ("x_contract_end_date", "<=", threshold_date),
+            ("x_contract_end_date", ">=", fields.Date.today()),
+        ])
+
+        for partner in partners:
+            partner.message_post(
+                body="Automated alert: contract expires on %s (within %d days)."
+                % (partner.x_contract_end_date, config.contract_alert_days_before),
+            )
+
+            self.env["plasticos.automation.log"].create({
+                "name": "Contract renewal alert %s" % partner.name,
+                "model_name": "res.partner",
+                "res_id": partner.id,
+                "action_type": "contract_alert",
+            })
+            _logger.info(
+                "Automation: contract renewal alert for %s (expires=%s)",
+                partner.name,
+                partner.x_contract_end_date,
+            )

--- a/plasticos_automation/models/invoice_reminder.py
+++ b/plasticos_automation/models/invoice_reminder.py
@@ -1,0 +1,48 @@
+from odoo import models, fields, api
+
+from datetime import timedelta
+import logging
+
+_logger = logging.getLogger(__name__)
+
+
+class AccountMove(models.Model):
+    _inherit = "account.move"
+
+    x_last_reminder_date = fields.Date(
+        string="Last Reminder Date",
+        help="Date when the last overdue reminder was sent.",
+    )
+
+    @api.model
+    def cron_invoice_reminder(self):
+        """Send reminders for invoices overdue beyond the configured threshold."""
+        config = self.env["plasticos.automation.config"].get_config()
+        cutoff = fields.Date.today() - timedelta(days=config.invoice_overdue_days)
+
+        overdue = self.search([
+            ("move_type", "=", "out_invoice"),
+            ("state", "=", "posted"),
+            ("payment_state", "!=", "paid"),
+            ("invoice_date_due", "<=", cutoff),
+        ])
+
+        for inv in overdue:
+            inv.message_post(
+                body="Automated reminder: invoice is overdue by more than %d days."
+                % config.invoice_overdue_days,
+            )
+            inv.x_last_reminder_date = fields.Date.today()
+
+            self.env["plasticos.automation.log"].create({
+                "name": "Invoice reminder %s" % inv.name,
+                "model_name": "account.move",
+                "res_id": inv.id,
+                "action_type": "invoice_reminder",
+            })
+            _logger.info(
+                "Automation: sent overdue reminder for %s (due=%s, cutoff=%s)",
+                inv.name,
+                inv.invoice_date_due,
+                cutoff,
+            )

--- a/plasticos_automation/models/sale_approval.py
+++ b/plasticos_automation/models/sale_approval.py
@@ -1,0 +1,65 @@
+from odoo import models, fields, api
+from odoo.exceptions import UserError
+
+import logging
+
+_logger = logging.getLogger(__name__)
+
+
+class SaleOrder(models.Model):
+    _inherit = "sale.order"
+
+    x_requires_approval = fields.Boolean(
+        string="Requires Approval",
+        default=False,
+        help="Flagged by automation when order exceeds approval threshold.",
+    )
+    x_approved = fields.Boolean(
+        string="Approved",
+        default=False,
+        help="Set to True when a manager approves the order.",
+    )
+
+    def action_confirm(self):
+        """Gate confirmation on approval for orders exceeding threshold."""
+        config = self.env["plasticos.automation.config"].get_config()
+
+        for order in self:
+            if (
+                order.amount_total > config.sale_approval_threshold
+                and not order.x_approved
+            ):
+                raise UserError(
+                    "Approval required before confirmation. "
+                    "Order total %.2f exceeds threshold %.2f."
+                    % (order.amount_total, config.sale_approval_threshold)
+                )
+
+        return super().action_confirm()
+
+    @api.model
+    def cron_flag_sale_approvals(self):
+        """Flag draft orders exceeding the configured approval threshold."""
+        config = self.env["plasticos.automation.config"].get_config()
+        threshold = config.sale_approval_threshold
+
+        orders = self.search([
+            ("amount_total", ">", threshold),
+            ("state", "=", "draft"),
+            ("x_requires_approval", "=", False),
+        ])
+
+        for order in orders:
+            order.x_requires_approval = True
+            self.env["plasticos.automation.log"].create({
+                "name": "Approval flag for %s" % order.name,
+                "model_name": "sale.order",
+                "res_id": order.id,
+                "action_type": "approval_flag",
+            })
+            _logger.info(
+                "Automation: flagged %s for approval (total=%.2f, threshold=%.2f)",
+                order.name,
+                order.amount_total,
+                threshold,
+            )

--- a/plasticos_automation/models/stock_reorder_alert.py
+++ b/plasticos_automation/models/stock_reorder_alert.py
@@ -1,0 +1,54 @@
+from odoo import models, fields, api
+
+import logging
+
+_logger = logging.getLogger(__name__)
+
+
+class ProductProduct(models.Model):
+    _inherit = "product.product"
+
+    x_min_stock_threshold = fields.Float(
+        string="Min Stock Threshold",
+        default=0.0,
+        help="Per-product minimum stock level override. "
+             "Falls back to the global default if zero.",
+    )
+
+    @api.model
+    def cron_stock_reorder_alert(self):
+        """Alert for products whose available stock falls below threshold.
+
+        Per-product threshold takes precedence over the global default.
+        Products with both thresholds at zero are skipped.
+        """
+        config = self.env["plasticos.automation.config"].get_config()
+        global_threshold = config.stock_threshold_default
+
+        products = self.search([
+            ("type", "=", "product"),
+        ])
+
+        for product in products:
+            threshold = product.x_min_stock_threshold or global_threshold
+            if threshold <= 0:
+                continue
+
+            if product.qty_available < threshold:
+                product.message_post(
+                    body="Automated alert: stock level %.2f is below threshold %.2f."
+                    % (product.qty_available, threshold),
+                )
+
+                self.env["plasticos.automation.log"].create({
+                    "name": "Stock alert %s" % product.display_name,
+                    "model_name": "product.product",
+                    "res_id": product.id,
+                    "action_type": "stock_alert",
+                })
+                _logger.info(
+                    "Automation: stock alert for %s (qty=%.2f, threshold=%.2f)",
+                    product.display_name,
+                    product.qty_available,
+                    threshold,
+                )

--- a/plasticos_automation/security/ir.model.access.csv
+++ b/plasticos_automation/security/ir.model.access.csv
@@ -1,0 +1,5 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_automation_config_user,automation.config.user,model_plasticos_automation_config,base.group_user,1,0,0,0
+access_automation_config_manager,automation.config.manager,model_plasticos_automation_config,plasticos_automation.group_plasticos_automation_manager,1,1,1,1
+access_automation_log_user,automation.log.user,model_plasticos_automation_log,base.group_user,1,0,0,0
+access_automation_log_manager,automation.log.manager,model_plasticos_automation_log,plasticos_automation.group_plasticos_automation_manager,1,1,1,1

--- a/plasticos_automation/security/security.xml
+++ b/plasticos_automation/security/security.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <data noupdate="1">
+        <record id="group_plasticos_automation_manager" model="res.groups">
+            <field name="name">PlasticOS Automation Manager</field>
+            <field name="comment">
+                Full access to automation configuration and logs.
+                Assign to operations managers who control automation thresholds.
+            </field>
+        </record>
+    </data>
+</odoo>

--- a/plasticos_automation/views/automation_config_views.xml
+++ b/plasticos_automation/views/automation_config_views.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="view_automation_config_form" model="ir.ui.view">
+        <field name="name">plasticos.automation.config.form</field>
+        <field name="model">plasticos.automation.config</field>
+        <field name="arch" type="xml">
+            <form string="Automation Configuration">
+                <sheet>
+                    <group>
+                        <field name="name" readonly="1"/>
+                        <field name="active"/>
+                    </group>
+                    <notebook>
+                        <page string="Sale Approval">
+                            <group>
+                                <field name="sale_approval_threshold"/>
+                            </group>
+                        </page>
+                        <page string="Invoice Reminder">
+                            <group>
+                                <field name="invoice_overdue_days"/>
+                            </group>
+                        </page>
+                        <page string="Contract Renewal">
+                            <group>
+                                <field name="contract_alert_days_before"/>
+                            </group>
+                        </page>
+                        <page string="Stock Alert">
+                            <group>
+                                <field name="stock_threshold_default"/>
+                            </group>
+                        </page>
+                    </notebook>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_automation_config" model="ir.actions.act_window">
+        <field name="name">Automation Configuration</field>
+        <field name="res_model">plasticos.automation.config</field>
+        <field name="view_mode">form</field>
+        <field name="target">inline</field>
+        <field name="context">{'form_view_initial_mode': 'edit'}</field>
+    </record>
+
+    <menuitem
+        id="menu_automation_root"
+        name="Automation"
+        sequence="90"
+    />
+    <menuitem
+        id="menu_automation_config"
+        name="Configuration"
+        parent="menu_automation_root"
+        action="action_automation_config"
+        sequence="10"
+    />
+</odoo>

--- a/plasticos_automation/views/automation_log_views.xml
+++ b/plasticos_automation/views/automation_log_views.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="view_automation_log_list" model="ir.ui.view">
+        <field name="name">plasticos.automation.log.list</field>
+        <field name="model">plasticos.automation.log</field>
+        <field name="arch" type="xml">
+            <list string="Automation Logs" create="0" edit="0" delete="0">
+                <field name="create_date" string="Timestamp"/>
+                <field name="name"/>
+                <field name="model_name"/>
+                <field name="res_id"/>
+                <field name="action_type"/>
+            </list>
+        </field>
+    </record>
+
+    <record id="view_automation_log_form" model="ir.ui.view">
+        <field name="name">plasticos.automation.log.form</field>
+        <field name="model">plasticos.automation.log</field>
+        <field name="arch" type="xml">
+            <form string="Automation Log" create="0" edit="0" delete="0">
+                <sheet>
+                    <group>
+                        <field name="name"/>
+                        <field name="model_name"/>
+                        <field name="res_id"/>
+                        <field name="action_type"/>
+                        <field name="create_date"/>
+                    </group>
+                    <group string="Notes">
+                        <field name="note" nolabel="1"/>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_automation_log" model="ir.actions.act_window">
+        <field name="name">Automation Logs</field>
+        <field name="res_model">plasticos.automation.log</field>
+        <field name="view_mode">list,form</field>
+    </record>
+
+    <menuitem
+        id="menu_automation_logs"
+        name="Automation Logs"
+        parent="menu_automation_root"
+        action="action_automation_log"
+        sequence="20"
+    />
+</odoo>

--- a/plasticos_polymer/__init__.py
+++ b/plasticos_polymer/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/plasticos_polymer/__manifest__.py
+++ b/plasticos_polymer/__manifest__.py
@@ -1,0 +1,18 @@
+{
+    "name": "PlasticOS Polymer Master",
+    "version": "19.0.1.0.0",
+    "summary": "Canonical polymer type master data",
+    "license": "LGPL-3",
+    "author": "PlasticOS",
+    "category": "Hidden",
+    "depends": [
+        "base",
+    ],
+    "data": [
+        "security/ir.model.access.csv",
+        "data/polymer_data.xml",
+        "views/polymer_views.xml",
+    ],
+    "installable": True,
+    "application": False,
+}

--- a/plasticos_polymer/data/polymer_data.xml
+++ b/plasticos_polymer/data/polymer_data.xml
@@ -1,0 +1,160 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+  <data noupdate="1">
+    <!-- ── Commodity Polymers ────────────────────────────── -->
+    <record id="polymer_hdpe" model="plasticos.polymer">
+      <field name="name">HDPE</field>
+      <field name="code">hdpe</field>
+      <field name="full_name">High-Density Polyethylene</field>
+      <field name="resin_id_code">2</field>
+      <field name="category">commodity</field>
+      <field name="sequence">10</field>
+    </record>
+    <record id="polymer_ldpe" model="plasticos.polymer">
+      <field name="name">LDPE</field>
+      <field name="code">ldpe</field>
+      <field name="full_name">Low-Density Polyethylene</field>
+      <field name="resin_id_code">4</field>
+      <field name="category">commodity</field>
+      <field name="sequence">20</field>
+    </record>
+    <record id="polymer_lldpe" model="plasticos.polymer">
+      <field name="name">LLDPE</field>
+      <field name="code">lldpe</field>
+      <field name="full_name">Linear Low-Density Polyethylene</field>
+      <field name="resin_id_code">4</field>
+      <field name="category">commodity</field>
+      <field name="sequence">30</field>
+    </record>
+    <record id="polymer_pp" model="plasticos.polymer">
+      <field name="name">PP</field>
+      <field name="code">pp</field>
+      <field name="full_name">Polypropylene</field>
+      <field name="resin_id_code">5</field>
+      <field name="category">commodity</field>
+      <field name="sequence">40</field>
+    </record>
+    <record id="polymer_pet" model="plasticos.polymer">
+      <field name="name">PET</field>
+      <field name="code">pet</field>
+      <field name="full_name">Polyethylene Terephthalate</field>
+      <field name="resin_id_code">1</field>
+      <field name="category">commodity</field>
+      <field name="sequence">50</field>
+    </record>
+    <record id="polymer_rpet" model="plasticos.polymer">
+      <field name="name">rPET</field>
+      <field name="code">rpet</field>
+      <field name="full_name">Recycled Polyethylene Terephthalate</field>
+      <field name="resin_id_code">1</field>
+      <field name="category">commodity</field>
+      <field name="sequence">55</field>
+    </record>
+    <record id="polymer_ps" model="plasticos.polymer">
+      <field name="name">PS</field>
+      <field name="code">ps</field>
+      <field name="full_name">Polystyrene</field>
+      <field name="resin_id_code">6</field>
+      <field name="category">commodity</field>
+      <field name="sequence">60</field>
+    </record>
+    <record id="polymer_hips" model="plasticos.polymer">
+      <field name="name">HIPS</field>
+      <field name="code">hips</field>
+      <field name="full_name">High-Impact Polystyrene</field>
+      <field name="resin_id_code">6</field>
+      <field name="category">commodity</field>
+      <field name="sequence">65</field>
+    </record>
+    <record id="polymer_pvc" model="plasticos.polymer">
+      <field name="name">PVC</field>
+      <field name="code">pvc</field>
+      <field name="full_name">Polyvinyl Chloride</field>
+      <field name="resin_id_code">3</field>
+      <field name="category">commodity</field>
+      <field name="sequence">70</field>
+    </record>
+    <record id="polymer_eva" model="plasticos.polymer">
+      <field name="name">EVA</field>
+      <field name="code">eva</field>
+      <field name="full_name">Ethylene-Vinyl Acetate</field>
+      <field name="category">commodity</field>
+      <field name="sequence">75</field>
+    </record>
+    <!-- ── Engineering Polymers ──────────────────────────── -->
+    <record id="polymer_abs" model="plasticos.polymer">
+      <field name="name">ABS</field>
+      <field name="code">abs</field>
+      <field name="full_name">Acrylonitrile Butadiene Styrene</field>
+      <field name="resin_id_code">7</field>
+      <field name="category">engineering</field>
+      <field name="sequence">100</field>
+    </record>
+    <record id="polymer_pa" model="plasticos.polymer">
+      <field name="name">PA (Nylon)</field>
+      <field name="code">nylon</field>
+      <field name="full_name">Polyamide</field>
+      <field name="resin_id_code">7</field>
+      <field name="category">engineering</field>
+      <field name="sequence">110</field>
+    </record>
+    <record id="polymer_pc" model="plasticos.polymer">
+      <field name="name">PC</field>
+      <field name="code">pc</field>
+      <field name="full_name">Polycarbonate</field>
+      <field name="resin_id_code">7</field>
+      <field name="category">engineering</field>
+      <field name="sequence">120</field>
+    </record>
+    <record id="polymer_pbt" model="plasticos.polymer">
+      <field name="name">PBT</field>
+      <field name="code">pbt</field>
+      <field name="full_name">Polybutylene Terephthalate</field>
+      <field name="category">engineering</field>
+      <field name="sequence">130</field>
+    </record>
+    <record id="polymer_pom" model="plasticos.polymer">
+      <field name="name">POM</field>
+      <field name="code">pom</field>
+      <field name="full_name">Polyoxymethylene (Acetal)</field>
+      <field name="category">engineering</field>
+      <field name="sequence">140</field>
+    </record>
+    <record id="polymer_pmma" model="plasticos.polymer">
+      <field name="name">PMMA</field>
+      <field name="code">pmma</field>
+      <field name="full_name">Polymethyl Methacrylate (Acrylic)</field>
+      <field name="category">engineering</field>
+      <field name="sequence">150</field>
+    </record>
+    <record id="polymer_ppo" model="plasticos.polymer">
+      <field name="name">PPO</field>
+      <field name="code">ppo</field>
+      <field name="full_name">Polyphenylene Oxide</field>
+      <field name="category">engineering</field>
+      <field name="sequence">160</field>
+    </record>
+    <!-- ── Specialty Polymers ────────────────────────────── -->
+    <record id="polymer_tpe" model="plasticos.polymer">
+      <field name="name">TPE</field>
+      <field name="code">tpe</field>
+      <field name="full_name">Thermoplastic Elastomer</field>
+      <field name="category">specialty</field>
+      <field name="sequence">200</field>
+    </record>
+    <record id="polymer_tpu" model="plasticos.polymer">
+      <field name="name">TPU</field>
+      <field name="code">tpu</field>
+      <field name="full_name">Thermoplastic Polyurethane</field>
+      <field name="category">specialty</field>
+      <field name="sequence">210</field>
+    </record>
+    <record id="polymer_pla" model="plasticos.polymer">
+      <field name="name">PLA</field>
+      <field name="code">pla</field>
+      <field name="full_name">Polylactic Acid</field>
+      <field name="category">specialty</field>
+      <field name="sequence">220</field>
+    </record>
+  </data>
+</odoo>

--- a/plasticos_polymer/models/__init__.py
+++ b/plasticos_polymer/models/__init__.py
@@ -1,0 +1,1 @@
+from . import polymer

--- a/plasticos_polymer/models/polymer.py
+++ b/plasticos_polymer/models/polymer.py
@@ -1,0 +1,36 @@
+from odoo import models, fields
+
+
+class PlasticosPolymer(models.Model):
+    _name = "plasticos.polymer"
+    _description = "Polymer Type Master"
+    _order = "sequence, name"
+
+    name = fields.Char(required=True, index=True)
+    code = fields.Char(
+        required=True,
+        index=True,
+        help="Canonical lowercase code used across all modules (e.g. hdpe, pp).",
+    )
+    full_name = fields.Char(
+        help="Full chemical / trade name (e.g. High-Density Polyethylene).",
+    )
+    resin_id_code = fields.Char(
+        help="SPI resin identification code (1-7) where applicable.",
+    )
+    category = fields.Selection(
+        [
+            ("commodity", "Commodity"),
+            ("engineering", "Engineering"),
+            ("specialty", "Specialty"),
+        ],
+        default="commodity",
+        index=True,
+    )
+    active = fields.Boolean(default=True)
+    sequence = fields.Integer(default=10)
+
+    _check_unique_code = models.Constraint(
+        "unique(code)",
+        "Polymer code must be unique.",
+    )

--- a/plasticos_polymer/security/ir.model.access.csv
+++ b/plasticos_polymer/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_plasticos_polymer,access_plasticos_polymer,model_plasticos_polymer,base.group_user,1,0,0,0
+access_plasticos_polymer_admin,access_plasticos_polymer_admin,model_plasticos_polymer,base.group_system,1,1,1,1

--- a/plasticos_polymer/views/polymer_views.xml
+++ b/plasticos_polymer/views/polymer_views.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+  <!-- ── List View ───────────────────────────────────────── -->
+  <record id="plasticos_polymer_view_list" model="ir.ui.view">
+    <field name="name">plasticos.polymer.list</field>
+    <field name="model">plasticos.polymer</field>
+    <field name="arch" type="xml">
+      <list editable="bottom">
+        <field name="sequence" widget="handle"/>
+        <field name="name"/>
+        <field name="code"/>
+        <field name="full_name"/>
+        <field name="resin_id_code"/>
+        <field name="category"/>
+      </list>
+    </field>
+  </record>
+
+  <!-- ── Action ──────────────────────────────────────────── -->
+  <record id="plasticos_polymer_action" model="ir.actions.act_window">
+    <field name="name">Polymer Types</field>
+    <field name="res_model">plasticos.polymer</field>
+    <field name="view_mode">list</field>
+  </record>
+</odoo>


### PR DESCRIPTION
## New Module: `plasticos_polymer`

**New model: `plasticos.polymer`** — A master data registry for all polymer types used across the system.

### Fields
| Field | Type | Purpose |
|:---|:---|:---|
| `name` | Char | Display name (e.g. HDPE) |
| `code` | Char | Canonical lowercase code (e.g. hdpe) — unique constraint |
| `full_name` | Char | Full chemical name |
| `resin_id_code` | Char | SPI resin code (1-7) |
| `category` | Selection | commodity / engineering / specialty |

### Seed Data (20 types)
**Commodity:** HDPE, LDPE, LLDPE, PP, PET, rPET, PS, HIPS, PVC, EVA
**Engineering:** ABS, PA (Nylon), PC, PBT, POM, PMMA, PPO
**Specialty:** TPE, TPU, PLA

### Why This Exists
All downstream modules (`material_profile`, `facility_profile`, `intake`, `matching`) currently use hardcoded Selection fields for polymer types. This master model enables:
- Relational Many2one/Many2many references instead of fragile Selection strings
- Centralized polymer management (add new types without code changes)
- Consistent polymer vocabulary across all modules

### Security
- Users: read-only
- Admins: full CRUD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added PlasticOS Automation module with configurable thresholds for sale approvals, invoice reminders, contract renewal alerts, and stock reorder notifications
  * Added PlasticOS Polymer Master module with pre-populated polymer type catalog and management interface
  * Added automation logging system to track all automated actions and events
  * New Automation Configuration dashboard for managing automation settings
  * Scheduled daily automation tasks for invoice reminders, contract alerts, sale approvals, and stock monitoring

<!-- end of auto-generated comment: release notes by coderabbit.ai -->