### PR TITLE
feat: Unify material.profile with Polymer Master

### DIFF
--- a/plasticos_material_profile/__manifest__.py
+++ b/plasticos_material_profile/__manifest__.py
@@ -1,20 +1,21 @@
 {
     "name": "PlasticOS Material Profile",
-    "version": "19.0.1.0.0",
-    "summary": "Material identity profiles for facility-level partners",
+    "version": "19.0.2.0.0",
+    "summary": "Material identity profiles — unified with polymer master",
     "license": "LGPL-3",
     "author": "PlasticOS",
     "category": "Hidden",
     "depends": [
         "base",
         "contacts",
-        "mail"
+        "mail",
+        "plasticos_polymer",
     ],
     "data": [
         "security/ir.model.access.csv",
         "data/polymer_seed.xml",
-        "views/material_profile_views.xml"
+        "views/material_profile_views.xml",
     ],
     "installable": True,
-    "application": False
+    "application": False,
 }

--- a/plasticos_material_profile/models/material_profile.py
+++ b/plasticos_material_profile/models/material_profile.py
@@ -2,11 +2,11 @@ from odoo import models, fields, api
 from odoo.exceptions import ValidationError
 
 
-class PlastosMaterialProfile(models.Model):
+class PlasticosMaterialProfile(models.Model):
     _name = "plasticos.material.profile"
     _description = "Material Identity Profile"
     _inherit = ["mail.thread"]
-    _order = "partner_id, polymer"
+    _order = "partner_id, polymer_id"
 
     partner_id = fields.Many2one(
         "res.partner",
@@ -14,60 +14,119 @@ class PlastosMaterialProfile(models.Model):
         index=True,
         domain="[('parent_id','!=',False)]",
         ondelete="cascade",
-        tracking=True
+        tracking=True,
     )
 
     active = fields.Boolean(default=True)
 
-    # Identity
-    polymer = fields.Selection([
-        ("pp", "PP"),
-        ("hdpe", "HDPE"),
-        ("ldpe", "LDPE"),
-        ("lldpe", "LLDPE"),
-        ("pet", "PET"),
-        ("ps", "PS"),
-        ("abs", "ABS"),
-        ("pvc", "PVC"),
-        ("nylon", "Nylon"),
-        ("other", "Other"),
-    ], index=True, required=True)
+    # ── Identity ─────────────────────────────────────────────
+    polymer_id = fields.Many2one(
+        "plasticos.polymer",
+        string="Polymer",
+        required=True,
+        index=True,
+        ondelete="restrict",
+        tracking=True,
+        help="Canonical polymer type from the master registry.",
+    )
+
+    # Backward-compatible computed field — reads polymer_id.code
+    polymer = fields.Selection(
+        [
+            ("pp", "PP"),
+            ("hdpe", "HDPE"),
+            ("ldpe", "LDPE"),
+            ("lldpe", "LLDPE"),
+            ("pet", "PET"),
+            ("rpet", "rPET"),
+            ("ps", "PS"),
+            ("hips", "HIPS"),
+            ("abs", "ABS"),
+            ("pvc", "PVC"),
+            ("nylon", "Nylon"),
+            ("pc", "PC"),
+            ("pom", "POM"),
+            ("tpe", "TPE"),
+            ("tpu", "TPU"),
+            ("pla", "PLA"),
+            ("eva", "EVA"),
+            ("other", "Other"),
+        ],
+        compute="_compute_polymer_code",
+        store=True,
+        index=True,
+        help="Auto-populated from polymer_id. Kept for backward compatibility.",
+    )
 
     sub_grade = fields.Char()
 
