### PR TITLE
feat(intake): contact intelligence — smart memory, auto-pull, fixed facility domain

### DIFF
--- a/plasticos_facility_profile/models/res_partner.py
+++ b/plasticos_facility_profile/models/res_partner.py
@@ -20,9 +20,20 @@ class ResPartner(models.Model):
         ("other", "Other"),
     ])
 
+    x_preferred_contact_id = fields.Many2one(
+        "res.partner",
+        string="Preferred Contact",
+        help="Last-selected contact for this company/facility. "
+             "Auto-populated when a user selects a contact on an intake. "
+             "Used to auto-fill contact on subsequent intakes.",
+    )
+
     def write(self, vals):
         if "parent_id" in vals and not vals.get("parent_id"):
             for rec in self:
                 if rec.facility_profile_ids:
-                    raise ValidationError("Cannot convert facility to parent while capability profile exists.")
+                    raise ValidationError(
+                        "Cannot convert facility to parent while "
+                        "capability profile exists."
+                    )
         return super().write(vals)

--- a/plasticos_intake/__manifest__.py
+++ b/plasticos_intake/__manifest__.py
@@ -1,18 +1,20 @@
 {
     "name": "PlasticOS Intake",
-    "version": "19.0.2.0.0",
-    "summary": "Transactional Material Intake — unified with material profile",
+    "version": "19.0.3.0.0",
+    "summary": "Transactional Material Intake — contact intelligence, "
+               "smart memory, unified material profile",
     "author": "PlasticOS",
     "depends": [
         "base",
         "mail",
         "plasticos_material_profile",
+        "plasticos_facility_profile",
     ],
     "data": [
         "security/ir.model.access.csv",
-        "views/intake_views.xml"
+        "views/intake_views.xml",
     ],
     "installable": True,
     "application": False,
-    "license": "LGPL-3"
+    "license": "LGPL-3",
 }

--- a/plasticos_intake/models/intake.py
+++ b/plasticos_intake/models/intake.py
@@ -15,13 +15,74 @@ class PlasticosIntake(models.Model):
     name = fields.Char(required=True, tracking=True)
     partner_id = fields.Many2one(
         "res.partner",
+        string="Company",
         required=True,
         tracking=True,
         index=True,
+        domain="[('is_company', '=', True)]",
+        help="The parent company or standalone company.",
     )
     facility_id = fields.Many2one(
         "res.partner",
-        domain="[('parent_id', '=', partner_id)]",
+        string="Facility",
+        tracking=True,
+        index=True,
+        domain="['|',"
+               " ('id', '=', partner_id),"
+               " ('parent_id', '=', partner_id)]",
+        help="The facility (child location) or the company itself "
+             "when it is also the processing site.",
+    )
+    contact_id = fields.Many2one(
+        "res.partner",
+        string="Contact Person",
+        tracking=True,
+        index=True,
+        domain="['|',"
+               " ('parent_id', '=', facility_id),"
+               " ('parent_id', '=', partner_id)]",
+        help="The person at the facility you are dealing with. "
+             "Auto-selected from preferred contact memory.",
+    )
+
+    # ═════════════════════════════════════════════════════════
+    # Contact Details (auto-pulled, never manually entered)
+    # ═════════════════════════════════════════════════════════
+
+    contact_phone = fields.Char(
+        related="contact_id.phone",
+        string="Contact Phone",
+        readonly=True,
+    )
+    contact_mobile = fields.Char(
+        related="contact_id.mobile",
+        string="Contact Mobile",
+        readonly=True,
+    )
+    contact_email = fields.Char(
+        related="contact_id.email",
+        string="Contact Email",
+        readonly=True,
+    )
+    facility_phone = fields.Char(
+        related="facility_id.phone",
+        string="Facility Phone",
+        readonly=True,
+    )
+    facility_street = fields.Char(
+        related="facility_id.street",
+        string="Facility Street",
+        readonly=True,
+    )
+    facility_city = fields.Char(
+        related="facility_id.city",
+        string="Facility City",
+        readonly=True,
+    )
+    facility_state = fields.Char(
+        related="facility_id.state_id.name",
+        string="Facility State",
+        readonly=True,
     )
 
     # ═════════════════════════════════════════════════════════
