### PR TITLE
feat: add safe deployment feature gates for buyer match engine

### DIFF
--- a/plasticos_buyer_match_engine/__manifest__.py
+++ b/plasticos_buyer_match_engine/__manifest__.py
@@ -19,6 +19,7 @@
     """,
     "author": "Plasticos Dev",
     "depends": [
+        "base_setup",
         "plasticos_base",
         "plasticos_intake",
         "plasticos_material_profile",

--- a/plasticos_buyer_match_engine/__manifest__.py
+++ b/plasticos_buyer_match_engine/__manifest__.py
@@ -29,9 +29,11 @@
     ],
     "data": [
         "security/ir.model.access.csv",
+        "data/feature_flags.xml",
         "data/ir_cron_graph_sync.xml",
         "views/intake_button_views.xml",
         "views/match_exclusion_views.xml",
+        "views/res_config_settings_views.xml",
     ],
     "external_dependencies": {
         "python": ["neo4j"],

--- a/plasticos_buyer_match_engine/data/feature_flags.xml
+++ b/plasticos_buyer_match_engine/data/feature_flags.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="1">
+        <record id="icp_matching_engine_enabled" model="ir.config_parameter">
+            <field name="key">ib.matching_engine.enabled</field>
+            <field name="value">False</field>
+        </record>
+
+        <record id="icp_inference_engine_enabled" model="ir.config_parameter">
+            <field name="key">ib.inference_engine.enabled</field>
+            <field name="value">False</field>
+        </record>
+
+        <record id="icp_matching_engine_url" model="ir.config_parameter">
+            <field name="key">ib.matching_engine.url</field>
+            <field name="value">http://localhost:8001</field>
+        </record>
+
+        <record id="icp_inference_engine_url" model="ir.config_parameter">
+            <field name="key">ib.inference_engine.url</field>
+            <field name="value">http://localhost:8002</field>
+        </record>
+
+        <record id="icp_feature_gate_message" model="ir.config_parameter">
+            <field name="key">ib.feature_gate.user_message</field>
+            <field name="value">This feature is being deployed and will be available shortly. Please check back in about an hour.</field>
+        </record>
+    </data>
+</odoo>

--- a/plasticos_buyer_match_engine/models/__init__.py
+++ b/plasticos_buyer_match_engine/models/__init__.py
@@ -1,3 +1,4 @@
+from . import feature_gate_mixin
 from . import matcher
 from . import graph_sync_log
 from . import graph_service
@@ -6,3 +7,4 @@ from . import material_profile_graph_hooks
 from . import intake_graph_hooks
 from . import intake_extension
 from . import match_exclusion
+from . import res_config_settings

--- a/plasticos_buyer_match_engine/models/feature_gate_mixin.py
+++ b/plasticos_buyer_match_engine/models/feature_gate_mixin.py
@@ -1,0 +1,67 @@
+import functools
+import logging
+
+from odoo import _, models
+from odoo.exceptions import UserError
+
+_logger = logging.getLogger(__name__)
+
+
+TRUTHY_PARAM_VALUES = {"true", "1", "yes", "on"}
+
+
+def feature_gated(param_key):
+    """Guard an interactive model method behind an ir.config_parameter flag."""
+
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(self, *args, **kwargs):
+            self._check_feature_gate(param_key)
+            return func(self, *args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+class FeatureGateMixin(models.AbstractModel):
+    _name = "plasticos.feature.gate.mixin"
+    _description = "PlasticOS Feature Gate Mixin"
+
+    def _get_feature_gate_message(self):
+        icp = self.env["ir.config_parameter"].sudo()
+        return icp.get_param(
+            "ib.feature_gate.user_message",
+            _("This feature is being deployed and will be available shortly. Please check back in about an hour."),
+        )
+
+    def _is_feature_enabled(self, param_key):
+        icp = self.env["ir.config_parameter"].sudo()
+        enabled = (icp.get_param(param_key, "False") or "False").strip().lower()
+        return enabled in TRUTHY_PARAM_VALUES
+
+    def _check_feature_gate(self, param_key):
+        if self._is_feature_enabled(param_key):
+            return True
+
+        message = self._get_feature_gate_message()
+        _logger.info(
+            "Feature gate blocked: model=%s gate=%s user=%s ids=%s",
+            self._name,
+            param_key,
+            self.env.uid,
+            list(self.ids),
+        )
+        raise UserError(message)
+
+    def _skip_feature_gate_for_cron(self, param_key, cron_name):
+        if self._is_feature_enabled(param_key):
+            return False
+
+        _logger.warning(
+            "Feature gate skip: cron=%s model=%s gate=%s",
+            cron_name,
+            self._name,
+            param_key,
+        )
+        return True

--- a/plasticos_buyer_match_engine/models/graph_service.py
+++ b/plasticos_buyer_match_engine/models/graph_service.py
@@ -1078,6 +1078,11 @@ class PlasticosGraphService(models.AbstractModel):
         if not self.env.cr.fetchone()[0]:
             _logger.info("Nightly graph sync skipped: advisory lock held.")
             return "Skipped: lock held"
+
+        gate = self.env["plasticos.feature.gate.mixin"]
+        if gate._skip_feature_gate_for_cron("ib.matching_engine.enabled", "nightly_graph_sync"):
+            return "Skipped: matching engine disabled"
+
         try:
             self.sudo().sync_all(trigger="nightly_cron")  # cron-sudo-justification: system cron needs full access
             return "Nightly graph sync completed."

--- a/plasticos_buyer_match_engine/models/graph_service.py
+++ b/plasticos_buyer_match_engine/models/graph_service.py
@@ -1079,10 +1079,6 @@ class PlasticosGraphService(models.AbstractModel):
             _logger.info("Nightly graph sync skipped: advisory lock held.")
             return "Skipped: lock held"
 
-        gate = self.env["plasticos.feature.gate.mixin"]
-        if gate._skip_feature_gate_for_cron("ib.matching_engine.enabled", "nightly_graph_sync"):
-            return "Skipped: matching engine disabled"
-
         try:
             self.sudo().sync_all(trigger="nightly_cron")  # cron-sudo-justification: system cron needs full access
             return "Nightly graph sync completed."

--- a/plasticos_buyer_match_engine/models/intake_extension.py
+++ b/plasticos_buyer_match_engine/models/intake_extension.py
@@ -3,11 +3,13 @@ import logging
 from odoo import _, fields, models
 from odoo.exceptions import UserError
 
+from .feature_gate_mixin import feature_gated
+
 _logger = logging.getLogger(__name__)
 
 
 class PlasticosIntake(models.Model):
-    _inherit = "plasticos.intake"
+    _inherit = ["plasticos.intake", "plasticos.feature.gate.mixin"]
 
     match_mode = fields.Selection(
         [
@@ -20,6 +22,7 @@ class PlasticosIntake(models.Model):
         "Relaxed: only polymer is hard, others are soft scoring signals.",
     )
 
+    @feature_gated("ib.matching_engine.enabled")
     def action_match_to_buyers(self):
         """Run buyer matching v2.0: facility.profile + Neo4j graph scoring.
 