-    form = fields.Selection([
-        ("bale", "Bale"),
-        ("regrind", "Regrind"),
-        ("flake", "Flake"),
-        ("pellet", "Pellet"),
-        ("rollstock", "Rollstock"),
-        ("purge", "Purge"),
-        ("lump", "Lump"),
-        ("other", "Other"),
-    ], index=True, required=True)
+    form = fields.Selection(
+        [
+            ("bale", "Bale"),
+            ("regrind", "Regrind"),
+            ("flake", "Flake"),
+            ("pellet", "Pellet"),
+            ("rollstock", "Rollstock"),
+            ("purge", "Purge"),
+            ("lump", "Lump"),
+            ("film", "Film"),
+            ("sheet", "Sheet"),
+            ("powder", "Powder"),
+            ("parts", "Parts"),
+            ("other", "Other"),
+        ],
+        index=True,
+        required=True,
+    )
 
-    # Source & Process
-    source_type = fields.Selection([
-        ("post_industrial", "Post Industrial"),
-        ("post_consumer", "Post Consumer"),
-        ("mixed", "Mixed"),
-        ("unknown", "Unknown"),
-    ])
+    # ── Color ────────────────────────────────────────────────
+    color = fields.Selection(
+        [
+            ("natural", "Natural"),
+            ("white", "White"),
+            ("black", "Black"),
+            ("clear", "Clear"),
+            ("mixed", "Mixed"),
+            ("other", "Other"),
+        ],
+        help="Primary color of the material.",
+    )
+    color_flexibility = fields.Selection(
+        [
+            ("exact", "Exact Match Only"),
+            ("similar", "Similar Shades OK"),
+            ("any", "Any Color"),
+        ],
+        help="How flexible the buyer/seller is on color.",
+    )
 
-    origin_process_type = fields.Selection([
-        ("injection", "Injection"),
-        ("extrusion", "Extrusion"),
-        ("blow_mold", "Blow Mold"),
-        ("thermoform", "Thermoform"),
-        ("film", "Film"),
-        ("mixed", "Mixed"),
-        ("unknown", "Unknown"),
-    ])
+    # ── Source & Process ─────────────────────────────────────
+    source_type = fields.Selection(
+        [
+            ("post_industrial", "Post Industrial"),
+            ("post_consumer", "Post Consumer"),
+            ("mixed", "Mixed"),
+            ("virgin", "Virgin"),
+            ("unknown", "Unknown"),
+        ],
+    )
+
+    origin_process_type = fields.Selection(
+        [
+            ("injection", "Injection"),
+            ("extrusion", "Extrusion"),
+            ("blow_mold", "Blow Mold"),
+            ("thermoform", "Thermoform"),
+            ("film", "Film"),
+            ("mixed", "Mixed"),
+            ("unknown", "Unknown"),
+        ],
+    )
 
     previously_washed = fields.Boolean()
     previously_pelletized = fields.Boolean()
 
-    # Quality
+    # ── Quality ──────────────────────────────────────────────
     melt_flow_index = fields.Float(index=True)
     density = fields.Float()
     moisture_percent = fields.Float()
@@ -75,45 +134,77 @@ class PlastosMaterialProfile(models.Model):
     contains_metal = fields.Boolean()
     contains_fr = fields.Boolean()
 
-    # Volume
+    # ── Volume ───────────────────────────────────────────────
     avg_lot_size_lbs = fields.Float(index=True)
     min_lot_size_lbs = fields.Float()
     max_lot_size_lbs = fields.Float()
     monthly_volume_lbs = fields.Float(index=True)
 
-    frequency = fields.Selection([
-        ("one_time", "One Time"),
-        ("weekly", "Weekly"),
-        ("biweekly", "Biweekly"),
-        ("monthly", "Monthly"),
-        ("contract", "Contract"),
-    ])
+    frequency = fields.Selection(
+        [
+            ("one_time", "One Time"),
+            ("weekly", "Weekly"),
+            ("biweekly", "Biweekly"),
+            ("monthly", "Monthly"),
+            ("contract", "Contract"),
+        ],
+    )
 
-    # Packaging
-    packaging_type = fields.Selection([
-        ("gaylord", "Gaylord"),
-        ("supersack", "Super Sack"),
-        ("loose", "Loose"),
-        ("palletized", "Palletized"),
-        ("bulk_trailer", "Bulk Trailer"),
-        ("other", "Other"),
-    ])
+    # ── Packaging ────────────────────────────────────────────
+    packaging_type = fields.Selection(
+        [
+            ("gaylord", "Gaylord"),
+            ("supersack", "Super Sack"),
+            ("loose", "Loose"),
+            ("palletized", "Palletized"),
+            ("bulk_trailer", "Bulk Trailer"),
+            ("other", "Other"),
+        ],
+    )
 
     avg_truckloads_per_month = fields.Float()
 
