### PR TITLE
fix(security): add missing ACL for plasticos.midnight.recompute

### DIFF
--- a/plasticos_base/__manifest__.py
+++ b/plasticos_base/__manifest__.py
@@ -11,6 +11,7 @@
         "sale_management",
     ],
     "data": [
+        "security/ir.model.access.csv",
         "data/service_user.xml",
         "data/partner_tags.xml",
         "data/material_taxonomy.xml",

--- a/plasticos_base/security/ir.model.access.csv
+++ b/plasticos_base/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_plasticos_midnight_recompute_user,plasticos.midnight.recompute user,model_plasticos_midnight_recompute,base.group_user,1,0,0,0
+access_plasticos_midnight_recompute_manager,plasticos.midnight.recompute manager,model_plasticos_midnight_recompute,base.group_system,1,1,1,1


### PR DESCRIPTION
## Problem

`plasticos_base` defines the `plasticos.midnight.recompute` model but has no `security/` directory and no `ir.model.access.csv`. Odoo requires every model to have explicit ACL entries — without them, all access is denied and access errors are logged at runtime.

## Fix

Created `plasticos_base/security/ir.model.access.csv` with two entries:

| Rule | Group | R | W | C | D |
|------|-------|---|---|---|---|
| user | `base.group_user` (internal users) | ✅ | ❌ | ❌ | ❌ |
| manager | `base.group_system` (admin) | ✅ | ✅ | ✅ | ✅ |

Also added `security/ir.model.access.csv` as the **first entry** in manifest `data[]` so ACLs load before any data files that may reference the model.

## Part of audit
This is BLOCKER 2 from the staging branch proactive audit. BLOCKER 1 (Odoo 19 test framework import) was fixed in PR #31.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated module configuration to include security access control settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->