--- a/plasticos_buyer_match_engine/models/intake_graph_hooks.py
+++ b/plasticos_buyer_match_engine/models/intake_graph_hooks.py
@@ -34,6 +34,10 @@ class IntakeGraphHooks(models.Model):
         Uses plasticos.buyer.matcher which internally calls
         graph_service.calculate_match_score() for Neo4j scoring.
         """
+        gate = self.env["plasticos.feature.gate.mixin"]
+        if gate._skip_feature_gate_for_cron("ib.matching_engine.enabled", "intake_normalized_auto_match"):
+            return
+
         try:
             matcher = self.env["plasticos.buyer.matcher"]
             matches = matcher.find_matches_for_supplier(

--- a/plasticos_buyer_match_engine/models/res_config_settings.py
+++ b/plasticos_buyer_match_engine/models/res_config_settings.py
@@ -1,0 +1,31 @@
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    ib_matching_engine_enabled = fields.Boolean(
+        string="Enable Matching Engine",
+        config_parameter="ib.matching_engine.enabled",
+        help="Activate buyer matching features backed by the matching engine.",
+    )
+    ib_inference_engine_enabled = fields.Boolean(
+        string="Enable Inference Engine",
+        config_parameter="ib.inference_engine.enabled",
+        help="Reserve toggle for inference-driven features as they come online.",
+    )
+    ib_matching_engine_url = fields.Char(
+        string="Matching Engine URL",
+        config_parameter="ib.matching_engine.url",
+        default="http://localhost:8001",
+    )
+    ib_inference_engine_url = fields.Char(
+        string="Inference Engine URL",
+        config_parameter="ib.inference_engine.url",
+        default="http://localhost:8002",
+    )
+    ib_feature_gate_message = fields.Text(
+        string="Feature Unavailable Message",
+        config_parameter="ib.feature_gate.user_message",
+        help="Shown to users when a disabled microservice-backed feature is invoked.",
+    )

--- a/plasticos_buyer_match_engine/tests/test_feature_gate.py
+++ b/plasticos_buyer_match_engine/tests/test_feature_gate.py
@@ -28,9 +28,11 @@ class TestFeatureGate(PlasticosTestCase):
         intake = self._create_intake(partner=self.default_partner, polymer=self.default_polymer, form=self.default_form)
         if intake is None:
             self.skipTest("plasticos.intake factory unavailable")
+            return None  # Unreachable, but satisfies static analysis
         material_profile = self._create_material_profile(partner=self.default_partner, polymer=self.default_polymer)
         if material_profile is None:
             self.skipTest("plasticos.material.profile factory unavailable")
+            return None  # Unreachable, but satisfies static analysis
         intake.write({"material_profile_id": material_profile.id})
         return intake
 
@@ -50,7 +52,9 @@ class TestFeatureGate(PlasticosTestCase):
     def test_matching_gate_allows_method_path_when_enabled(self):
         intake = self._create_gated_intake()
         self.ICP.set_param("ib.matching_engine.enabled", "True")
-        with patch("odoo.addons.plasticos_buyer_match_engine.models.intake_extension.PlasticosIntake._notify_neo4j_fallback") as notify:
+        with patch(
+            "odoo.addons.plasticos_buyer_match_engine.models.intake_extension.PlasticosIntake._notify_neo4j_fallback"
+        ) as notify:
             with patch.object(
                 self.env["plasticos.buyer.matcher"],
                 "find_matches_for_supplier",

--- a/plasticos_buyer_match_engine/tests/test_feature_gate.py
+++ b/plasticos_buyer_match_engine/tests/test_feature_gate.py
@@ -1,0 +1,83 @@
+from unittest.mock import patch
+
+from odoo.addons.plasticos_base.test_common import PlasticosTestCase
+from odoo.exceptions import UserError
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install", "plasticos", "feature_gate")
+class TestFeatureGate(PlasticosTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls._skip_if_model_missing("plasticos.intake", "plasticos.feature.gate.mixin", "res.config.settings")
+        cls.ICP = cls.env["ir.config_parameter"].sudo()
+        cls.Intake = cls.env["plasticos.intake"]
+        cls.Gate = cls.env["plasticos.feature.gate.mixin"]
+
+    def setUp(self):
+        super().setUp()
+        self.ICP.set_param("ib.matching_engine.enabled", "False")
+        self.ICP.set_param("ib.inference_engine.enabled", "False")
+        self.ICP.set_param(
+            "ib.feature_gate.user_message",
+            "This feature is being deployed and will be available shortly. Please check back in about an hour.",
+        )
+
+    def _create_gated_intake(self):
+        intake = self._create_intake(partner=self.default_partner, polymer=self.default_polymer, form=self.default_form)
+        if intake is None:
+            self.skipTest("plasticos.intake factory unavailable")
+        material_profile = self._create_material_profile(partner=self.default_partner, polymer=self.default_polymer)
+        if material_profile is None:
+            self.skipTest("plasticos.material.profile factory unavailable")
+        intake.write({"material_profile_id": material_profile.id})
+        return intake
+
+    def test_matching_action_blocked_when_disabled(self):
+        intake = self._create_gated_intake()
+        with self.assertRaises(UserError):
+            intake.action_match_to_buyers()
+
+    def test_matching_action_uses_custom_message_when_disabled(self):
+        intake = self._create_gated_intake()
+        custom_msg = "System upgrade in progress. Back in about an hour."
+        self.ICP.set_param("ib.feature_gate.user_message", custom_msg)
+        with self.assertRaises(UserError) as ctx:
+            intake.action_match_to_buyers()
+        self.assertIn(custom_msg, str(ctx.exception))
+
+    def test_matching_gate_allows_method_path_when_enabled(self):
+        intake = self._create_gated_intake()
+        self.ICP.set_param("ib.matching_engine.enabled", "True")
+        with patch("odoo.addons.plasticos_buyer_match_engine.models.intake_extension.PlasticosIntake._notify_neo4j_fallback") as notify:
+            with patch.object(
+                self.env["plasticos.buyer.matcher"],
+                "find_matches_for_supplier",
+                return_value=[],
+            ) as matcher:
+                result = intake.action_match_to_buyers()
+        self.assertTrue(result)
+        self.assertIn(result.get("type"), {"ir.actions.act_window", "ir.actions.client"})
+        notify.assert_called()
+        matcher.assert_called()
+
+    def test_cron_skip_helper_returns_true_when_disabled(self):
+        skipped = self.Gate._skip_feature_gate_for_cron("ib.matching_engine.enabled", "nightly_graph_sync")
+        self.assertTrue(skipped)
+
+    def test_cron_skip_helper_returns_false_when_enabled(self):
+        self.ICP.set_param("ib.matching_engine.enabled", "True")
+        skipped = self.Gate._skip_feature_gate_for_cron("ib.matching_engine.enabled", "nightly_graph_sync")
+        self.assertFalse(skipped)
+
+    def test_settings_fields_are_registered(self):
+        settings = self.env["res.config.settings"]
+        for field_name in [
+            "ib_matching_engine_enabled",
+            "ib_inference_engine_enabled",
+            "ib_matching_engine_url",
+            "ib_inference_engine_url",
+            "ib_feature_gate_message",
+        ]:
+            self.assertIn(field_name, settings._fields)

--- a/plasticos_buyer_match_engine/tests/test_feature_gate.py
+++ b/plasticos_buyer_match_engine/tests/test_feature_gate.py
@@ -63,12 +63,12 @@ class TestFeatureGate(PlasticosTestCase):
         matcher.assert_called()
 
     def test_cron_skip_helper_returns_true_when_disabled(self):
-        skipped = self.Gate._skip_feature_gate_for_cron("ib.matching_engine.enabled", "nightly_graph_sync")
+        skipped = self.Gate._skip_feature_gate_for_cron("ib.matching_engine.enabled", "intake_normalized_auto_match")
         self.assertTrue(skipped)
 
     def test_cron_skip_helper_returns_false_when_enabled(self):
         self.ICP.set_param("ib.matching_engine.enabled", "True")
-        skipped = self.Gate._skip_feature_gate_for_cron("ib.matching_engine.enabled", "nightly_graph_sync")
+        skipped = self.Gate._skip_feature_gate_for_cron("ib.matching_engine.enabled", "intake_normalized_auto_match")
         self.assertFalse(skipped)
 
     def test_settings_fields_are_registered(self):

--- a/plasticos_buyer_match_engine/tests/test_module_install.py
+++ b/plasticos_buyer_match_engine/tests/test_module_install.py
@@ -26,6 +26,7 @@ class TestModuleInstall(PlasticosTestCase):
         """All plasticos_buyer_match_engine models must be in the registry."""
         expected_models = [
             "plasticos.buyer.matcher",
+            "plasticos.feature.gate.mixin",
             "plasticos.graph.service",
             "plasticos.graph.sync.log",
             "plasticos.match.exclusion",

--- a/plasticos_buyer_match_engine/views/intake_button_views.xml
+++ b/plasticos_buyer_match_engine/views/intake_button_views.xml
@@ -11,6 +11,7 @@
                         string="Match to Buyers"
                         type="object"
                         class="btn-primary"
+                        help="Requires the matching engine to be enabled in Settings > General Settings > IB Microservices."
                         invisible="not material_profile_id"/>
             </xpath>
         </field>

--- a/plasticos_buyer_match_engine/views/res_config_settings_views.xml
+++ b/plasticos_buyer_match_engine/views/res_config_settings_views.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="res_config_settings_view_form_plasticos_feature_gates" model="ir.ui.view">
+        <field name="name">res.config.settings.view.form.plasticos.feature.gates</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="base_setup.res_config_settings_view_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//form" position="inside">
+                <app string="IB Microservices" name="ib_microservices" groups="base.group_system">
+                    <block title="Microservice Feature Gates">
+                        <setting id="ib_matching_engine_enabled_setting" string="Enable Matching Engine"
+                                 help="Activate buyer/seller matching via the external matching engine.">
+                            <field name="ib_matching_engine_enabled"/>
+                            <div class="content-group" invisible="not ib_matching_engine_enabled">
+                                <label for="ib_matching_engine_url"/>
+                                <field name="ib_matching_engine_url" placeholder="http://matching-svc:8001"/>
+                            </div>
+                        </setting>
+
+                        <setting id="ib_inference_engine_enabled_setting" string="Enable Inference Engine"
+                                 help="Activate inference-driven valuation, scoring, and recommendations when the service is ready.">
+                            <field name="ib_inference_engine_enabled"/>
+                            <div class="content-group" invisible="not ib_inference_engine_enabled">
+                                <label for="ib_inference_engine_url"/>
+                                <field name="ib_inference_engine_url" placeholder="http://inference-svc:8002"/>
+                            </div>
+                        </setting>
+                    </block>
+
+                    <block title="Graceful Degradation">
+                        <setting id="ib_feature_gate_message_setting" string="Feature Unavailable Message"
+                                 help="Message shown when a disabled microservice-backed feature is invoked.">
+                            <field name="ib_feature_gate_message"/>
+                        </setting>
+                    </block>
+                </app>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
## Summary
Implements safe deployment feature gates for buyer matching with default-disabled settings, friendly runtime blocking for the real matching UI action, and guarded auto-match behavior on normalized intakes.

## Implemented in code
- Added default-disabled system parameters in `plasticos_buyer_match_engine/data/feature_flags.xml`
  - `ib.matching_engine.enabled=False`
  - `ib.inference_engine.enabled=False`
  - `ib.matching_engine.url`
  - `ib.inference_engine.url`
  - `ib.feature_gate.user_message`
- Added shared gate layer in `plasticos_buyer_match_engine/models/feature_gate_mixin.py`
  - `feature_gated(param_key)` decorator
  - `_check_feature_gate()` for interactive actions
  - `_skip_feature_gate_for_cron()` for non-crashing background skips
- Wired the real matching UI entrypoint behind the feature gate
  - `plasticos.intake.action_match_to_buyers()` now requires `ib.matching_engine.enabled`
- Guarded the matching-triggered background path
  - normalized-intake auto match hook skips cleanly when disabled
- Added admin-facing settings UI in `res.config.settings`
  - matching toggle/url
  - inference toggle/url
  - editable user-facing degraded-mode message
- Added Odoo-side tests for gate behavior, helper behavior, and settings field registration
- Added missing manifest dependency on `base_setup` for the settings view inheritance

## Repo mapping vs source spec
The source spec referenced generic models like `ib.property.listing` and `crm.lead` inference actions. In this repo, the actual matching surface is:
- UI action: `plasticos.intake.action_match_to_buyers`
- auto-match hook: `plasticos.intake._run_buyer_match_if_available`

The nightly graph topology sync exists in this module, but it is not itself a matching invocation path, so it is not feature-gated by `ib.matching_engine.enabled` in this PR.

There is currently no equivalent Odoo-backed inference UI action in the repo to gate without inventing fake behavior, so the inference side is implemented as config/settings/flags for later activation rather than fabricated business methods.

## Production deploy / runbook handoff items not executable from this environment
These steps still need execution on the actual Odoo host / Odoo.sh environment:

### Environment validation
- [ ] `odoo-bin --version`
- [ ] verify `addons_path` contains all required addon directories
- [ ] verify DB backup exists before update
- [ ] verify env vars / config for matching and inference service URLs
- [ ] verify target environment access / health

### Deploy + flag verification on host
- [ ] update target modules
- [ ] verify `ir_config_parameter` values for matching/inference flags are `False`
- [ ] confirm modules install/upgrade cleanly on staging database

### Behavior validation on staging
- [ ] manually trigger normalized-intake auto match path with flag disabled
- [ ] confirm logs show skip/warning behavior instead of traceback/retry storm
- [ ] clicking **Match To Buyers** shows friendly message, not traceback
- [ ] unrelated modules/pages continue loading normally

### Enable later / rollback
- [ ] health check matching service endpoint
- [ ] health check inference service endpoint
- [ ] enable toggles in Settings > General Settings > IB Microservices
- [ ] save production URLs
- [ ] if either service degrades later, uncheck the failing toggle and verify graceful degradation resumes

## Success criteria checklist
### Code-level
- [x] matching action is blocked by default with friendly `UserError`
- [x] admin can edit the degraded-mode message and URLs without code change
- [x] matching-triggered background path skips safely when disabled
- [x] settings view has its manifest dependency declared
- [x] no module removal / no destructive behavior introduced

### Operational handoff
- [ ] staging module upgrade completes successfully
- [ ] default flags remain disabled after upgrade
- [ ] clicking **Match To Buyers** shows friendly message, not traceback
- [ ] disabled background path logs skip behavior, not errors
- [ ] unrelated modules/pages continue loading normally
- [ ] enabling a healthy service later works without restart
- [ ] disabling a failing service later restores graceful degradation immediately

## Verification performed here
- `python3 -m compileall plasticos_buyer_match_engine`

## Notes
- Scope kept surgical: real matching paths only, no fabricated inference actions, no native Odoo runtime testing attempted here.
