### PR TITLE
chore: remove SonarCloud CI job

### DIFF
--- a/.github/workflows/odoo-quality.yml
+++ b/.github/workflows/odoo-quality.yml
@@ -78,19 +78,3 @@ jobs:
         run: |
           semgrep --config .semgrep/ --error --exclude plasticos_inference_engine --exclude plasticos_buyer_match_engine --exclude plasticos_matching .
         continue-on-error: true  # warn only until rules are tuned
-
-  sonarcloud:
-    name: SonarCloud Analysis
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@master
-        with:
-          args: >
-            -Dsonar.qualitygate.wait=true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
Removes the `sonarcloud` job from `odoo-quality.yml`. SonarCloud Automatic Analysis or alternative will handle scanning outside of CI triggers.