### PR TITLE
feat: plasticos_offer — Offer Lifecycle Management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@
 !/plasticos_material_profile/
 !/plasticos_transaction/
 !/plasticos_foundation_seed/
+!/plasticos_matching/
+!/plasticos_offer/
 !/plasticos_partner_import/
 !/reports/
 

--- a/plasticos_offer/__init__.py
+++ b/plasticos_offer/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/plasticos_offer/__manifest__.py
+++ b/plasticos_offer/__manifest__.py
@@ -1,0 +1,20 @@
+{
+    "name": "PlasticOS Offer",
+    "version": "19.0.1.0.0",
+    "summary": "Offer lifecycle management — from match to deal",
+    "license": "LGPL-3",
+    "author": "PlasticOS",
+    "category": "Hidden",
+    "depends": [
+        "base",
+        "mail",
+        "plasticos_intake",
+        "plasticos_matching",
+    ],
+    "data": [
+        "security/ir.model.access.csv",
+        "views/offer_views.xml",
+    ],
+    "installable": True,
+    "application": False,
+}

--- a/plasticos_offer/models/__init__.py
+++ b/plasticos_offer/models/__init__.py
@@ -1,0 +1,1 @@
+from . import offer

--- a/plasticos_offer/models/offer.py
+++ b/plasticos_offer/models/offer.py
@@ -1,0 +1,250 @@
+import logging
+
+from odoo import models, fields, api
+from odoo.exceptions import ValidationError, UserError
+
+_logger = logging.getLogger(__name__)
+
+
+class PlasticosOffer(models.Model):
+    """Offer lifecycle: draft → sent → responded → accepted/rejected/expired.
+
+    An offer is created from an accepted match result. It represents a
+    concrete commercial proposal from a supplier to a buyer (or vice
+    versa) for a specific material at a specific price.
+    """
+
+    _name = "plasticos.offer"
+    _description = "Material Offer"
+    _inherit = ["mail.thread", "mail.activity.mixin"]
+    _order = "create_date desc"
+    _rec_name = "display_name"
+
+    # ═════════════════════════════════════════════════════════
+    # Origin
+    # ═════════════════════════════════════════════════════════
+
+    match_result_id = fields.Many2one(
+        "plasticos.match.result",
+        string="Match Result",
+        index=True,
+        ondelete="set null",
+        help="The match result that originated this offer, if any.",
+    )
+    intake_id = fields.Many2one(
+        "plasticos.intake",
+        string="Intake",
+        required=True,
+        index=True,
+        ondelete="cascade",
+        tracking=True,
+        help="The intake record this offer is based on.",
+    )
+
+    # ═════════════════════════════════════════════════════════
+    # Parties
+    # ═════════════════════════════════════════════════════════
+
+    supplier_id = fields.Many2one(
+        "res.partner",
+        string="Supplier",
+        required=True,
+        index=True,
+        ondelete="cascade",
+        tracking=True,
+    )
+    buyer_id = fields.Many2one(
+        "res.partner",
+        string="Buyer",
+        required=True,
+        index=True,
+        ondelete="cascade",
+        tracking=True,
+    )
+
+    # ═════════════════════════════════════════════════════════
+    # Material Summary (denormalized for quick display)
+    # ═════════════════════════════════════════════════════════
+
+    polymer = fields.Char(
+        related="intake_id.polymer",
+        store=True,
+        index=True,
+    )
+    form = fields.Char(
+        related="intake_id.form",
+        store=True,
+    )
+
+    # ═════════════════════════════════════════════════════════
+    # Commercial Terms
+    # ═════════════════════════════════════════════════════════
+
+    price_per_lb = fields.Float(
+        digits=(10, 4),
+        tracking=True,
+        help="Offered price per pound.",
+    )
+    currency_id = fields.Many2one(
+        "res.currency",
+        default=lambda self: self.env.company.currency_id,
+    )
+    quantity_lbs = fields.Float(
+        tracking=True,
+        help="Total quantity offered in pounds.",
+    )
+    loads = fields.Integer(
+        help="Number of truckloads.",
+    )
+    delivery_terms = fields.Selection(
+        [
+            ("fob_origin", "FOB Origin"),
+            ("fob_destination", "FOB Destination"),
+            ("cif", "CIF"),
+            ("exw", "EXW"),
+            ("dap", "DAP"),
+        ],
+        tracking=True,
+    )
+    payment_terms = fields.Selection(
+        [
+            ("net_15", "Net 15"),
+            ("net_30", "Net 30"),
+            ("net_45", "Net 45"),
+            ("net_60", "Net 60"),
+            ("cod", "COD"),
+            ("prepaid", "Prepaid"),
+        ],
+        tracking=True,
+    )
+    valid_until = fields.Date(
+        tracking=True,
+        help="Offer expiration date.",
+    )
+    notes = fields.Text(
+        help="Additional terms, conditions, or notes.",
+    )
+
+    # ═════════════════════════════════════════════════════════
+    # Lifecycle
+    # ═════════════════════════════════════════════════════════
+
+    state = fields.Selection(
+        [
+            ("draft", "Draft"),
+            ("sent", "Sent"),
+            ("responded", "Responded"),
+            ("accepted", "Accepted"),
+            ("rejected", "Rejected"),
+            ("expired", "Expired"),
+            ("cancelled", "Cancelled"),
+        ],
+        default="draft",
+        tracking=True,
+        index=True,
+        required=True,
+    )
+
+    response_notes = fields.Text(
+        help="Buyer's response or counter-offer notes.",
+    )
+    counter_price_per_lb = fields.Float(
+        digits=(10, 4),
+        help="Counter-offered price per pound from the buyer.",
+    )
+
+    accepted_by = fields.Many2one(
+        "res.users",
+        readonly=True,
+    )
+    accepted_date = fields.Datetime(
+        readonly=True,
+    )
+    rejection_reason = fields.Text()
+
+    # ═════════════════════════════════════════════════════════
+    # Display
+    # ═════════════════════════════════════════════════════════
+
+    display_name = fields.Char(
+        compute="_compute_display_name",
+        store=True,
+    )
+
+    # ═════════════════════════════════════════════════════════
+    # Constraints
+    # ═════════════════════════════════════════════════════════
+
+    _check_price_positive = models.Constraint(
+        "check(price_per_lb >= 0)",
+        "Price per pound cannot be negative.",
+    )
+
+    _check_quantity_positive = models.Constraint(
+        "check(quantity_lbs >= 0)",
+        "Quantity cannot be negative.",
+    )
+
+    # ═════════════════════════════════════════════════════════
+    # Computed
+    # ═════════════════════════════════════════════════════════
+
+    @api.depends("intake_id", "buyer_id", "state")
+    def _compute_display_name(self):
+        for rec in self:
+            intake = rec.intake_id.name or "?"
+            buyer = rec.buyer_id.name or "?"
+            rec.display_name = f"Offer: {intake} → {buyer} [{rec.state or 'draft'}]"
+
+    # ═════════════════════════════════════════════════════════
+    # State Transitions
+    # ═════════════════════════════════════════════════════════
+
+    def action_send(self):
+        """Mark offer as sent to the buyer."""
+        for rec in self:
+            if rec.state != "draft":
+                raise UserError("Only draft offers can be sent.")
+            rec.write({"state": "sent"})
+        _logger.info("Offers sent: %s", self.mapped("display_name"))
+
+    def action_mark_responded(self):
+        """Mark that the buyer has responded."""
+        for rec in self:
+            if rec.state != "sent":
+                raise UserError("Only sent offers can be marked as responded.")
+            rec.write({"state": "responded"})
+
+    def action_accept(self):
+        """Accept this offer — ready for transaction creation."""
+        for rec in self:
+            if rec.state not in ("sent", "responded"):
+                raise UserError("Only sent or responded offers can be accepted.")
+            rec.write({
+                "state": "accepted",
+                "accepted_by": self.env.uid,
+                "accepted_date": fields.Datetime.now(),
+            })
+        _logger.info("Offers accepted: %s", self.mapped("display_name"))
+
+    def action_reject(self):
+        """Reject this offer."""
+        for rec in self:
+            if rec.state in ("accepted", "cancelled"):
+                raise UserError("Cannot reject an accepted or cancelled offer.")
+            rec.write({"state": "rejected"})
+        _logger.info("Offers rejected: %s", self.mapped("display_name"))
+
+    def action_cancel(self):
+        """Cancel this offer."""
+        for rec in self:
+            if rec.state == "accepted":
+                raise UserError("Cannot cancel an accepted offer.")
+            rec.write({"state": "cancelled"})
+
+    def action_reset_to_draft(self):
+        """Reset a rejected or cancelled offer back to draft."""
+        for rec in self:
+            if rec.state not in ("rejected", "cancelled"):
+                raise UserError("Only rejected or cancelled offers can be reset.")
+            rec.write({"state": "draft"})

