### PR TITLE
fix(tests): use product_uom instead of product_uom_id in stock.move

### DIFF
--- a/plasticos_automation/tests/test_cron_plasticos_automation.py
+++ b/plasticos_automation/tests/test_cron_plasticos_automation.py
@@ -197,7 +197,7 @@ class TestTruckerFollowupCron(PlasticosTestCase, AutomationTestMixin):
                     {
                         "product_id": self._test_product.id,
                         "product_uom_qty": 1.0,
-                        "product_uom_id": self._test_product.uom_id.id,
+                        "product_uom": self._test_product.uom_id.id,
                         "location_id": self._stock_location.id,
                         "location_dest_id": self._customer_location.id,
                     },


### PR DESCRIPTION
## Summary
- Fixes `_create_picking()` helper in `TestTruckerFollowupCron` tests
- Renamed `product_uom_id` → `product_uom` on stock.move dict (Odoo 19 field name change)

## Test plan
- [ ] Verify TestTruckerFollowupCron tests pass:
  - test_confirmed_receipt_skipped
  - test_creates_automation_log
  - test_done_cancelled_excluded
  - All other tests calling `_create_picking()`


Made with [Cursor](https://cursor.com)