### PR TITLE
fix(services): add registry guards for optional service dependencies

### DIFF
--- a/plasticos_commission/tests/test_commission_rule.py
+++ b/plasticos_commission/tests/test_commission_rule.py
@@ -1,10 +1,14 @@
 import uuid
 
-from psycopg2 import IntegrityError
-
 from odoo.addons.plasticos_base.test_common import PlasticosTestCase
 from odoo.exceptions import ValidationError
 from odoo.tests import tagged
+
+# Odoo 19 may use psycopg3; handle both
+try:
+    from psycopg2 import IntegrityError
+except ImportError:
+    from psycopg import IntegrityError
 
 
 @tagged("post_install", "-at_install")

--- a/plasticos_documents/models/transaction_docs.py
+++ b/plasticos_documents/models/transaction_docs.py
@@ -63,6 +63,13 @@ class PlasticosTransactionDocs(models.Model):
         Leverages plasticos.compliance.service.get_missing_documents()
         and cross-references against the validation matrix categories.
         """
+        if "plasticos.compliance.service" not in self.env:
+            for tx in self:
+                tx.missing_supplier_docs = False
+                tx.missing_carrier_docs = False
+                tx.missing_buyer_docs = False
+            return
+
         matrix_model = self.env["plasticos.document.validation.matrix"]
         compliance = self.env["plasticos.compliance.service"]
 

--- a/plasticos_transaction/models/transaction.py
+++ b/plasticos_transaction/models/transaction.py
@@ -697,6 +697,10 @@ class PlasticosTransaction(models.Model):
         "commission_locked_amount",
     )
     def _compute_commission(self):
+        if "plasticos.commission.service" not in self.env:
+            for rec in self:
+                rec.commission_amount = rec.commission_locked_amount or 0.0
+            return
         service = self.env["plasticos.commission.service"]
         for rec in self:
             if rec.commission_locked:

--- a/plasticos_transaction/tests/test_commission_rule.py
+++ b/plasticos_transaction/tests/test_commission_rule.py
@@ -1,10 +1,14 @@
 import uuid
 
-from psycopg2 import IntegrityError
-
 from odoo.addons.plasticos_base.test_common import PlasticosTestCase
 from odoo.exceptions import ValidationError
 from odoo.tests import tagged
+
+# Odoo 19 may use psycopg3; handle both
+try:
+    from psycopg2 import IntegrityError
+except ImportError:
+    from psycopg import IntegrityError
 
 
 @tagged("post_install", "-at_install")


### PR DESCRIPTION
## Summary
- Adds registry guards for optional service dependencies to prevent KeyError when modules are not installed
- `transaction.py`: Guard `plasticos.commission.service` in `_compute_commission`
- `transaction_docs.py`: Guard `plasticos.compliance.service` in `_compute_missing_doc_flags`

## Test plan
- [ ] Verify plasticos_transaction tests pass without plasticos_commission installed
- [ ] Verify plasticos_documents tests pass without plasticos_compliance installed
- [ ] All existing tests continue to pass


Made with [Cursor](https://cursor.com)