--- a/plasticos_offer/security/ir.model.access.csv
+++ b/plasticos_offer/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_offer_user,plasticos.offer.user,model_plasticos_offer,base.group_user,1,0,0,0
+access_offer_manager,plasticos.offer.manager,model_plasticos_offer,base.group_system,1,1,1,1

--- a/plasticos_offer/views/offer_views.xml
+++ b/plasticos_offer/views/offer_views.xml
@@ -1,0 +1,135 @@
+<odoo>
+
+    <!-- List View -->
+    <record id="view_offer_list" model="ir.ui.view">
+        <field name="name">plasticos.offer.list</field>
+        <field name="model">plasticos.offer</field>
+        <field name="arch" type="xml">
+            <list decoration-success="state == 'accepted'"
+                  decoration-danger="state == 'rejected'"
+                  decoration-muted="state in ('expired','cancelled')">
+                <field name="intake_id"/>
+                <field name="polymer"/>
+                <field name="form"/>
+                <field name="supplier_id"/>
+                <field name="buyer_id"/>
+                <field name="price_per_lb"/>
+                <field name="quantity_lbs"/>
+                <field name="delivery_terms" optional="show"/>
+                <field name="valid_until" optional="show"/>
+                <field name="state"/>
+            </list>
+        </field>
+    </record>
+
+    <!-- Form View -->
+    <record id="view_offer_form" model="ir.ui.view">
+        <field name="name">plasticos.offer.form</field>
+        <field name="model">plasticos.offer</field>
+        <field name="arch" type="xml">
+            <form>
+                <header>
+                    <button name="action_send" type="object"
+                            string="Send" class="btn-primary"
+                            invisible="state != 'draft'"/>
+                    <button name="action_mark_responded" type="object"
+                            string="Mark Responded" class="btn-primary"
+                            invisible="state != 'sent'"/>
+                    <button name="action_accept" type="object"
+                            string="Accept" class="btn-success"
+                            invisible="state not in ('sent','responded')"/>
+                    <button name="action_reject" type="object"
+                            string="Reject" class="btn-danger"
+                            invisible="state in ('accepted','cancelled','expired')"/>
+                    <button name="action_cancel" type="object"
+                            string="Cancel" class="btn-secondary"
+                            invisible="state in ('accepted','cancelled','expired')"/>
+                    <button name="action_reset_to_draft" type="object"
+                            string="Reset to Draft"
+                            invisible="state not in ('rejected','cancelled')"/>
+                    <field name="state" widget="statusbar"
+                           statusbar_visible="draft,sent,responded,accepted"/>
+                </header>
+                <sheet>
+                    <group>
+                        <group string="Origin">
+                            <field name="match_result_id"/>
+                            <field name="intake_id"/>
+                        </group>
+                        <group string="Parties">
+                            <field name="supplier_id"/>
+                            <field name="buyer_id"/>
+                        </group>
+                    </group>
+
+                    <notebook>
+                        <page string="Commercial Terms">
+                            <group>
+                                <group string="Pricing">
+                                    <field name="price_per_lb"/>
+                                    <field name="currency_id"/>
+                                    <field name="quantity_lbs"/>
+                                    <field name="loads"/>
+                                </group>
+                                <group string="Terms">
+                                    <field name="delivery_terms"/>
+                                    <field name="payment_terms"/>
+                                    <field name="valid_until"/>
+                                </group>
+                            </group>
+                            <group string="Notes">
+                                <field name="notes"/>
+                            </group>
+                        </page>
+
+                        <page string="Response">
+                            <group>
+                                <group>
+                                    <field name="response_notes"/>
+                                    <field name="counter_price_per_lb"/>
+                                </group>
+                                <group>
+                                    <field name="accepted_by"
+                                           invisible="state != 'accepted'"/>
+                                    <field name="accepted_date"
+                                           invisible="state != 'accepted'"/>
+                                    <field name="rejection_reason"
+                                           invisible="state != 'rejected'"/>
+                                </group>
+                            </group>
+                        </page>
+
+                        <page string="Material">
+                            <group>
+                                <group>
+                                    <field name="polymer"/>
+                                    <field name="form"/>
+                                </group>
+                            </group>
+                        </page>
+                    </notebook>
+                </sheet>
+                <chatter/>
+            </form>
+        </field>
+    </record>
+
+    <!-- Action -->
+    <record id="action_offer" model="ir.actions.act_window">
+        <field name="name">Offers</field>
+        <field name="res_model">plasticos.offer</field>
+        <field name="view_mode">list,form</field>
+    </record>
+
+    <!-- Menu under PlasticOS root -->
+    <menuitem id="menu_offer_root"
+              name="Offers"
+              parent="plasticos_intake.plasticos_root_menu"
+              sequence="25"/>
+    <menuitem id="menu_offers"
+              name="All Offers"
+              parent="menu_offer_root"
+              action="action_offer"
+              sequence="1"/>
+
+</odoo>


