### PR TITLE
fix(ci): remove plasticos_*/tests/ from coverage-report collection

### DIFF
--- a/.github/workflows/test-quality.yml
+++ b/.github/workflows/test-quality.yml
@@ -393,8 +393,7 @@ jobs:
             --cov-report=xml \
             --cov-report=term \
             --cov-report=html:coverage-html \
-            tests/ \
-            plasticos_*/tests/
+            tests/
 
       - name: Check Coverage Threshold
         run: |


### PR DESCRIPTION
## Problem

The `coverage-report` job's "Run full test suite with coverage" step collects tests from both `tests/` and `plasticos_*/tests/`. The latter fails with:

```
ModuleNotFoundError: No module named 'odoo'
```

Odoo is a managed PaaS (Odoo.sh) — the Odoo runtime is not installed in CI runners.

## Fix

Remove `plasticos_*/tests/` from the pytest collection path in the coverage-report job. The `tests/` directory contains standalone tests that work without Odoo installed.

## Impact

- Coverage-report job will no longer fail at collection time
- Module-level `plasticos_*` coverage is still tracked (via `--cov=plasticos_*` flags)
- Odoo module tests remain runnable in Odoo.sh staging environment where the runtime is available