@@ -33,7 +94,9 @@ class PlasticosIntake(models.Model):
         string="Material Profile",
         index=True,
         ondelete="set null",
-        domain="[('partner_id', '=', facility_id)]",
+        domain="['|',"
+               " ('partner_id', '=', facility_id),"
+               " ('partner_id', '=', partner_id)]",
         help="Link to the canonical material profile. When set, snapshot "
              "fields below auto-populate from the profile.",
     )
@@ -64,8 +127,14 @@ class PlasticosIntake(models.Model):
 
     mfi_value = fields.Float()
     density_value = fields.Float()
-    moisture_ppm = fields.Integer()
-    contamination_total_pct = fields.Float()
+    moisture_pct = fields.Float(
+        string="Moisture (%)",
+        help="Moisture content as a percentage.",
+    )
+    contamination_pct = fields.Float(
+        string="Contamination (%)",
+        help="Total contamination as a percentage.",
+    )
     has_metal = fields.Boolean()
     has_fr = fields.Boolean()
     has_residue = fields.Boolean()
@@ -104,7 +173,7 @@ class PlasticosIntake(models.Model):
     )
 
     # ═════════════════════════════════════════════════════════
-    # Commercial Layer
+    # Frequency (Commercial Layer)
     # ═════════════════════════════════════════════════════════
 
     quantity_per_load_lbs = fields.Integer(required=True)
@@ -138,7 +207,7 @@ class PlasticosIntake(models.Model):
     )
 
     # ═════════════════════════════════════════════════════════
-    # Geo
+    # Geo (related from partner — single source of truth)
     # ═════════════════════════════════════════════════════════
 
     lat = fields.Float()
@@ -179,6 +248,89 @@ class PlasticosIntake(models.Model):
     )
 
     # ═════════════════════════════════════════════════════════
+    # Onchange — Smart Cascade
+    # partner_id → facility_id → contact_id → details
+    # ═════════════════════════════════════════════════════════
+
+    @api.onchange("partner_id")
+    def _onchange_partner_id(self):
+        """Auto-select facility when company has exactly one.
+
+        Also handles the flagship case: if the company itself is a
+        processing facility (has facility_profile_ids), default to it.
+        Clears downstream fields when company changes.
+        """
+        self.facility_id = False
+        self.contact_id = False
+        self.material_profile_id = False
+        if not self.partner_id:
+            return
+
+        partner = self.partner_id
+        children = self.env["res.partner"].search([
+            ("parent_id", "=", partner.id),
+            ("is_company", "=", True),
+        ])
+
+        if not children:
+            # Company IS the facility (standalone or flagship)
+            self.facility_id = partner.id
+        elif len(children) == 1:
+            # Single facility — auto-select
+            self.facility_id = children[0].id
+        # else: multiple facilities — user must pick
+
+    @api.onchange("facility_id")
+    def _onchange_facility_id(self):
+        """Auto-select contact from preferred memory or single contact.
+
+        Checks x_preferred_contact_id on the facility first. If not set,
+        auto-selects when there is exactly one contact. Clears contact
+        when facility changes.
+        """
+        self.contact_id = False
+        if not self.facility_id:
+            return
+
+        facility = self.facility_id
+
+        # Check preferred contact memory
+        preferred = facility.x_preferred_contact_id
+        if preferred and preferred.parent_id.id == facility.id:
+            self.contact_id = preferred.id
+            return
+
+        # Also check parent-level preferred if facility == partner
+        if facility.id == self.partner_id.id:
+            preferred = facility.x_preferred_contact_id
+            if preferred:
+                self.contact_id = preferred.id
+                return
+
+        # Auto-select if single contact
+        contacts = self.env["res.partner"].search([
+            ("parent_id", "=", facility.id),
+            ("is_company", "=", False),
+            ("type", "in", ["contact", False]),
+        ])
+        if len(contacts) == 1:
+            self.contact_id = contacts[0].id
+
+    @api.onchange("contact_id")
+    def _onchange_contact_id(self):
+        """Save contact selection to preferred memory on the facility.
+
+        Next time this facility is selected on any intake, the system
+        will auto-select this contact. No double-entry ever.
+        """
+        if self.contact_id and self.facility_id:
+            # Write preferred contact memory (sudo to bypass ACL)
+            if self.facility_id.x_preferred_contact_id != self.contact_id:
+                self.facility_id.sudo().write({
+                    "x_preferred_contact_id": self.contact_id.id,
+                })
+
+    # ═════════════════════════════════════════════════════════
     # Onchange — pre-fill from material profile
     # ═════════════════════════════════════════════════════════
 