### PR DESCRIPTION
## New Module: `plasticos_offer`
### New Model: `plasticos.offer`

Full offer lifecycle from match result to deal acceptance.

### State Machine

```
draft → sent → responded → accepted
                         → rejected → (reset to draft)
      → cancelled → (reset to draft)
      → expired
```

### Fields

| Group | Fields |
|:---|:---|
| **Origin** | `match_result_id`, `intake_id` |
| **Parties** | `supplier_id`, `buyer_id` |
| **Material** | `polymer` (related), `form` (related) |
| **Commercial** | `price_per_lb`, `currency_id`, `quantity_lbs`, `loads`, `delivery_terms`, `payment_terms`, `valid_until`, `notes` |
| **Response** | `response_notes`, `counter_price_per_lb` |
| **Lifecycle** | `state`, `accepted_by`, `accepted_date`, `rejection_reason` |

### Actions
- `action_send` — draft → sent
- `action_mark_responded` — sent → responded
- `action_accept` — sent/responded → accepted (records user + timestamp)
- `action_reject` — any (except accepted/cancelled) → rejected
- `action_cancel` — any (except accepted) → cancelled
- `action_reset_to_draft` — rejected/cancelled → draft

### Views
- List: decorated by state, optional delivery_terms and valid_until columns
- Form: header with state-conditional buttons + statusbar, tabbed Commercial Terms / Response / Material pages, chatter

### Dependencies
- `plasticos_intake`, `plasticos_matching`