### PR TITLE
fix(tests): add psycopg3 compatibility for IntegrityError import

### DIFF
--- a/plasticos_commission/tests/test_commission_rule.py
+++ b/plasticos_commission/tests/test_commission_rule.py
@@ -1,10 +1,14 @@
 import uuid
 
-from psycopg2 import IntegrityError
-
 from odoo.addons.plasticos_base.test_common import PlasticosTestCase
 from odoo.exceptions import ValidationError
 from odoo.tests import tagged
+
+# Odoo 19 may use psycopg3; handle both
+try:
+    from psycopg2 import IntegrityError
+except ImportError:
+    from psycopg import IntegrityError
 
 
 @tagged("post_install", "-at_install")

--- a/plasticos_transaction/tests/test_commission_rule.py
+++ b/plasticos_transaction/tests/test_commission_rule.py
@@ -1,10 +1,14 @@
 import uuid
 
-from psycopg2 import IntegrityError
-
 from odoo.addons.plasticos_base.test_common import PlasticosTestCase
 from odoo.exceptions import ValidationError
 from odoo.tests import tagged
+
+# Odoo 19 may use psycopg3; handle both
+try:
+    from psycopg2 import IntegrityError
+except ImportError:
+    from psycopg import IntegrityError
 
 
 @tagged("post_install", "-at_install")


### PR DESCRIPTION
## Summary
- Adds try/except import to handle both psycopg2 and psycopg3 IntegrityError
- Odoo 19 may use psycopg3 instead of psycopg2

## Files Changed
- `plasticos_commission/tests/test_commission_rule.py`
- `plasticos_transaction/tests/test_commission_rule.py`

## Test plan
- [ ] Verify commission rule constraint tests pass on Odoo.sh


Made with [Cursor](https://cursor.com)