### PR TITLE
fix(orm): replace self.env.get() with self.env[] — 10 files; add antipattern detection + auto-fixer hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -120,6 +120,15 @@ repos:
         pass_filenames: false
         stages: [pre-commit, pre-push]
 
+
+      - id: fix-odoo-antipatterns
+        name: Auto-fix Odoo antipatterns (env.get, pool.get, @api.multi)
+        entry: python3 scripts/fix_odoo_antipatterns.py
+        language: system
+        types: [python]
+        pass_filenames: true
+        stages: [pre-commit]
+
       - id: orm-integrity
         name: ORM integrity check
         entry: python3 ci/check_orm_integrity.py

--- a/ci/check_orm_integrity.py
+++ b/ci/check_orm_integrity.py
@@ -181,9 +181,13 @@ def scan_file(filepath: str) -> list[dict]:
     # Regex-based checks
     issues.extend(check_unguarded_search_regex(filepath, content))
 
-    # Add filepath to all issues
+    # Odoo antipattern checks (env.get, pool.get, api.multi, etc.)
+    issues.extend(check_odoo_antipatterns(filepath, content))
+
+    # Add filepath to all issues (for AST-sourced issues without file key)
     for issue in issues:
-        issue["file"] = filepath
+        if "file" not in issue:
+            issue["file"] = filepath
 
     return issues
 
@@ -270,3 +274,131 @@ def main() -> int:
 
 if __name__ == "__main__":
     sys.exit(main())
+
+
+# ---------------------------------------------------------------------------
+# Extended antipattern checks (added: self.env.get, pool.get, api.multi, etc.)
+# ---------------------------------------------------------------------------
+
+ENV_GET_PATTERN = re.compile(
+    r'\bself\.env\.get\s*\(\s*["\']([^"\']+)["\']\s*\)',
+    re.MULTILINE,
+)
+POOL_GET_PATTERN = re.compile(
+    r'\bself\.pool\.get\s*\(\s*["\']([^"\']+)["\']\s*\)',
+    re.MULTILINE,
+)
+API_MULTI_PATTERN = re.compile(r'@api\.multi\b')
+FIELDS_FUNCTION_PATTERN = re.compile(r'\bfields\.function\b')
+SEARCH_NO_LIMIT_PATTERN = re.compile(
+    r'\.search\s*\(\s*\[.*?\]\s*\)',
+    re.DOTALL,
+)
+
+
+def check_odoo_antipatterns(filepath: str, content: str) -> list[dict]:
+    """Regex-based check for Odoo antipatterns not caught by AST."""
+    issues: list[dict] = []
+    is_test = "/tests/" in filepath or filepath.startswith("tests/")
+    lines = content.splitlines()
+
+    for i, line in enumerate(lines, 1):
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            continue
+
+        # 1. self.env.get("model") — silently returns None (invalid API)
+        for m in ENV_GET_PATTERN.finditer(line):
+            model = m.group(1)
+            issues.append(
+                {
+                    "type": "INVALID_ENV_GET",
+                    "file": filepath,
+                    "line": i,
+                    "col": m.start(),
+                    "message": (
+                        f'self.env.get("{model}") is not valid Odoo API — '
+                        f'silently returns None. Use self.env["{model}"]'
+                    ),
+                    "severity": "CRITICAL",
+                    "autofix": True,
+                    "fix": m.group(0).replace(".env.get(", ".env[").rstrip(")") + "]",
+                }
+            )
+
+        # 2. self.pool.get("model") — Odoo v7 API removed in v8+
+        for m in POOL_GET_PATTERN.finditer(line):
+            model = m.group(1)
+            issues.append(
+                {
+                    "type": "DEPRECATED_POOL_GET",
+                    "file": filepath,
+                    "line": i,
+                    "col": m.start(),
+                    "message": (
+                        f'self.pool.get("{model}") is Odoo v7 API removed in v8+. '
+                        f'Use self.env["{model}"]'
+                    ),
+                    "severity": "CRITICAL",
+                    "autofix": True,
+                    "fix": f'self.env["{model}"]',
+                }
+            )
+
+        # 3. @api.multi — removed in Odoo 14+
+        if API_MULTI_PATTERN.search(line):
+            issues.append(
+                {
+                    "type": "DEPRECATED_API_MULTI",
+                    "file": filepath,
+                    "line": i,
+                    "col": line.index("@api.multi"),
+                    "message": "@api.multi is removed in Odoo 14+. Remove this decorator entirely.",
+                    "severity": "HIGH",
+                    "autofix": True,
+                    "fix": "",  # Delete the line
+                }
+            )
+
+        # 4. fields.function(...) — deprecated field type
+        if FIELDS_FUNCTION_PATTERN.search(line):
+            issues.append(
+                {
+                    "type": "DEPRECATED_FIELDS_FUNCTION",
+                    "file": filepath,
+                    "line": i,
+                    "col": 0,
+                    "message": (
+                        "fields.function() is a deprecated v7 field type. "
+                        "Replace with fields.Xxx(compute='_compute_xxx')"
+                    ),
+                    "severity": "HIGH",
+                    "autofix": False,
+                }
+            )
+
+        # 5. Unbounded search without limit (skip already-limited or test helpers)
+        if ".search(" in line and "limit=" not in line and not is_test:
+            # Narrow: only flag searches that look like production record fetches
+            if re.search(r'\bself\.env\[', line) or ".search(" in line:
+                # Exclude common safe patterns
+                if not any(
+                    safe in line
+                    for safe in ["search_count(", "search_read(", "#", "sudo().search([])"]
+                ):
+                    issues.append(
+                        {
+                            "type": "UNBOUNDED_SEARCH",
+                            "file": filepath,
+                            "line": i,
+                            "col": 0,
+                            "message": (
+                                "search() without limit= can return unbounded recordsets. "
+                                "Add limit= or use search_count() if you only need the count."
+                            ),
+                            "severity": "MEDIUM",
+                            "autofix": False,
+                        }
+                    )
+
+    return issues

