### PR TITLE
feat: plasticos_geolocalize — Auto-Geocode Partners + Related Geo on Intake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@
 !/plasticos_polymer/
 !/plasticos_web_leads/
 !/plasticos_intake_normalizer/
+!/plasticos_security_base/
+!/plasticos_documents_native/
+!/plasticos_geolocalize/
 !/reports/
 
 # Ignore within allowed paths

--- a/plasticos_geolocalize/__init__.py
+++ b/plasticos_geolocalize/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/plasticos_geolocalize/__manifest__.py
+++ b/plasticos_geolocalize/__manifest__.py
@@ -1,0 +1,19 @@
+{
+    "name": "PlasticOS Geolocalize",
+    "version": "19.0.1.0.0",
+    "summary": "Auto-geocode partners on create/write + nightly backfill cron",
+    "author": "PlasticOS",
+    "depends": [
+        "base",
+        "base_geolocalize",
+        "plasticos_intake",
+    ],
+    "data": [
+        "security/ir.model.access.csv",
+        "data/cron_geo_backfill.xml",
+        "views/intake_geo_views.xml",
+    ],
+    "installable": True,
+    "application": False,
+    "license": "LGPL-3",
+}

--- a/plasticos_geolocalize/data/cron_geo_backfill.xml
+++ b/plasticos_geolocalize/data/cron_geo_backfill.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo noupdate="1">
+
+    <record id="ir_cron_geo_backfill" model="ir.cron">
+        <field name="name">PlasticOS: Nightly Geo Backfill</field>
+        <field name="model_id" ref="base.model_res_partner"/>
+        <field name="state">code</field>
+        <field name="code">model.cron_geo_backfill()</field>
+        <field name="interval_number">1</field>
+        <field name="interval_type">days</field>
+        <field name="numbercall">-1</field>
+        <field name="active">True</field>
+        <field name="doall">False</field>
+    </record>
+
+</odoo>

--- a/plasticos_geolocalize/models/__init__.py
+++ b/plasticos_geolocalize/models/__init__.py
@@ -1,0 +1,2 @@
+from . import res_partner_geo
+from . import intake_geo

--- a/plasticos_geolocalize/models/intake_geo.py
+++ b/plasticos_geolocalize/models/intake_geo.py
@@ -1,0 +1,30 @@
+"""Make intake geo fields related to the partner's coordinates.
+
+Replaces standalone ``lat``/``lon`` Float fields on
+``plasticos.intake`` with ``related`` fields that read from
+``partner_id.partner_latitude`` / ``partner_id.partner_longitude``.
+
+``store=True`` ensures the values are indexed and searchable
+for freight automation queries.
+"""
+
+from odoo import fields, models
+
+
+class PlasticosIntakeGeo(models.Model):
+    _inherit = "plasticos.intake"
+
+    # Override standalone Float fields with related fields.
+    # store=True persists to DB for indexing / freight queries.
+    lat = fields.Float(
+        string="Latitude",
+        related="partner_id.partner_latitude",
+        store=True,
+        readonly=True,
+    )
+    lon = fields.Float(
+        string="Longitude",
+        related="partner_id.partner_longitude",
+        store=True,
+        readonly=True,
+    )

--- a/plasticos_geolocalize/models/res_partner_geo.py
+++ b/plasticos_geolocalize/models/res_partner_geo.py
@@ -1,0 +1,115 @@
+"""Auto-geocode partners on create/write and nightly backfill.
+
+This module extends ``res.partner`` to automatically call
+``geo_localize()`` (provided by ``base_geolocalize``) whenever
+a partner is created or its address fields change.
+
+A nightly cron backfills any partners that still lack coordinates
+(e.g. bulk imports, legacy data).
+"""
+
+import logging
+
+from odoo import api, models
+
+_logger = logging.getLogger(__name__)
+
+# Address fields that trigger re-geocoding when changed.
+_ADDRESS_FIELDS = frozenset({
+    "street", "street2", "city", "state_id",
+    "zip", "country_id",
+})
+
+
+class ResPartnerGeo(models.Model):
+    _inherit = "res.partner"
+
+    # ─────────────────────────────────────────────────────────
+    # CRUD Overrides
+    # ─────────────────────────────────────────────────────────
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        """Geocode newly created partners that have an address."""
+        partners = super().create(vals_list)
+        to_geocode = partners.filtered(
+            lambda p: p.street or p.city or p.zip
+        )
+        if to_geocode:
+            try:
+                to_geocode.geo_localize()
+                _logger.info(
+                    "Auto-geocoded %d new partner(s).", len(to_geocode),
+                )
+            except Exception:
+                _logger.warning(
+                    "Geocoding failed for new partner(s) %s. "
+                    "Nightly cron will retry.",
+                    to_geocode.ids,
+                    exc_info=True,
+                )
+        return partners
+
+    def write(self, vals):
+        """Re-geocode when address fields change."""
+        res = super().write(vals)
+        if _ADDRESS_FIELDS & set(vals):
+            to_geocode = self.filtered(
+                lambda p: p.street or p.city or p.zip
+            )
+            if to_geocode:
+                try:
+                    to_geocode.geo_localize()
+                    _logger.info(
+                        "Re-geocoded %d partner(s) after address change.",
+                        len(to_geocode),
+                    )
+                except Exception:
+                    _logger.warning(
+                        "Re-geocoding failed for partner(s) %s. "
+                        "Nightly cron will retry.",
+                        to_geocode.ids,
+                        exc_info=True,
+                    )
+        return res
+
+    # ─────────────────────────────────────────────────────────
+    # Nightly Backfill Cron
+    # ─────────────────────────────────────────────────────────
+
+    @api.model
+    def cron_geo_backfill(self):
+        """Backfill coordinates for partners missing geo data.
+
+        Runs nightly.  Processes in batches of 50 to respect
+        geocoding API rate limits (Nominatim: 1 req/sec).
+        """
+        BATCH_SIZE = 50
+        domain = [
+            ("partner_latitude", "in", [0.0, False]),
+            "|",
+            ("street", "!=", False),
+            ("city", "!=", False),
+        ]
+        partners = self.search(domain, limit=BATCH_SIZE)
+        if not partners:
+            _logger.info("Geo backfill: no partners need geocoding.")
+            return
+
+        success = 0
+        for partner in partners:
+            try:
+                partner.geo_localize()
+                if partner.partner_latitude:
+                    success += 1
+            except Exception:
+                _logger.warning(
+                    "Geo backfill: failed for partner %s (%s).",
+                    partner.id, partner.name,
+                    exc_info=True,
+                )
+
+        _logger.info(
+            "Geo backfill complete: %d/%d partners geocoded.",
+            success, len(partners),
+        )