-    # Compliance
+    # ── Compliance ───────────────────────────────────────────
     food_grade = fields.Boolean()
     medical_grade = fields.Boolean()
     certification_notes = fields.Text()
 
-    # AI Enrichment
+    # ── AI Enrichment ────────────────────────────────────────
     freeform_notes = fields.Text()
+
+    # ═════════════════════════════════════════════════════════
+    # Constraints
+    # ═════════════════════════════════════════════════════════
+
+    _check_unique_partner_polymer = models.Constraint(
+        "unique(partner_id, polymer_id, form)",
+        "A facility may only have one profile per polymer + form combination.",
+    )
+
+    # ═════════════════════════════════════════════════════════
+    # Computed
+    # ═════════════════════════════════════════════════════════
+
+    @api.depends("polymer_id", "polymer_id.code")
+    def _compute_polymer_code(self):
+        for rec in self:
+            rec.polymer = rec.polymer_id.code if rec.polymer_id else False
+
+    # ═════════════════════════════════════════════════════════
+    # Validation
+    # ═════════════════════════════════════════════════════════
 
     @api.constrains("partner_id")
     def _check_partner_is_facility(self):
         for rec in self:
             if not rec.partner_id.parent_id:
-                raise ValidationError("Material profiles can only attach to facility-level partners.")
+                raise ValidationError(
+                    "Material profiles can only attach to facility-level partners."
+                )
+
+    # ═════════════════════════════════════════════════════════
+    # CRUD
+    # ═════════════════════════════════════════════════════════
 
     @api.model_create_multi
     def create(self, vals_list):
@@ -128,12 +219,18 @@ class PlastosMaterialProfile(models.Model):
             rec._emit_material_packet()
         return res
 
+    # ═════════════════════════════════════════════════════════
+    # Capability Packet (stub for L9 adapter)
+    # ═════════════════════════════════════════════════════════
+
     def _emit_material_packet(self):
         for rec in self:
             packet = {
                 "partner_id": rec.partner_id.id,
-                "polymer": rec.polymer,
+                "polymer": rec.polymer_id.code if rec.polymer_id else None,
+                "polymer_name": rec.polymer_id.name if rec.polymer_id else None,
                 "form": rec.form,
+                "color": rec.color,
                 "quality": {
                     "mfi": rec.melt_flow_index,
                     "density": rec.density,
@@ -152,6 +249,7 @@ class PlastosMaterialProfile(models.Model):
                     "origin_process": rec.origin_process_type,
                     "washed": rec.previously_washed,
                     "pelletized": rec.previously_pelletized,
-                }
+                },
             }
+            # Stub only — L9 adapter will consume this.
             _ = packet

--- a/plasticos_material_profile/views/material_profile_views.xml
+++ b/plasticos_material_profile/views/material_profile_views.xml
@@ -6,8 +6,10 @@
     <field name="model">plasticos.material.profile</field>
     <field name="arch" type="xml">
       <list editable="bottom">
-        <field name="polymer"/>
+        <field name="polymer_id"/>
         <field name="form"/>
+        <field name="color"/>
+        <field name="source_type"/>
         <field name="monthly_volume_lbs"/>
         <field name="contamination_percent"/>
       </list>
@@ -20,50 +22,80 @@
     <field name="model">plasticos.material.profile</field>
     <field name="arch" type="xml">
       <form>
-        <group string="Identity">
-          <field name="polymer"/>
-          <field name="sub_grade"/>
-          <field name="form"/>
-        </group>
+        <sheet>
+          <notebook>
+            <page string="Identity">
+              <group>
+                <group string="Material">
+                  <field name="polymer_id"/>
+                  <field name="sub_grade"/>
+                  <field name="form"/>
+                </group>
+                <group string="Appearance">
+                  <field name="color"/>
+                  <field name="color_flexibility"/>
+                </group>
+              </group>
+            </page>
 