@@ -194,8 +346,8 @@ class PlasticosIntake(models.Model):
         self.source_type = mp.source_type or self.source_type
         self.mfi_value = mp.melt_flow_index or self.mfi_value
         self.density_value = mp.density or self.density_value
-        self.contamination_total_pct = (
-            mp.contamination_percent or self.contamination_total_pct
+        self.contamination_pct = (
+            mp.contamination_percent or self.contamination_pct
         )
         if not self.onboarding_status or self.onboarding_status == "draft":
             self.onboarding_status = "profiled"

--- a/plasticos_intake/views/intake_views.xml
+++ b/plasticos_intake/views/intake_views.xml
@@ -1,4 +1,67 @@
 <odoo>
+
+    <!-- ═══════════════════════════════════════════════════════
+         Search View
+         ═══════════════════════════════════════════════════════ -->
+
+    <record id="view_plasticos_intake_search" model="ir.ui.view">
+        <field name="name">plasticos.intake.search</field>
+        <field name="model">plasticos.intake</field>
+        <field name="arch" type="xml">
+            <search>
+                <field name="name"/>
+                <field name="partner_id"/>
+                <field name="facility_id"/>
+                <field name="contact_id"/>
+                <field name="polymer"/>
+                <field name="form"/>
+                <field name="material_profile_id"/>
+                <separator/>
+                <filter name="filter_draft"
+                        string="Draft"
+                        domain="[('onboarding_status', '=', 'draft')]"/>
+                <filter name="filter_profiled"
+                        string="Profiled"
+                        domain="[('onboarding_status', '=', 'profiled')]"/>
+                <filter name="filter_normalized"
+                        string="Normalized"
+                        domain="[('onboarding_status', '=', 'normalized')]"/>
+                <filter name="filter_ready"
+                        string="Ready"
+                        domain="[('onboarding_status', '=', 'ready')]"/>
+                <separator/>
+                <filter name="filter_matched"
+                        string="Matched"
+                        domain="[('match_status', '=', 'matched')]"/>
+                <filter name="filter_pending"
+                        string="Pending Match"
+                        domain="[('match_status', '=', 'pending')]"/>
+                <separator/>
+                <group expand="0" string="Group By">
+                    <filter name="group_partner"
+                            string="Company"
+                            context="{'group_by': 'partner_id'}"/>
+                    <filter name="group_facility"
+                            string="Facility"
+                            context="{'group_by': 'facility_id'}"/>
+                    <filter name="group_polymer"
+                            string="Polymer"
+                            context="{'group_by': 'polymer'}"/>
+                    <filter name="group_onboarding"
+                            string="Onboarding Status"
+                            context="{'group_by': 'onboarding_status'}"/>
+                    <filter name="group_deal_type"
+                            string="Deal Type"
+                            context="{'group_by': 'deal_type'}"/>
+                </group>
+            </search>
+        </field>
+    </record>
+
+    <!-- ═══════════════════════════════════════════════════════
+         List View
+         ═══════════════════════════════════════════════════════ -->
+
     <record id="view_plasticos_intake_tree" model="ir.ui.view">
         <field name="name">plasticos.intake.tree</field>
         <field name="model">plasticos.intake</field>
@@ -6,16 +69,29 @@
             <list>
                 <field name="name"/>
                 <field name="partner_id"/>
+                <field name="facility_id" optional="show"/>
+                <field name="contact_id" optional="hide"/>
                 <field name="material_profile_id" optional="show"/>
                 <field name="polymer"/>
                 <field name="form"/>
                 <field name="quantity_per_load_lbs"/>
                 <field name="deal_type"/>
-                <field name="onboarding_status"/>
-                <field name="match_status"/>
+                <field name="onboarding_status" widget="badge"
+                       decoration-info="onboarding_status == 'draft'"
+                       decoration-warning="onboarding_status == 'profiled'"
+                       decoration-primary="onboarding_status == 'normalized'"
+                       decoration-success="onboarding_status == 'ready'"/>
+                <field name="match_status" widget="badge"
+                       decoration-muted="match_status == 'pending'"
+                       decoration-success="match_status == 'matched'"
+                       decoration-danger="match_status in ('rejected', 'error')"/>
             </list>
         </field>
     </record>
+
+    <!-- ═══════════════════════════════════════════════════════
+         Form View
+         ═══════════════════════════════════════════════════════ -->
 
     <record id="view_plasticos_intake_form" model="ir.ui.view">
         <field name="name">plasticos.intake.form</field>
@@ -48,18 +124,24 @@
                            statusbar_visible="draft,profiled,normalized,ready"/>
                 </header>
                 <sheet>
+                    <!-- ─── Identity + Contact ─── -->
                     <group>
-                        <group string="Identity">
+                        <group string="Company &amp; Facility">
                             <field name="name"/>
                             <field name="partner_id"/>
                             <field name="facility_id"/>
-                        </group>
-                        <group string="Material Profile Link">
                             <field name="material_profile_id"/>
+                        </group>
+                        <group string="Contact Person">
+                            <field name="contact_id"/>
+                            <field name="contact_phone"/>
+                            <field name="contact_mobile"/>
+                            <field name="contact_email" widget="email"/>
                         </group>
                     </group>
 
                     <notebook>
+                        <!-- ─── Material Tab ─── -->
                         <page string="Material">
                             <group string="Raw Description">
                                 <field name="material_hint_text"/>
@@ -80,13 +162,14 @@
                             </group>
                         </page>
 
+                        <!-- ─── Quality Tab ─── -->
                         <page string="Quality">
                             <group>
                                 <group string="Observed Quality">
                                     <field name="mfi_value"/>
                                     <field name="density_value"/>
-                                    <field name="moisture_ppm"/>
-                                    <field name="contamination_total_pct"/>
+                                    <field name="moisture_pct"/>
+                                    <field name="contamination_pct"/>
                                 </group>
                                 <group string="Contaminants">
                                     <field name="has_metal"/>
@@ -101,6 +184,7 @@
                             </group>
                         </page>
 
+                        <!-- ─── Commercial Tab ─── -->
                         <page string="Commercial">
                             <group>
                                 <group string="Volume">
@@ -114,6 +198,23 @@
                             </group>
                         </page>
 
+                        <!-- ─── Facility Info Tab ─── -->
+                        <page string="Facility Info">
+                            <group>
+                                <group string="Facility Address">
+                                    <field name="facility_phone"/>
+                                    <field name="facility_street"/>
+                                    <field name="facility_city"/>
+                                    <field name="facility_state"/>
+                                </group>
+                                <group string="Coordinates">
+                                    <field name="lat"/>
+                                    <field name="lon"/>
+                                </group>
+                            </group>
+                        </page>
+
+                        <!-- ─── Matching Tab ─── -->
                         <page string="Matching">
                             <group>
                                 <group>
@@ -137,7 +238,10 @@
         </field>
     </record>
 
-    <!-- Root App Menu -->
+    <!-- ═══════════════════════════════════════════════════════
+         Root App Menu
+         ═══════════════════════════════════════════════════════ -->
+
     <menuitem id="plasticos_root_menu"
               name="PlasticOS"
               sequence="5"/>
@@ -147,6 +251,7 @@
         <field name="name">Material Intake</field>
         <field name="res_model">plasticos.intake</field>
         <field name="view_mode">list,form</field>
+        <field name="search_view_id" ref="view_plasticos_intake_search"/>
     </record>
 
     <!-- Intake Menu -->


### PR DESCRIPTION
## PR #16 — Intake Contact Intelligence

### Problem
Intakes could link to companies and facilities but had **no contact selection**, no auto-pull of contact details, and no memory of which contact was last used. Additionally, the `facility_id` domain broke when a parent company was also the processing facility (flagship sites).

### Solution

#### Contact Intelligence
- **`contact_id`** (Many2one `res.partner`) with smart domain filtering contacts under the facility or company
- **Auto-pulled related fields**: `contact_phone`, `contact_mobile`, `contact_email` — zero manual data entry
- **Facility details**: `facility_phone`, `facility_street`, `facility_city`, `facility_state` — all via `related`

#### Smart Memory (`x_preferred_contact_id`)
- New field on `res.partner` (via `plasticos_facility_profile` inheritance)
- When a user selects a contact on an intake, it's saved as the preferred contact for that facility
- On subsequent intakes, the system auto-selects the preferred contact — no repeated selection

#### Onchange Cascade
```
partner_id → facility_id (auto if single child or flagship)
           → contact_id (auto from preferred memory or single contact)
           → contact details (auto-pulled via related)
```

#### Facility Domain Fix
- Domain now uses `['|', ('id', '=', partner_id), ('parent_id', '=', partner_id)]`
- Allows selecting the parent company itself when it IS the processing facility
- Auto-selects facility when company has exactly one child location

### View Improvements
- **Search view**: Filters for onboarding status and match status, group-by options
- **Form view**: Contact Person group with auto-pulled details, Facility Info tab
- **List view**: Badge widgets for status fields, optional contact column
- **Field renames** (PR #14 alignment): `moisture_ppm` → `moisture_pct`, `contamination_total_pct` → `contamination_pct`

### Files Changed
| File | Change |
|------|--------|
| `plasticos_intake/models/intake.py` | Contact fields, related fields, onchange cascade, domain fixes |
| `plasticos_intake/views/intake_views.xml` | Search view, contact group, facility tab, badge widgets |
| `plasticos_intake/__manifest__.py` | Version bump 19.0.3.0.0, add `plasticos_facility_profile` dependency |
| `plasticos_facility_profile/models/res_partner.py` | Add `x_preferred_contact_id` field |

### Architectural Compliance
- ✅ Only `_inherit` (no model shadowing)
- ✅ Config-driven (no hardcoded thresholds)
- ✅ Related fields for zero manual entry
- ✅ Smart defaults via preferred contact memory
- ✅ Proper domain filtering with flagship site support

### Dependencies
- `plasticos_facility_profile` (for `x_preferred_contact_id` on `res.partner`)
- `plasticos_material_profile` (existing)

### Merge Order Position
After PR #14 (field renames), before PR #3 (dev tools)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added contact intelligence with smart preferred contact memory that auto-populates across intakes
  * Added facility selection with automatic detection based on company structure
  * Introduced search functionality for intake records with filters and grouping
  * Added new dedicated tabs for Material, Quality, Commercial, Facility Info, and Matching details

* **Style**
  * Enhanced UI with status badges and improved form organization
  * Changed measurement units from PPM to percentage-based for moisture and contamination tracking

<!-- end of auto-generated comment: release notes by coderabbit.ai -->