### PR TITLE
fix: Intake Field Renames + UX Normalization (moisture_pct, tab reorder, debug tab)

### DIFF
--- a/plasticos_intake/__manifest__.py
+++ b/plasticos_intake/__manifest__.py
@@ -1,7 +1,7 @@
 {
     "name": "PlasticOS Intake",
-    "version": "19.0.2.0.0",
-    "summary": "Transactional Material Intake — unified with material profile",
+    "version": "19.0.3.0.0",
+    "summary": "Transactional Material Intake — field fixes, UX normalization",
     "author": "PlasticOS",
     "depends": [
         "base",
@@ -10,9 +10,9 @@
     ],
     "data": [
         "security/ir.model.access.csv",
-        "views/intake_views.xml"
+        "views/intake_views.xml",
     ],
     "installable": True,
     "application": False,
-    "license": "LGPL-3"
+    "license": "LGPL-3",
 }

--- a/plasticos_intake/models/intake.py
+++ b/plasticos_intake/models/intake.py
@@ -62,15 +62,21 @@ class PlasticosIntake(models.Model):
     # Observed Quality (Instance-Level)
     # ═════════════════════════════════════════════════════════
 
-    mfi_value = fields.Float()
-    density_value = fields.Float()
-    moisture_ppm = fields.Integer()
-    contamination_total_pct = fields.Float()
-    has_metal = fields.Boolean()
-    has_fr = fields.Boolean()
-    has_residue = fields.Boolean()
+    mfi_value = fields.Float(string="MFI")
+    density_value = fields.Float(string="Density (g/cm3)")
+    moisture_pct = fields.Float(
+        string="Moisture (%)",
+        help="Moisture content as a percentage (e.g. 0.5 = 0.5%).",
+    )
+    contamination_pct = fields.Float(
+        string="Contamination (%)",
+        help="Total contamination as a percentage.",
+    )
+    has_metal = fields.Boolean(string="Metal Present")
+    has_fr = fields.Boolean(string="Flame Retardant")
+    has_residue = fields.Boolean(string="Residue Present")
     filler_type = fields.Char()
-    filler_pct = fields.Float()
+    filler_pct = fields.Float(string="Filler (%)")
     contamination_notes = fields.Text()
 
     # ═════════════════════════════════════════════════════════
@@ -104,11 +110,14 @@ class PlasticosIntake(models.Model):
     )
 
     # ═════════════════════════════════════════════════════════
-    # Commercial Layer
+    # Frequency (Volume + Deal Terms)
     # ═════════════════════════════════════════════════════════
 
-    quantity_per_load_lbs = fields.Integer(required=True)
-    loads_per_month = fields.Integer()
+    quantity_per_load_lbs = fields.Integer(
+        string="Qty per Load (lbs)",
+        required=True,
+    )
+    loads_per_month = fields.Integer(string="Loads / Month")
     deal_type = fields.Selection(
         [
             ("spot", "Spot"),
@@ -118,7 +127,7 @@ class PlasticosIntake(models.Model):
         ],
         default="spot",
     )
-    contract_duration_months = fields.Integer()
+    contract_duration_months = fields.Integer(string="Contract Duration (mo)")
 
     # ═════════════════════════════════════════════════════════
     # Onboarding Status
@@ -138,14 +147,14 @@ class PlasticosIntake(models.Model):
     )
 
     # ═════════════════════════════════════════════════════════
-    # Geo
+    # Geo (hidden from UI, used by freight automation)
     # ═════════════════════════════════════════════════════════
 
-    lat = fields.Float()
-    lon = fields.Float()
+    lat = fields.Float(string="Latitude")
+    lon = fields.Float(string="Longitude")
 
     # ═════════════════════════════════════════════════════════
-    # Matching
+    # Matching / Debug (admin-only in UI)
     # ═════════════════════════════════════════════════════════
 
     match_status = fields.Selection(
@@ -159,15 +168,15 @@ class PlasticosIntake(models.Model):
         default="pending",
         tracking=True,
     )
-    match_response = fields.Json()
+    match_response = fields.Json(string="Match Response (JSON)")
     normalized = fields.Boolean(
         default=False,
         help="Must be True before adapter emits packet.",
     )
-    last_packet_id = fields.Char(index=True)
-    last_packet_version = fields.Char()
-    last_packet_payload = fields.Json()
-    last_packet_ts = fields.Datetime()
+    last_packet_id = fields.Char(string="Packet ID", index=True)
+    last_packet_version = fields.Char(string="Packet Version")
+    last_packet_payload = fields.Json(string="Packet Payload (JSON)")
+    last_packet_ts = fields.Datetime(string="Packet Timestamp")
 
     # ═════════════════════════════════════════════════════════
     # Constraints
