### PR TITLE
feat: plasticos_matching — Match Result Container for L9 Adapter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@
 !/plasticos_material_profile/
 !/plasticos_transaction/
 !/plasticos_foundation_seed/
+!/plasticos_matching/
+!/plasticos_offer/
 !/plasticos_partner_import/
 !/reports/
 

--- a/plasticos_matching/__init__.py
+++ b/plasticos_matching/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/plasticos_matching/__manifest__.py
+++ b/plasticos_matching/__manifest__.py
@@ -1,0 +1,20 @@
+{
+    "name": "PlasticOS Matching",
+    "version": "19.0.1.0.0",
+    "summary": "Match result storage — L9 adapter populates, Odoo displays",
+    "license": "LGPL-3",
+    "author": "PlasticOS",
+    "category": "Hidden",
+    "depends": [
+        "base",
+        "mail",
+        "plasticos_intake",
+        "plasticos_facility_profile",
+    ],
+    "data": [
+        "security/ir.model.access.csv",
+        "views/match_result_views.xml",
+    ],
+    "installable": True,
+    "application": False,
+}

--- a/plasticos_matching/models/__init__.py
+++ b/plasticos_matching/models/__init__.py
@@ -1,0 +1,1 @@
+from . import match_result

--- a/plasticos_matching/models/match_result.py
+++ b/plasticos_matching/models/match_result.py
@@ -1,0 +1,209 @@
+import logging
+
+from odoo import models, fields, api
+from odoo.exceptions import ValidationError
+
+_logger = logging.getLogger(__name__)
+
+
+class PlasticosMatchResult(models.Model):
+    """Stores match outcomes produced by the L9 adapter.
+
+    No scoring logic lives in Odoo. This model is a pure result
+    container: the L9 SDK adapter writes results here, and Odoo
+    users consume them through views and reports.
+    """
+
+    _name = "plasticos.match.result"
+    _description = "Material–Buyer Match Result"
+    _inherit = ["mail.thread"]
+    _order = "score desc, create_date desc"
+    _rec_name = "display_name"
+
+    # ═════════════════════════════════════════════════════════
+    # Supply Side (Intake)
+    # ═════════════════════════════════════════════════════════
+
+    intake_id = fields.Many2one(
+        "plasticos.intake",
+        required=True,
+        index=True,
+        ondelete="cascade",
+        tracking=True,
+        help="The intake record that was submitted for matching.",
+    )
+
+    # Denormalized for list-view performance — no joins needed
+    intake_polymer = fields.Char(
+        related="intake_id.polymer",
+        store=True,
+        index=True,
+    )
+    intake_form = fields.Char(
+        related="intake_id.form",
+        store=True,
+    )
+    intake_partner_id = fields.Many2one(
+        related="intake_id.partner_id",
+        store=True,
+        string="Supplier",
+    )
+
+    # ═════════════════════════════════════════════════════════
+    # Demand Side (Buyer / Facility Capability)
+    # ═════════════════════════════════════════════════════════
+
+    buyer_partner_id = fields.Many2one(
+        "res.partner",
+        string="Buyer",
+        required=True,
+        index=True,
+        ondelete="cascade",
+        tracking=True,
+        help="The buyer company matched to this intake.",
+    )
+    buyer_facility_id = fields.Many2one(
+        "res.partner",
+        string="Buyer Facility",
+        index=True,
+        ondelete="set null",
+        domain="[('parent_id', '=', buyer_partner_id)]",
+        help="Specific facility of the buyer, if matched at location level.",
+    )
+    facility_profile_id = fields.Many2one(
+        "plasticos.facility.profile",
+        string="Capability Profile",
+        index=True,
+        ondelete="set null",
+        help="The facility capability profile that was evaluated.",
+    )
+
+    # ═════════════════════════════════════════════════════════
+    # Score & Reasoning (written by L9)
+    # ═════════════════════════════════════════════════════════
+
+    score = fields.Float(
+        digits=(5, 2),
+        index=True,
+        tracking=True,
+        help="Overall match score (0–100). Computed by L9 adapter.",
+    )
+    confidence = fields.Float(
+        digits=(5, 2),
+        help="Confidence level of the match (0–100).",
+    )
+    score_breakdown = fields.Json(
+        help="Structured breakdown of score components from L9.",
+    )
+    match_reasoning = fields.Text(
+        help="Human-readable explanation of why this match was produced.",
+    )
+
+    # ═════════════════════════════════════════════════════════
+    # L9 Metadata
+    # ═════════════════════════════════════════════════════════
+
+    l9_run_id = fields.Char(
+        index=True,
+        help="Unique identifier of the L9 matching run.",
+    )
+    l9_model_version = fields.Char(
+        help="Version of the L9 matching model that produced this result.",
+    )
+    l9_timestamp = fields.Datetime(
+        help="Timestamp when L9 produced this result.",
+    )
+
+    # ═════════════════════════════════════════════════════════
+    # Lifecycle
+    # ═════════════════════════════════════════════════════════
+
+    state = fields.Selection(
+        [
+            ("pending", "Pending Review"),
+            ("accepted", "Accepted"),
+            ("rejected", "Rejected"),
+            ("expired", "Expired"),
+        ],
+        default="pending",
+        tracking=True,
+        index=True,
+    )
+    reviewed_by = fields.Many2one(
+        "res.users",
+        string="Reviewed By",
+        readonly=True,
+    )
+    reviewed_date = fields.Datetime(
+        readonly=True,
+    )
+    rejection_reason = fields.Text()
+
+    # ═════════════════════════════════════════════════════════
+    # Display
+    # ═════════════════════════════════════════════════════════
+
+    display_name = fields.Char(
+        compute="_compute_display_name",
+        store=True,
+    )
+
+    # ═════════════════════════════════════════════════════════
+    # Constraints
+    # ═════════════════════════════════════════════════════════
+
+    _check_unique_match_per_run = models.Constraint(
+        "unique(intake_id, buyer_partner_id, l9_run_id)",
+        "Duplicate match result for the same intake + buyer + run.",
+    )
+
+    _check_score_range = models.Constraint(
+        "check(score >= 0 AND score <= 100)",
+        "Score must be between 0 and 100.",
+    )
+
+    _check_confidence_range = models.Constraint(
+        "check(confidence >= 0 AND confidence <= 100)",
+        "Confidence must be between 0 and 100.",
+    )
+
+    # ═════════════════════════════════════════════════════════
+    # Computed
+    # ═════════════════════════════════════════════════════════
+
+    @api.depends("intake_id", "buyer_partner_id", "score")
+    def _compute_display_name(self):
+        for rec in self:
+            intake = rec.intake_id.name or "?"
+            buyer = rec.buyer_partner_id.name or "?"
+            rec.display_name = f"{intake} → {buyer} ({rec.score:.0f}%)"
+
+    # ═════════════════════════════════════════════════════════
+    # Actions
+    # ═════════════════════════════════════════════════════════
+
+    def action_accept(self):
+        """Accept this match result — marks it for offer generation."""
+        for rec in self:
+            rec.write({
+                "state": "accepted",
+                "reviewed_by": self.env.uid,
+                "reviewed_date": fields.Datetime.now(),
+            })
+        _logger.info(
+            "Match results accepted: %s",
+            self.mapped("display_name"),
+        )
+
+    def action_reject(self):
+        """Reject this match result."""
+        for rec in self:
+            rec.write({
+                "state": "rejected",
+                "reviewed_by": self.env.uid,
+                "reviewed_date": fields.Datetime.now(),
+            })
+        _logger.info(
+            "Match results rejected: %s",
+            self.mapped("display_name"),
+        )