--- a/plasticos_automation/models/load_automation.py
+++ b/plasticos_automation/models/load_automation.py
@@ -41,7 +41,7 @@ class PlasticosLoadAutomation(models.Model):
                 order="entered_state_at ASC, id ASC",
                 limit=500,
             )
-            log_model = self.env.get("plasticos.automation.log")
+            log_model = self.env["plasticos.automation.log"]
 
             for load in loads:
                 if not load.entered_state_at:

--- a/plasticos_automation/models/purchase_order_automation.py
+++ b/plasticos_automation/models/purchase_order_automation.py
@@ -36,7 +36,7 @@ class PurchaseOrderAutomation(models.Model):
                 order="last_followup_on ASC, id ASC",
                 limit=200,
             )
-            log_model = self.env.get("plasticos.automation.log")
+            log_model = self.env["plasticos.automation.log"]
 
             for order in orders:
                 order.followup_count += 1

--- a/plasticos_automation/models/sale_approval.py
+++ b/plasticos_automation/models/sale_approval.py
@@ -44,7 +44,7 @@ class SaleOrder(models.Model):
                 limit=500,
             )
 
-            log_model = self.env.get("plasticos.automation.log")
+            log_model = self.env["plasticos.automation.log"]
             for order in orders:
                 order.requires_approval = True
                 if log_model:

--- a/plasticos_automation/models/stock_picking_automation.py
+++ b/plasticos_automation/models/stock_picking_automation.py
@@ -58,7 +58,7 @@ class StockPickingAutomation(models.Model):
                 limit=200,
             )
 
-            log_model = self.env.get("plasticos.automation.log")
+            log_model = self.env["plasticos.automation.log"]
 
             for picking in pickings:
                 picking.trucker_followup_count += 1

--- a/plasticos_base/models/midnight_recompute.py
+++ b/plasticos_base/models/midnight_recompute.py
@@ -63,7 +63,7 @@ class PlasticosMidnightRecompute(models.AbstractModel):
         - expiry_date <= today AND is_expired = False (newly expired)
         - expiry_date > today AND is_expired = True (incorrectly marked)
         """
-        Document = self.env.get("plasticos.document")
+        Document = self.env["plasticos.document"]
         if not Document:
             _logger.debug("plasticos.document not installed, skipping.")
             return
@@ -104,7 +104,7 @@ class PlasticosMidnightRecompute(models.AbstractModel):
 
         Only touches claims that are still open (not resolved/archived).
         """
-        Claim = self.env.get("plasticos.claim")
+        Claim = self.env["plasticos.claim"]
         if not Claim:
             _logger.debug("plasticos.claim not installed, skipping.")
             return

--- a/plasticos_intake/models/intake.py
+++ b/plasticos_intake/models/intake.py
@@ -952,7 +952,7 @@ class PlasticosIntake(models.Model):
         if not self.partner_id:
             raise UserError("Cannot create PO without a supplier partner.")
 
