### PR TITLE
fix(tests): guard odoo.tests import for Odoo 19 startup — clears Odoo.sh build ERROR

### DIFF
--- a/plasticos_base/tests/common.py
+++ b/plasticos_base/tests/common.py
@@ -3,8 +3,22 @@
 Provides PlasticosTestCase with pre-created master data (partner, polymer, form, etc.)
 to avoid NOT NULL and UniqueViolation failures across plasticos test modules.
 """
+from __future__ import annotations
 
-from odoo.tests import TransactionCase
+# Odoo 19 guard: importing odoo.tests outside --test-enable logs an ERROR at
+# startup and causes Odoo.sh to mark the build as failed.
+# We use odoo.tools.config to detect test mode and fall back to unittest.TestCase
+# so this module is safely importable during normal module loading.
+try:
+    import odoo.tools.config as _odoo_config
+    _test_mode = _odoo_config.get('test_enable') or _odoo_config.get('test_file')
+except Exception:
+    _test_mode = False
+
+if _test_mode:
+    from odoo.tests.common import TransactionCase
+else:
+    from unittest import TestCase as TransactionCase  # type: ignore[assignment]
 
 
 class PlastOSTestFactoryMixin:


### PR DESCRIPTION
## Problem

Odoo.sh builds were failing with:
```
ERROR odoo.tests.common: Importing test framework, avoid importing from business modules and when not running in test mode
```

**Root cause chain:**
1. Top-level `tests` addon loads `test_bridge_contracts`
2. `test_bridge_contracts` imports `PlasticosTestCase` from `plasticos_base.tests.common`
3. `plasticos_base/tests/common.py` unconditionally ran `from odoo.tests import TransactionCase` at module load time
4. Odoo 19 added a guard in `odoo/tests/common.py` that logs ERROR when `odoo.tests` is imported outside `--test-enable` mode
5. Odoo.sh marks builds as failed on ERROR-level logs

## Fix

Guard the `odoo.tests` import in `plasticos_base/tests/common.py` using `odoo.tools.config`:
- **Non-test mode** (startup/build): falls back to `unittest.TestCase` — module loads cleanly, no ERROR logged
- **Test mode** (`--test-enable`): uses `odoo.tests.common.TransactionCase` as before — no change in test behaviour

## Testing

Before: build logs show ERROR, Odoo.sh marks build failed
After: clean startup, no ERROR, tests run identically under `--test-enable`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test framework reliability through intelligent runtime detection that dynamically selects appropriate test base components based on execution mode, ensuring consistent behavior across different execution contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->