@@ -194,8 +203,8 @@ class PlasticosIntake(models.Model):
         self.source_type = mp.source_type or self.source_type
         self.mfi_value = mp.melt_flow_index or self.mfi_value
         self.density_value = mp.density or self.density_value
-        self.contamination_total_pct = (
-            mp.contamination_percent or self.contamination_total_pct
+        self.contamination_pct = (
+            mp.contamination_percent or self.contamination_pct
         )
         if not self.onboarding_status or self.onboarding_status == "draft":
             self.onboarding_status = "profiled"

--- a/plasticos_intake/views/intake_views.xml
+++ b/plasticos_intake/views/intake_views.xml
@@ -1,4 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
 <odoo>
+
+    <!-- List View -->
     <record id="view_plasticos_intake_tree" model="ir.ui.view">
         <field name="name">plasticos.intake.tree</field>
         <field name="model">plasticos.intake</field>
@@ -10,13 +13,62 @@
                 <field name="polymer"/>
                 <field name="form"/>
                 <field name="quantity_per_load_lbs"/>
+                <field name="loads_per_month" optional="show"/>
                 <field name="deal_type"/>
-                <field name="onboarding_status"/>
-                <field name="match_status"/>
+                <field name="onboarding_status"
+                       decoration-info="onboarding_status == 'draft'"
+                       decoration-warning="onboarding_status == 'profiled'"
+                       decoration-success="onboarding_status in ('normalized', 'ready')"
+                       widget="badge"/>
+                <field name="match_status"
+                       decoration-info="match_status == 'pending'"
+                       decoration-success="match_status in ('normalized', 'matched')"
+                       decoration-danger="match_status in ('rejected', 'error')"
+                       widget="badge"/>
             </list>
         </field>
     </record>
 
+    <!-- Search View -->
+    <record id="view_plasticos_intake_search" model="ir.ui.view">
+        <field name="name">plasticos.intake.search</field>
+        <field name="model">plasticos.intake</field>
+        <field name="arch" type="xml">
+            <search>
+                <field name="name"/>
+                <field name="partner_id"/>
+                <field name="polymer"/>
+                <field name="form"/>
+                <filter name="draft" string="Draft"
+                        domain="[('onboarding_status', '=', 'draft')]"/>
+                <filter name="profiled" string="Profiled"
+                        domain="[('onboarding_status', '=', 'profiled')]"/>
+                <filter name="normalized" string="Normalized"
+                        domain="[('onboarding_status', '=', 'normalized')]"/>
+                <filter name="ready" string="Ready"
+                        domain="[('onboarding_status', '=', 'ready')]"/>
+                <separator/>
+                <filter name="matched" string="Matched"
+                        domain="[('match_status', '=', 'matched')]"/>
+                <filter name="pending_match" string="Pending Match"
+                        domain="[('match_status', '=', 'pending')]"/>
+                <group expand="0" string="Group By">
+                    <filter name="group_partner" string="Partner"
+                            context="{'group_by': 'partner_id'}"/>
+                    <filter name="group_polymer" string="Polymer"
+                            context="{'group_by': 'polymer'}"/>
+                    <filter name="group_deal_type" string="Deal Type"
+                            context="{'group_by': 'deal_type'}"/>
+                    <filter name="group_onboarding" string="Onboarding Status"
+                            context="{'group_by': 'onboarding_status'}"/>
+                    <filter name="group_match" string="Match Status"
+                            context="{'group_by': 'match_status'}"/>
+                </group>
+            </search>
+        </field>
+    </record>
+
+    <!-- Form View -->
     <record id="view_plasticos_intake_form" model="ir.ui.view">
         <field name="name">plasticos.intake.form</field>
         <field name="model">plasticos.intake</field>
@@ -48,6 +100,7 @@
                            statusbar_visible="draft,profiled,normalized,ready"/>
                 </header>
                 <sheet>
+                    <!-- Identity Header -->
                     <group>
                         <group string="Identity">
                             <field name="name"/>
@@ -60,6 +113,7 @@
                     </group>
 
                     <notebook>
+                        <!-- Tab 1: Material -->
                         <page string="Material">
                             <group string="Raw Description">
                                 <field name="material_hint_text"/>
@@ -80,13 +134,28 @@
                             </group>
                         </page>
 
+                        <!-- Tab 2: Frequency (was "Commercial", moved before Quality) -->
+                        <page string="Frequency">
+                            <group>
+                                <group string="Volume">
+                                    <field name="quantity_per_load_lbs"/>
+                                    <field name="loads_per_month"/>
+                                </group>
+                                <group string="Deal Terms">
+                                    <field name="deal_type"/>
+                                    <field name="contract_duration_months"/>
+                                </group>
+                            </group>
+                        </page>
+
+                        <!-- Tab 3: Quality -->
                         <page string="Quality">
                             <group>
                                 <group string="Observed Quality">
                                     <field name="mfi_value"/>
                                     <field name="density_value"/>
-                                    <field name="moisture_ppm"/>
-                                    <field name="contamination_total_pct"/>
+                                    <field name="moisture_pct"/>
+                                    <field name="contamination_pct"/>
                                 </group>
                                 <group string="Contaminants">
                                     <field name="has_metal"/>
@@ -101,33 +170,33 @@
                             </group>
                         </page>
 
-                        <page string="Commercial">
+                        <!-- Tab 4: Matching (visible to all, read-only display) -->
+                        <page string="Matching">
                             <group>
-                                <group string="Volume">
-                                    <field name="quantity_per_load_lbs"/>
-                                    <field name="loads_per_month"/>
+                                <group string="Status">
+                                    <field name="match_status"/>
+                                    <field name="normalized"/>
                                 </group>
-                                <group string="Deal">
-                                    <field name="deal_type"/>
-                                    <field name="contract_duration_months"/>
+                                <group string="Packet">
+                                    <field name="last_packet_id" readonly="1"/>
+                                    <field name="last_packet_version" readonly="1"/>
+                                    <field name="last_packet_ts" readonly="1"/>
                                 </group>
                             </group>
                         </page>
 
-                        <page string="Matching">
-                            <group>
-                                <group>
-                                    <field name="match_status"/>
-                                    <field name="normalized"/>
-                                </group>
-                                <group>
-                                    <field name="last_packet_id"/>
-                                    <field name="last_packet_version"/>
-                                    <field name="last_packet_ts"/>
-                                </group>
+                        <!-- Tab 5: Debug (admin-only, JSON payloads + geo) -->
+                        <page string="Debug"
+                              groups="base.group_system">
+                            <group string="Geo (freight automation)">
+                                <field name="lat"/>
+                                <field name="lon"/>
                             </group>
                             <group string="Match Response">
-                                <field name="match_response"/>
+                                <field name="match_response" readonly="1"/>
+                            </group>
+                            <group string="Last Packet Payload">
+                                <field name="last_packet_payload" readonly="1"/>
                             </group>
                         </page>
                     </notebook>
@@ -147,6 +216,7 @@
         <field name="name">Material Intake</field>
         <field name="res_model">plasticos.intake</field>
         <field name="view_mode">list,form</field>
+        <field name="search_view_id" ref="view_plasticos_intake_search"/>
     </record>
 
     <!-- Intake Menu -->


### PR DESCRIPTION
# fix: Intake Field Renames + UX Normalization

## Summary

Applies field corrections and UX improvements to `plasticos_intake` based on the approved hardening spec. This PR establishes the tab ordering and field naming conventions that all other modules should follow.

## Field Renames

| Before | After | Rationale |
|:---|:---|:---|
| `moisture_ppm` (Integer) | `moisture_pct` (Float) | PPM is lab-grade precision nobody uses in scrap. Percentage is industry standard. |
| `contamination_total_pct` | `contamination_pct` | Shorter, cleaner. `contamination_notes` (Text) kept for qualitative detail. |

## UX Changes

### Tab Reorder

| Position | Before | After |
|:---|:---|:---|
| Tab 1 | Material | Material (unchanged) |
| Tab 2 | Quality | **Frequency** (was "Commercial", moved up) |
| Tab 3 | Commercial | **Quality** (moved down) |
| Tab 4 | Matching | Matching (status only, packet fields moved) |
| Tab 5 | *(none)* | **Debug** (admin-only, new) |

### Field Visibility

| Field(s) | Change |
|:---|:---|
| `lat`, `lon` | Hidden from UI, moved to Debug tab. Kept in DB for freight automation. |
| `match_response` (JSON) | Moved to Debug tab, `readonly="1"`, `groups="base.group_system"` |
| `last_packet_payload` (JSON) | Moved to Debug tab, `readonly="1"`, `groups="base.group_system"` |
| Packet ID / Version / Timestamp | Kept on Matching tab as read-only summary |

### New Features

- **Search view** with filters (Draft, Profiled, Normalized, Ready, Matched, Pending Match) and group-by (Partner, Polymer, Deal Type, Onboarding, Match Status)
- **Badge widgets** on list view for `onboarding_status` and `match_status` with color decorations
- **String labels** added to all quality/frequency fields for clarity

## Convention Established

This PR sets the canonical tab order for all modules going forward:

> **Identity → Material → Frequency → Quality → Matching → Debug**

## Version

`19.0.2.0.0` → `19.0.3.0.0`

## Migration Note

The field renames (`moisture_ppm` → `moisture_pct`, `contamination_total_pct` → `contamination_pct`) are breaking changes. If there is existing data in these columns, a pre-migration script should rename the columns. Since the repo has no production data yet, this is safe to merge as-is.