-        Transaction = self.env.get("plasticos.transaction")
+        Transaction = self.env["plasticos.transaction"]
         if Transaction is None:
             raise UserError(
                 "Transaction module not installed.\n\nInstall 'PlasticOS Transactions' to enable PO creation."

--- a/plasticos_intake_normalizer/models/intake_normalizer.py
+++ b/plasticos_intake_normalizer/models/intake_normalizer.py
@@ -500,7 +500,7 @@ class PlasticosIntakeNormalizer(models.Model):
             return None
 
         # facility_profile is linked via partner
-        FP = self.env.get("plasticos.facility.profile")
+        FP = self.env["plasticos.facility.profile"]
         if FP is None:
             return None
 
@@ -547,7 +547,7 @@ class PlasticosIntakeNormalizer(models.Model):
         Falls back to hardcoded list if table not available.
         Returns a frozenset of uppercase codes.
         """
-        Polymer = self.env.get("plasticos.polymer")
+        Polymer = self.env["plasticos.polymer"]
         if Polymer is None:
             return FALLBACK_POLYMERS
 
@@ -564,7 +564,7 @@ class PlasticosIntakeNormalizer(models.Model):
     def _log_normalization(self, action, errors):
         """Write to plasticos.automation.log if the model exists."""
         self.ensure_one()
-        AutoLog = self.env.get("plasticos.automation.log")
+        AutoLog = self.env["plasticos.automation.log"]
         if AutoLog is None:
             return
 

--- a/plasticos_transaction/models/account_move_inherit.py
+++ b/plasticos_transaction/models/account_move_inherit.py
@@ -38,7 +38,7 @@ class AccountMove(models.Model):
         Compliance check runs before super().action_post() to prevent side effects
         (webhooks, email notifications) from firing before potential rollback.
         """
-        service = self.env.get("plasticos.compliance.service")
+        service = self.env["plasticos.compliance.service"]
 
         # Batch query: collect all invoice_origins for SO lookup
         out_invoice_origins = [

--- a/plasticos_transaction/models/transaction.py
+++ b/plasticos_transaction/models/transaction.py
@@ -700,7 +700,7 @@ class PlasticosTransaction(models.Model):
         When compliance changes from 'missing' to 'compliant', auto-posts any
         draft invoices/bills linked to this transaction.
         """
-        service = self.env.get("plasticos.compliance.service")
+        service = self.env["plasticos.compliance.service"]
         if not service:
             for rec in self:
                 rec.compliance_status = "compliant"
@@ -815,8 +815,8 @@ class PlasticosTransaction(models.Model):
         self.state = "active"
 
     def action_close(self):
-        service_docs = self.env.get("plasticos.compliance.service")
-        service_commission = self.env.get("plasticos.commission.service")
+        service_docs = self.env["plasticos.compliance.service"]
+        service_commission = self.env["plasticos.commission.service"]
 
         for rec in self:
             self.env.cr.execute(

--- a/scripts/fix_odoo_antipatterns.py
+++ b/scripts/fix_odoo_antipatterns.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""
+Auto-fixer for safe Odoo antipatterns.
+
+Fixes (mechanical, safe substitutions only):
+1. self.env.get("model.name")  →  self.env["model.name"]
+2. self.pool.get("model.name") →  self.env["model.name"]
+3. @api.multi                  →  (line deleted)
+
+Skips:
+- Anything requiring semantic understanding (fields.function, unbounded search)
+
+Usage:
+    python3 scripts/fix_odoo_antipatterns.py [--check] [file ...]
+    pre-commit run fix-odoo-antipatterns --all-files
+
+Exit codes:
+    0 = No issues (or --check: no issues found)
+    1 = Files were modified (or --check: issues found)
+"""
+
+import re
+import sys
+from pathlib import Path
+
+ENV_GET_RE = re.compile(r'\bself\.env\.get\s*\(\s*(["\'])([^"\']+)\1\s*\)')
+POOL_GET_RE = re.compile(r'\bself\.pool\.get\s*\(\s*(["\'])([^"\']+)\1\s*\)')
+API_MULTI_RE = re.compile(r'^(\s*)@api\.multi\s*$')
+
+PLASTICOS_MODULES = [
+    "plasticos_automation", "plasticos_base", "plasticos_buyer_match_engine",
+    "plasticos_claims", "plasticos_commission", "plasticos_crm_bridge",
+    "plasticos_dev_tools", "plasticos_documents", "plasticos_documents_native",
+    "plasticos_enrichment", "plasticos_enrichment_bridge",
+    "plasticos_facility_profile", "plasticos_geolocalize",
+    "plasticos_graph_intelligence", "plasticos_inference_engine",
+    "plasticos_intake", "plasticos_intake_normalizer", "plasticos_logistics",
+    "plasticos_matching", "plasticos_material_profile", "plasticos_offer",
+    "plasticos_order_lines", "plasticos_partner_import", "plasticos_product",
+    "plasticos_security_base", "plasticos_transaction", "plasticos_web_leads",
+]
+
+
+def fix_content(content: str) -> tuple[str, list[str]]:
+    """Apply all safe auto-fixes. Returns (new_content, list_of_changes)."""
+    changes = []
+    lines = content.splitlines(keepends=True)
+    new_lines = []
+
+    for i, line in enumerate(lines, 1):
+        stripped = line.strip()
+
+        # Skip comment lines
+        if stripped.startswith("#"):
+            new_lines.append(line)
+            continue
+
+        original = line
+
+        # Fix 1: self.env.get("model") → self.env["model"]
+        def replace_env_get(m: re.Match) -> str:
+            quote, model = m.group(1), m.group(2)
+            changes.append(f"  line {i}: env.get({quote}{model}{quote}) → env[\"{model}\"]")
+            return f'self.env["{model}"]'
+
+        line = ENV_GET_RE.sub(replace_env_get, line)
+
+        # Fix 2: self.pool.get("model") → self.env["model"]
+        def replace_pool_get(m: re.Match) -> str:
+            quote, model = m.group(1), m.group(2)
+            changes.append(f"  line {i}: pool.get({quote}{model}{quote}) → env[\"{model}\"]")
+            return f'self.env["{model}"]'
+
+        line = POOL_GET_RE.sub(replace_pool_get, line)
+
+        # Fix 3: @api.multi → delete line
+        if API_MULTI_RE.match(line):
+            changes.append(f"  line {i}: removed @api.multi")
+            continue  # Drop the line
+
+        new_lines.append(line)
+
+    return "".join(new_lines), changes
+
+
+def find_python_files(paths: list[str]) -> list[Path]:
+    if paths:
+        return [Path(p) for p in paths if p.endswith(".py")]
+    files = []
+    for module in PLASTICOS_MODULES:
+        if Path(module).is_dir():
+            files.extend(Path(module).rglob("*.py"))
+    if Path("tests").is_dir():
+        files.extend(Path("tests").rglob("*.py"))
+    return files
+
+
+def main() -> int:
+    check_only = "--check" in sys.argv
+    file_args = [a for a in sys.argv[1:] if not a.startswith("--")]
+
+    files = find_python_files(file_args)
+    modified = 0
+
+    for path in files:
+        try:
+            original = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+
+        fixed, changes = fix_content(original)
+        if changes:
+            modified += 1
+            print(f"{'Would fix' if check_only else 'Fixed'}: {path}")
+            for c in changes:
+                print(c)
+            if not check_only:
+                path.write_text(fixed, encoding="utf-8")
+
+    if modified:
+        status = "issues found" if check_only else "files fixed"
+        print(f"\n{'❌' if check_only else '✅'} {modified} {status}")
+        return 1
+    else:
+        print("✅ No Odoo antipatterns found")
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/integration/test_account_move_transaction_link.py
+++ b/tests/integration/test_account_move_transaction_link.py
@@ -354,14 +354,14 @@ class TestAccountMoveComplianceGate(PlasticosTestCase):
 
     def test_compliance_check_blocks_invoice_when_docs_missing(self):
         """If compliance service returns False, action_post raises."""
-        ComplianceService = self.env.get("plasticos.compliance.service")
+        ComplianceService = self.env["plasticos.compliance.service"]
         if ComplianceService is None:
             self.skipTest("plasticos_documents not installed")
 
         # Mock is_compliant to return False
         with patch.object(type(ComplianceService), "is_compliant", return_value=False):
-            SO = self.env.get("sale.order")
-            TX = self.env.get("plasticos.transaction")
+            SO = self.env["sale.order"]
+            TX = self.env["plasticos.transaction"]
             if not SO or not TX:
                 self.skipTest("sale.order or transaction not available")
 


### PR DESCRIPTION
## Problem
`self.env.get('model')` is not a valid Odoo API. It silently returns `None`, causing silent failures (no logs created, transactions not recorded).

Found in **10 files** across 5 modules after running the new auto-fixer.

## Changes
### Auto-fixed (all 10 files)
Mechanical `env.get('x')` → `env['x']` substitution:
- plasticos_automation (4 models)
- plasticos_base midnight_recompute
- plasticos_intake, plasticos_intake_normalizer
- plasticos_transaction (account_move + transaction)
- tests/integration

### Requires manual fix (not touched)
`tests/test_cron_runtime.py` uses `env.get(variable)` for existence checks — replace with `model_name in self.env`.

### New tooling
- `scripts/fix_odoo_antipatterns.py` — auto-fixes env.get, pool.get, @api.multi on `pre-commit run`
- `ci/check_orm_integrity.py` — 5 new detectors: INVALID_ENV_GET, DEPRECATED_POOL_GET, DEPRECATED_API_MULTI, DEPRECATED_FIELDS_FUNCTION, UNBOUNDED_SEARCH
- `.pre-commit-config.yaml` — `fix-odoo-antipatterns` hook wired at pre-commit stage