--- a/plasticos_matching/security/ir.model.access.csv
+++ b/plasticos_matching/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_match_result_user,plasticos.match.result.user,model_plasticos_match_result,base.group_user,1,0,0,0
+access_match_result_manager,plasticos.match.result.manager,model_plasticos_match_result,base.group_system,1,1,1,1

--- a/plasticos_matching/views/match_result_views.xml
+++ b/plasticos_matching/views/match_result_views.xml
@@ -1,0 +1,115 @@
+<odoo>
+
+    <!-- List View -->
+    <record id="view_match_result_list" model="ir.ui.view">
+        <field name="name">plasticos.match.result.list</field>
+        <field name="model">plasticos.match.result</field>
+        <field name="arch" type="xml">
+            <list decoration-success="state == 'accepted'"
+                  decoration-danger="state == 'rejected'"
+                  decoration-muted="state == 'expired'">
+                <field name="intake_id"/>
+                <field name="intake_polymer"/>
+                <field name="intake_form"/>
+                <field name="intake_partner_id" string="Supplier"/>
+                <field name="buyer_partner_id"/>
+                <field name="buyer_facility_id" optional="hide"/>
+                <field name="score" widget="progressbar"/>
+                <field name="confidence" optional="show"/>
+                <field name="state"/>
+                <field name="create_date" string="Matched On"/>
+            </list>
+        </field>
+    </record>
+
+    <!-- Form View -->
+    <record id="view_match_result_form" model="ir.ui.view">
+        <field name="name">plasticos.match.result.form</field>
+        <field name="model">plasticos.match.result</field>
+        <field name="arch" type="xml">
+            <form>
+                <header>
+                    <button name="action_accept" type="object"
+                            string="Accept" class="btn-success"
+                            invisible="state != 'pending'"/>
+                    <button name="action_reject" type="object"
+                            string="Reject" class="btn-danger"
+                            invisible="state != 'pending'"/>
+                    <field name="state" widget="statusbar"
+                           statusbar_visible="pending,accepted"/>
+                </header>
+                <sheet>
+                    <group>
+                        <group string="Supply Side">
+                            <field name="intake_id"/>
+                            <field name="intake_polymer"/>
+                            <field name="intake_form"/>
+                            <field name="intake_partner_id"/>
+                        </group>
+                        <group string="Demand Side">
+                            <field name="buyer_partner_id"/>
+                            <field name="buyer_facility_id"/>
+                            <field name="facility_profile_id"/>
+                        </group>
+                    </group>
+
+                    <notebook>
+                        <page string="Score">
+                            <group>
+                                <group>
+                                    <field name="score" widget="progressbar"/>
+                                    <field name="confidence"/>
+                                </group>
+                                <group>
+                                    <field name="l9_run_id"/>
+                                    <field name="l9_model_version"/>
+                                    <field name="l9_timestamp"/>
+                                </group>
+                            </group>
+                            <group string="Score Breakdown">
+                                <field name="score_breakdown" widget="json"/>
+                            </group>
+                            <group string="Reasoning">
+                                <field name="match_reasoning"/>
+                            </group>
+                        </page>
+
+                        <page string="Review">
+                            <group>
+                                <group>
+                                    <field name="reviewed_by"/>
+                                    <field name="reviewed_date"/>
+                                </group>
+                                <group>
+                                    <field name="rejection_reason"
+                                           invisible="state != 'rejected'"/>
+                                </group>
+                            </group>
+                        </page>
+                    </notebook>
+                </sheet>
+                <chatter/>
+            </form>
+        </field>
+    </record>
+
+    <!-- Action -->
+    <record id="action_match_result" model="ir.actions.act_window">
+        <field name="name">Match Results</field>
+        <field name="res_model">plasticos.match.result</field>
+        <field name="view_mode">list,form</field>
+        <field name="context">{'search_default_state': 'pending'}</field>
+    </record>
+
+    <!-- Menu under PlasticOS root -->
+    <menuitem id="menu_matching_root"
+              name="Matching"
+              parent="plasticos_intake.plasticos_root_menu"
+              sequence="20"/>
+    <menuitem id="menu_match_results"
+              name="Match Results"
+              parent="menu_matching_root"
+              action="action_match_result"
+              sequence="1"/>
+
+</odoo>