--- a/plasticos_geolocalize/security/ir.model.access.csv
+++ b/plasticos_geolocalize/security/ir.model.access.csv
@@ -1,0 +1,1 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink

--- a/plasticos_geolocalize/views/intake_geo_views.xml
+++ b/plasticos_geolocalize/views/intake_geo_views.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <!-- Extend the partner form to show geocode status -->
+    <record id="view_partner_geo_status" model="ir.ui.view">
+        <field name="name">res.partner.geo.status</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.view_partner_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='website']" position="after">
+                <field name="partner_latitude" string="Latitude" readonly="1"/>
+                <field name="partner_longitude" string="Longitude" readonly="1"/>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
# feat: plasticos_geolocalize -- Auto-Geocode Partners + Related Geo on Intake

## Summary

Adds automatic geocoding infrastructure to the platform. Every partner with an address gets coordinates automatically -- either in real-time (on create/write) or via nightly backfill cron. Intake geo fields become related fields that read from the partner, eliminating manual entry and ensuring single source of truth.

## Architecture

```
Partner Created/Updated (with address)
    |
    v  geo_localize() called automatically
    partner_latitude / partner_longitude populated
    |
    v  related fields
    plasticos.intake.lat / .lon auto-populated
    |
    v  available for
    Freight automation, carrier lane matching, distance calc
```

## What Was Built

### New Module: plasticos_geolocalize (7 files)

| Component | What It Does |
|:---|:---|
| res_partner_geo.py | _inherit res.partner: auto geo_localize() on create() and write() when address fields change |
| intake_geo.py | _inherit plasticos.intake: lat/lon become related fields from partner_latitude/longitude, store=True |
| cron_geo_backfill.xml | Nightly cron: batch-geocodes up to 50 partners missing coordinates per run |
| intake_geo_views.xml | Extends partner form with readonly lat/lon display |

### Real-Time Path (for hands-on operators)

When a partner is created or its address fields (street, city, state_id, zip, country_id) are updated, geo_localize() fires immediately. Coordinates appear within seconds. This covers:
- Manual partner creation
- Web lead auto-created partners
- Address corrections

### Safety Net Path (for imports)

Nightly cron finds all partners where partner_latitude = 0.0 and street/city is not empty, geocodes them in batches of 50. This covers:
- Bulk CSV imports
- Legacy data backfill
- Any partner where real-time geocoding failed (network timeout, API rate limit)

### Geocoding Provider

Uses Odoo native base_geolocalize which supports:
- OpenStreetMap Nominatim (default, free, no API key)
- Google Maps API (set base_geolocalize.google_map_api_key in System Parameters for higher accuracy on industrial addresses)

## Error Handling

All geocoding calls are wrapped in try/except. Failures are logged but never block partner creation or updates. The nightly cron retries failed partners automatically.

## Merge Dependencies

Depends on: plasticos_intake (PR #7)
Merge after: #12 -> #4 -> #5 -> #6 -> #7 -> #14 -> #15 (this)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- **Auto-geocoding**: Contact addresses are automatically geocoded when created or updated
- **Scheduled backfill**: Missing geolocation data is automatically updated each night
- **Location display**: Latitude and longitude coordinates now visible on intake and contact records

<!-- end of auto-generated comment: release notes by coderabbit.ai -->