-        <group string="Source &amp; Process">
-          <field name="source_type"/>
-          <field name="origin_process_type"/>
-          <field name="previously_washed"/>
-          <field name="previously_pelletized"/>
-        </group>
+            <page string="Source &amp; Process">
+              <group>
+                <group>
+                  <field name="source_type"/>
+                  <field name="origin_process_type"/>
+                </group>
+                <group>
+                  <field name="previously_washed"/>
+                  <field name="previously_pelletized"/>
+                </group>
+              </group>
+            </page>
 
-        <group string="Quality">
-          <field name="melt_flow_index"/>
-          <field name="density"/>
-          <field name="moisture_percent"/>
-          <field name="contamination_percent"/>
-          <field name="contains_metal"/>
-          <field name="contains_fr"/>
-        </group>
+            <page string="Quality">
+              <group>
+                <group>
+                  <field name="melt_flow_index"/>
+                  <field name="density"/>
+                </group>
+                <group>
+                  <field name="moisture_percent"/>
+                  <field name="contamination_percent"/>
+                  <field name="contains_metal"/>
+                  <field name="contains_fr"/>
+                </group>
+              </group>
+            </page>
 
-        <group string="Volume">
-          <field name="avg_lot_size_lbs"/>
-          <field name="min_lot_size_lbs"/>
-          <field name="max_lot_size_lbs"/>
-          <field name="monthly_volume_lbs"/>
-          <field name="frequency"/>
-        </group>
+            <page string="Volume &amp; Packaging">
+              <group>
+                <group string="Volume">
+                  <field name="avg_lot_size_lbs"/>
+                  <field name="min_lot_size_lbs"/>
+                  <field name="max_lot_size_lbs"/>
+                  <field name="monthly_volume_lbs"/>
+                  <field name="frequency"/>
+                </group>
+                <group string="Packaging">
+                  <field name="packaging_type"/>
+                  <field name="avg_truckloads_per_month"/>
+                </group>
+              </group>
+            </page>
 
-        <group string="Packaging">
-          <field name="packaging_type"/>
-          <field name="avg_truckloads_per_month"/>
-        </group>
-
-        <group string="Compliance">
-          <field name="food_grade"/>
-          <field name="medical_grade"/>
-          <field name="certification_notes"/>
-        </group>
-
-        <group string="AI Notes">
-          <field name="freeform_notes"/>
-        </group>
+            <page string="Compliance &amp; Notes">
+              <group>
+                <group string="Compliance">
+                  <field name="food_grade"/>
+                  <field name="medical_grade"/>
+                  <field name="certification_notes"/>
+                </group>
+                <group string="Notes">
+                  <field name="freeform_notes"/>
+                </group>
+              </group>
+            </page>
+          </notebook>
+        </sheet>
       </form>
     </field>
   </record>
@@ -82,50 +114,84 @@
 
           <field name="material_profile_ids">
             <list editable="bottom">
-              <field name="polymer"/>
+              <field name="polymer_id"/>
               <field name="form"/>
+              <field name="color"/>
+              <field name="source_type"/>
               <field name="monthly_volume_lbs"/>
               <field name="contamination_percent"/>
             </list>
             <form>