### PR DESCRIPTION
## New Module: `plasticos_matching`
### New Model: `plasticos.match.result`

Pure result container — **no scoring logic in Odoo**. The L9 SDK adapter writes match results here; Odoo users consume them.

### Fields

| Group | Fields |
|:---|:---|
| **Supply Side** | `intake_id`, `intake_polymer` (related), `intake_form` (related), `intake_partner_id` (related) |
| **Demand Side** | `buyer_partner_id`, `buyer_facility_id`, `facility_profile_id` |
| **Score** | `score` (0-100), `confidence` (0-100), `score_breakdown` (JSON), `match_reasoning` (Text) |
| **L9 Metadata** | `l9_run_id`, `l9_model_version`, `l9_timestamp` |
| **Lifecycle** | `state` (pending/accepted/rejected/expired), `reviewed_by`, `reviewed_date`, `rejection_reason` |

### Constraints
- `unique(intake_id, buyer_partner_id, l9_run_id)` — no duplicate matches per run
- `check(score >= 0 AND score <= 100)`
- `check(confidence >= 0 AND confidence <= 100)`

### Views
- List: decorated by state, score as progressbar, denormalized polymer/form for zero-join display
- Form: header with Accept/Reject buttons + statusbar, tabbed Score + Review pages, chatter

### Dependencies
- `plasticos_intake`, `plasticos_facility_profile`