### PR TITLE
feat: Refactor Intake — Material Profile Reference + Onboarding Pipeline

### DIFF
--- a/plasticos_intake/__manifest__.py
+++ b/plasticos_intake/__manifest__.py
@@ -1,11 +1,12 @@
 {
     "name": "PlasticOS Intake",
-    "version": "19.0.1.0.0",
-    "summary": "Transactional Material Intake Engine",
+    "version": "19.0.2.0.0",
+    "summary": "Transactional Material Intake — unified with material profile",
     "author": "PlasticOS",
     "depends": [
         "base",
         "mail",
+        "plasticos_material_profile",
     ],
     "data": [
         "security/ir.model.access.csv",

--- a/plasticos_intake/models/intake.py
+++ b/plasticos_intake/models/intake.py
@@ -8,9 +8,9 @@ class PlasticosIntake(models.Model):
     _inherit = ["mail.thread", "mail.activity.mixin"]
     _order = "id desc"
 
-    # =========================
+    # ═════════════════════════════════════════════════════════
     # Identity
-    # =========================
+    # ═════════════════════════════════════════════════════════
 
     name = fields.Char(required=True, tracking=True)
     partner_id = fields.Many2one(
@@ -21,23 +21,36 @@ class PlasticosIntake(models.Model):
     )
     facility_id = fields.Many2one(
         "res.partner",
-        domain="[('parent_id', '=', partner_id)]"
+        domain="[('parent_id', '=', partner_id)]",
     )
-    # processing_profile_id = fields.Many2one(
-    #     "plasticos.processing.profile"
-    # )  # TODO: Enable when plasticos_processing module is available
 
-    # =========================
+    # ═════════════════════════════════════════════════════════
+    # Material Profile Reference (Unified Schema)
+    # ═════════════════════════════════════════════════════════
+
+    material_profile_id = fields.Many2one(
+        "plasticos.material.profile",
+        string="Material Profile",
+        index=True,
+        ondelete="set null",
+        domain="[('partner_id', '=', facility_id)]",
+        help="Link to the canonical material profile. When set, snapshot "
+             "fields below auto-populate from the profile.",
+    )
+
+    # ═════════════════════════════════════════════════════════
     # Raw Broker Layer
-    # =========================
+    # ═════════════════════════════════════════════════════════
 
     material_hint_text = fields.Text(
-        help="Raw broker description. Parsed later by L9."
+        help="Raw broker description. Parsed later by L9.",
     )
 
-    # =========================
+    # ═════════════════════════════════════════════════════════
     # Material Snapshot (Schema-Aligned)
-    # =========================
+    # Kept as editable Char/Selection for manual intake and
+    # backward compatibility. Can be pre-filled from profile.
+    # ═════════════════════════════════════════════════════════
 
     polymer = fields.Char(required=True, index=True)
     form = fields.Char(required=True, index=True)
@@ -45,105 +58,149 @@ class PlasticosIntake(models.Model):
     source_type = fields.Char()
     grade_hint = fields.Char()
 
-    # =========================
+    # ═════════════════════════════════════════════════════════
     # Observed Quality (Instance-Level)
-    # =========================
+    # ═════════════════════════════════════════════════════════
 
     mfi_value = fields.Float()
     density_value = fields.Float()
     moisture_ppm = fields.Integer()
     contamination_total_pct = fields.Float()
-
     has_metal = fields.Boolean()
     has_fr = fields.Boolean()
     has_residue = fields.Boolean()
-
     filler_type = fields.Char()
     filler_pct = fields.Float()
-
     contamination_notes = fields.Text()
 
-    # =========================
+    # ═════════════════════════════════════════════════════════
     # Origin Intelligence
-    # =========================
+    # ═════════════════════════════════════════════════════════
 
     origin_application = fields.Char()
+    origin_sector = fields.Selection(
+        [
+            ("medical", "Medical"),
+            ("automotive", "Automotive"),
+            ("packaging", "Packaging"),
+            ("construction", "Construction"),
+            ("consumer_goods", "Consumer Goods"),
+            ("industrial", "Industrial"),
+            ("other", "Other"),
+        ],
+    )
+    origin_process_type = fields.Selection(
+        [
+            ("injection", "Injection"),
+            ("extrusion", "Extrusion"),
+            ("blow_molding", "Blow Molding"),
+            ("thermoforming", "Thermoforming"),
+            ("rotomolding", "Rotomolding"),
+            ("film", "Film"),
+            ("compounding", "Compounding"),
+            ("unknown", "Unknown"),
+        ],
+        default="unknown",
+    )
 
-    origin_sector = fields.Selection([
-        ("medical", "Medical"),
-        ("automotive", "Automotive"),
-        ("packaging", "Packaging"),
-        ("construction", "Construction"),
-        ("consumer_goods", "Consumer Goods"),
-        ("industrial", "Industrial"),
-        ("other", "Other")
-    ])
-
-    origin_process_type = fields.Selection([
-        ("injection", "Injection"),
-        ("extrusion", "Extrusion"),
-        ("blow_molding", "Blow Molding"),
-        ("thermoforming", "Thermoforming"),
-        ("rotomolding", "Rotomolding"),
-        ("film", "Film"),
-        ("compounding", "Compounding"),
-        ("unknown", "Unknown")
-    ], default="unknown")
-
-    # =========================
+    # ═════════════════════════════════════════════════════════
     # Commercial Layer
-    # =========================
+    # ═════════════════════════════════════════════════════════
 
     quantity_per_load_lbs = fields.Integer(required=True)
     loads_per_month = fields.Integer()
-
-    deal_type = fields.Selection([
-        ("spot", "Spot"),
-        ("ongoing", "Ongoing")
-    ], default="spot")
-
+    deal_type = fields.Selection(
+        [
+            ("spot", "Spot"),
+            ("ongoing", "Ongoing"),
+        ],
+        default="spot",
+    )
     contract_duration_months = fields.Integer()
 
-    # =========================
+    # ═════════════════════════════════════════════════════════
+    # Onboarding Status
+    # ═════════════════════════════════════════════════════════
+
+    onboarding_status = fields.Selection(
+        [
+            ("draft", "Draft"),
+            ("profiled", "Profiled"),
+            ("normalized", "Normalized"),
+            ("ready", "Ready for Matching"),
+        ],
+        default="draft",
+        tracking=True,
+        index=True,
+        help="Tracks the intake's progression through the onboarding pipeline.",
+    )
+
+    # ═════════════════════════════════════════════════════════
     # Geo
-    # =========================
+    # ═════════════════════════════════════════════════════════
 
     lat = fields.Float()
     lon = fields.Float()
 
-    # =========================
+    # ═════════════════════════════════════════════════════════
     # Matching
-    # =========================
+    # ═════════════════════════════════════════════════════════
 
-    match_status = fields.Selection([
-        ("pending", "Pending"),
-        ("normalized", "Normalized"),
-        ("matched", "Matched"),
-        ("rejected", "Rejected"),
-        ("error", "Error"),
-    ], default="pending", tracking=True)
-
+    match_status = fields.Selection(
+        [
+            ("pending", "Pending"),
+            ("normalized", "Normalized"),
+            ("matched", "Matched"),
+            ("rejected", "Rejected"),
+            ("error", "Error"),
+        ],
+        default="pending",
+        tracking=True,
+    )
     match_response = fields.Json()
-
     normalized = fields.Boolean(
         default=False,
-        help="Must be True before adapter emits packet",
+        help="Must be True before adapter emits packet.",
     )
-
     last_packet_id = fields.Char(index=True)
     last_packet_version = fields.Char()
     last_packet_payload = fields.Json()
     last_packet_ts = fields.Datetime()
 
-    # SQL Constraint (Odoo 19 syntax: named class attribute)
+    # ═════════════════════════════════════════════════════════
+    # Constraints
+    # ═════════════════════════════════════════════════════════
+
     _check_unique_packet = models.Constraint(
         "unique(last_packet_id, last_packet_version)",
         "Duplicate packet emission detected.",
     )
 
-    # =========================
+    # ═════════════════════════════════════════════════════════
+    # Onchange — pre-fill from material profile
+    # ═════════════════════════════════════════════════════════
+
+    @api.onchange("material_profile_id")
+    def _onchange_material_profile(self):
+        """Pre-fill snapshot fields from the selected material profile."""
+        mp = self.material_profile_id
+        if not mp:
+            return
+        self.polymer = mp.polymer_id.code if mp.polymer_id else self.polymer
+        self.form = mp.form or self.form
+        self.color = mp.color or self.color
+        self.source_type = mp.source_type or self.source_type
+        self.mfi_value = mp.melt_flow_index or self.mfi_value
+        self.density_value = mp.density or self.density_value
+        self.contamination_total_pct = (
+            mp.contamination_percent or self.contamination_total_pct
+        )
+        if not self.onboarding_status or self.onboarding_status == "draft":
+            self.onboarding_status = "profiled"
+
+    # ═════════════════════════════════════════════════════════
     # Validation
-    # =========================
+    # ═════════════════════════════════════════════════════════
 
     @api.constrains("quantity_per_load_lbs")
     def _check_quantity(self):
@@ -157,27 +214,39 @@ class PlasticosIntake(models.Model):
             if rec.loads_per_month and rec.loads_per_month < 0:
                 raise ValidationError("Loads per month cannot be negative.")
 
+    # ═════════════════════════════════════════════════════════
+    # Actions
+    # ═════════════════════════════════════════════════════════
+
     def action_mark_normalized(self):
         for rec in self:
             rec.write({
                 "normalized": True,
                 "match_status": "normalized",
+                "onboarding_status": "normalized",
             })
 
+    def action_mark_ready(self):
+        """Mark intake as ready for matching after normalization."""
+        for rec in self:
+            if not rec.normalized:
+                raise UserError("Intake must be normalized before marking ready.")
+            rec.write({"onboarding_status": "ready"})
+
     def action_run_buyer_match(self):
-        # TODO: Enable when l9_trace module is available
-        # adapter = self.env["l9.adapter.service"]
         for rec in self:
             if not rec.normalized:
                 raise UserError("Intake must be normalized before match.")
-            # adapter.run_buyer_match(rec)
-            raise UserError("L9 adapter not yet configured. Enable l9_trace module.")
+            # L9 adapter stub — will be consumed by SDK adapter
+            raise UserError(
+                "L9 adapter not yet configured. Enable l9_trace module."
+            )
 
     def action_replay_last_packet(self):
-        # TODO: Enable when l9_trace module is available
-        # adapter = self.env["l9.adapter.service"]
         for rec in self:
             if not rec.last_packet_payload:
                 raise UserError("No stored packet to replay.")
-            # adapter.emit_raw_packet(rec.last_packet_payload)
-            raise UserError("L9 adapter not yet configured. Enable l9_trace module.")
+            # L9 adapter stub
+            raise UserError(
+                "L9 adapter not yet configured. Enable l9_trace module."
+            )

--- a/plasticos_intake/views/intake_views.xml
+++ b/plasticos_intake/views/intake_views.xml
@@ -1,5 +1,4 @@
 <odoo>
-
     <record id="view_plasticos_intake_tree" model="ir.ui.view">
         <field name="name">plasticos.intake.tree</field>
         <field name="model">plasticos.intake</field>
@@ -7,10 +6,12 @@
             <list>
                 <field name="name"/>
                 <field name="partner_id"/>
+                <field name="material_profile_id" optional="show"/>
                 <field name="polymer"/>
                 <field name="form"/>
                 <field name="quantity_per_load_lbs"/>
                 <field name="deal_type"/>
+                <field name="onboarding_status"/>
                 <field name="match_status"/>
             </list>
         </field>
@@ -21,75 +22,117 @@
         <field name="model">plasticos.intake</field>
         <field name="arch" type="xml">
             <form>
+                <header>
+                    <button
+                        name="action_mark_normalized"
+                        type="object"
+                        string="Mark Normalized"
+                        class="btn-primary"
+                        invisible="normalized"
+                    />
+                    <button
+                        name="action_mark_ready"
+                        type="object"
+                        string="Mark Ready"
+                        class="btn-primary"
+                        invisible="onboarding_status != 'normalized'"
+                    />
+                    <button
+                        name="action_run_buyer_match"
+                        type="object"
+                        string="Run Buyer Match"
+                        class="btn-success"
+                        invisible="onboarding_status != 'ready'"
+                    />
+                    <field name="onboarding_status" widget="statusbar"
+                           statusbar_visible="draft,profiled,normalized,ready"/>
+                </header>
                 <sheet>
-
-                    <group string="Identity">
-                        <field name="name"/>
-                        <field name="partner_id"/>
-                        <field name="facility_id"/>
-                        <!-- processing_profile_id: enable when plasticos_processing module available -->
+                    <group>
+                        <group string="Identity">
+                            <field name="name"/>
+                            <field name="partner_id"/>
+                            <field name="facility_id"/>
+                        </group>
+                        <group string="Material Profile Link">
+                            <field name="material_profile_id"/>
+                        </group>
                     </group>
 
-                    <group string="Raw Description">
-                        <field name="material_hint_text"/>
-                    </group>
+                    <notebook>
+                        <page string="Material">
+                            <group string="Raw Description">
+                                <field name="material_hint_text"/>
+                            </group>
+                            <group>
+                                <group string="Material Snapshot">
+                                    <field name="polymer"/>
+                                    <field name="form"/>
+                                    <field name="color"/>
+                                    <field name="source_type"/>
+                                    <field name="grade_hint"/>
+                                </group>
+                                <group string="Origin">
+                                    <field name="origin_application"/>
+                                    <field name="origin_sector"/>
+                                    <field name="origin_process_type"/>
+                                </group>
+                            </group>
+                        </page>
 
-                    <group string="Material Snapshot">
-                        <field name="polymer"/>
-                        <field name="form"/>
-                        <field name="color"/>
-                        <field name="source_type"/>
-                        <field name="grade_hint"/>
-                    </group>
+                        <page string="Quality">
+                            <group>
+                                <group string="Observed Quality">
+                                    <field name="mfi_value"/>
+                                    <field name="density_value"/>
+                                    <field name="moisture_ppm"/>
+                                    <field name="contamination_total_pct"/>
+                                </group>
+                                <group string="Contaminants">
+                                    <field name="has_metal"/>
+                                    <field name="has_fr"/>
+                                    <field name="has_residue"/>
+                                    <field name="filler_type"/>
+                                    <field name="filler_pct"/>
+                                </group>
+                            </group>
+                            <group string="Notes">
+                                <field name="contamination_notes"/>
+                            </group>
+                        </page>
 
-                    <group string="Observed Quality">
-                        <field name="mfi_value"/>
-                        <field name="density_value"/>
-                        <field name="moisture_ppm"/>
-                        <field name="contamination_total_pct"/>
-                        <field name="has_metal"/>
-                        <field name="has_fr"/>
-                        <field name="has_residue"/>
-                        <field name="filler_type"/>
-                        <field name="filler_pct"/>
-                        <field name="contamination_notes"/>
-                    </group>
+                        <page string="Commercial">
+                            <group>
+                                <group string="Volume">
+                                    <field name="quantity_per_load_lbs"/>
+                                    <field name="loads_per_month"/>
+                                </group>
+                                <group string="Deal">
+                                    <field name="deal_type"/>
+                                    <field name="contract_duration_months"/>
+                                </group>
+                            </group>
+                        </page>
 
-                    <group string="Origin">
-                        <field name="origin_application"/>
-                        <field name="origin_sector"/>
-                        <field name="origin_process_type"/>
-                    </group>
-
-                    <group string="Commercial">
-                        <field name="quantity_per_load_lbs"/>
-                        <field name="loads_per_month"/>
-                        <field name="deal_type"/>
-                        <field name="contract_duration_months"/>
-                    </group>
-
-                    <group string="Matching">
-                        <field name="match_status"/>
-                        <field name="match_response"/>
-                    </group>
-
-                    <group string="L9 Controls">
-                        <field name="normalized"/>
-                        <button
-                            name="action_mark_normalized"
-                            type="object"
-                            string="Mark Normalized"
-                            class="btn-primary"
-                        />
-                        <button
-                            name="action_run_buyer_match"
-                            type="object"
-                            string="Run Buyer Match"
-                            class="btn-success"
-                        />
-                    </group>
-
+                        <page string="Matching">
+                            <group>
+                                <group>
+                                    <field name="match_status"/>
+                                    <field name="normalized"/>
+                                </group>
+                                <group>
+                                    <field name="last_packet_id"/>
+                                    <field name="last_packet_version"/>
+                                    <field name="last_packet_ts"/>
+                                </group>
+                            </group>
+                            <group string="Match Response">
+                                <field name="match_response"/>
+                            </group>
+                        </page>
+                    </notebook>
                 </sheet>
+                <chatter/>
             </form>
         </field>
     </record>
@@ -103,7 +146,7 @@
     <record id="plasticos_intake_action" model="ir.actions.act_window">
         <field name="name">Material Intake</field>
         <field name="res_model">plasticos.intake</field>
-        <field name="view_mode">tree,form</field>
+        <field name="view_mode">list,form</field>
     </record>
 
     <!-- Intake Menu -->
@@ -112,5 +155,4 @@
               parent="plasticos_root_menu"
               action="plasticos_intake_action"
               sequence="1"/>
-
 </odoo>


### PR DESCRIPTION
## Modified Model: `plasticos.intake`

Links intake to the unified material profile and adds an onboarding status pipeline.

### Key Changes

| Change | Detail |
|:---|:---|
| `material_profile_id` | New Many2one to `plasticos.material.profile` — domain filtered by facility |
| `onboarding_status` | New Selection: draft → profiled → normalized → ready |
| `_onchange_material_profile` | Pre-fills polymer, form, color, source_type, quality fields from profile |
| `action_mark_ready` | New action — post-normalization gate before matching |
| Statusbar | `onboarding_status` displayed as statusbar widget in form header |
| Action buttons | Moved to header with visibility conditions per onboarding state |
| Form restructured | Tabbed notebook: Material, Quality, Commercial, Matching |
| Chatter added | `<chatter/>` appended to form |

### Architectural Significance
This is the key unification point. Intake now references the canonical material profile instead of duplicating its fields. The flow is:

```
Company → Facility → Material Profile → Intake (references profile) → Matching
```

Snapshot fields remain editable for manual intake and broker-provided data, but can be auto-populated from the profile via onchange.

### Dependencies
- Requires `plasticos_material_profile` (which requires `plasticos_polymer` from PR #4)