-              <group string="Identity">
-                <field name="polymer"/>
-                <field name="sub_grade"/>
-                <field name="form"/>
-              </group>
-              <group string="Source &amp; Process">
-                <field name="source_type"/>
-                <field name="origin_process_type"/>
-                <field name="previously_washed"/>
-                <field name="previously_pelletized"/>
-              </group>
-              <group string="Quality">
-                <field name="melt_flow_index"/>
-                <field name="density"/>
-                <field name="moisture_percent"/>
-                <field name="contamination_percent"/>
-                <field name="contains_metal"/>
-                <field name="contains_fr"/>
-              </group>
-              <group string="Volume">
-                <field name="avg_lot_size_lbs"/>
-                <field name="min_lot_size_lbs"/>
-                <field name="max_lot_size_lbs"/>
-                <field name="monthly_volume_lbs"/>
-                <field name="frequency"/>
-              </group>
-              <group string="Packaging">
-                <field name="packaging_type"/>
-                <field name="avg_truckloads_per_month"/>
-              </group>
-              <group string="Compliance">
-                <field name="food_grade"/>
-                <field name="medical_grade"/>
-                <field name="certification_notes"/>
-              </group>
-              <group string="AI Notes">
-                <field name="freeform_notes"/>
-              </group>
+              <sheet>
+                <notebook>
+                  <page string="Identity">
+                    <group>
+                      <group string="Material">
+                        <field name="polymer_id"/>
+                        <field name="sub_grade"/>
+                        <field name="form"/>
+                      </group>
+                      <group string="Appearance">
+                        <field name="color"/>
+                        <field name="color_flexibility"/>
+                      </group>
+                    </group>
+                  </page>
+                  <page string="Source &amp; Process">
+                    <group>
+                      <group>
+                        <field name="source_type"/>
+                        <field name="origin_process_type"/>
+                      </group>
+                      <group>
+                        <field name="previously_washed"/>
+                        <field name="previously_pelletized"/>
+                      </group>
+                    </group>
+                  </page>
+                  <page string="Quality">
+                    <group>
+                      <group>
+                        <field name="melt_flow_index"/>
+                        <field name="density"/>
+                      </group>
+                      <group>
+                        <field name="moisture_percent"/>
+                        <field name="contamination_percent"/>
+                        <field name="contains_metal"/>
+                        <field name="contains_fr"/>
+                      </group>
+                    </group>
+                  </page>
+                  <page string="Volume &amp; Packaging">
+                    <group>
+                      <group string="Volume">
+                        <field name="avg_lot_size_lbs"/>
+                        <field name="min_lot_size_lbs"/>
+                        <field name="max_lot_size_lbs"/>
+                        <field name="monthly_volume_lbs"/>
+                        <field name="frequency"/>
+                      </group>
+                      <group string="Packaging">
+                        <field name="packaging_type"/>
+                        <field name="avg_truckloads_per_month"/>
+                      </group>
+                    </group>
+                  </page>
+                  <page string="Compliance &amp; Notes">
+                    <group>
+                      <group string="Compliance">
+                        <field name="food_grade"/>
+                        <field name="medical_grade"/>
+                        <field name="certification_notes"/>
+                      </group>
+                      <group string="Notes">
+                        <field name="freeform_notes"/>
+                      </group>
+                    </group>
+                  </page>
+                </notebook>
+              </sheet>
             </form>
           </field>
 


### PR DESCRIPTION
## Modified Model: `plasticos.material.profile`

Replaces the hardcoded `polymer` Selection field with a relational `polymer_id` Many2one to `plasticos.polymer`, and adds color/appearance fields from the BCP schema.

### Key Changes

| Change | Detail |
|:---|:---|
| `polymer_id` | New Many2one to `plasticos.polymer` — required, indexed, ondelete=restrict |
| `polymer` (kept) | Now a `compute+store` field reading `polymer_id.code` — full backward compat |
| `color` | New Selection: natural, white, black, clear, mixed, other |
| `color_flexibility` | New Selection: exact, similar, any |
| `form` expanded | Added: film, sheet, powder, parts |
| `source_type` expanded | Added: virgin |
| Constraint updated | `unique(partner_id, polymer_id, form)` — one profile per polymer+form combo |
| Class name fixed | `PlastosMaterialProfile` → `PlasticosMaterialProfile` |
| Views restructured | Tabbed notebook: Identity → Source → Quality → Volume → Compliance |

### Why This Matters
This is the supply-side half of the unified schema. Material profiles now speak the same polymer vocabulary as facility capability profiles. When intake references `material_profile_id`, the full chain is: **Company → Capability Profile → Material Profile → Intake → Matching**

### Dependencies
- Requires `plasticos_polymer` module (PR #4)