### PR TITLE
fix: replace ALL psycopg2 IntegrityError imports with psycopg3

### DIFF
--- a/plasticos_automation/tests/test_automation_config.py
+++ b/plasticos_automation/tests/test_automation_config.py
@@ -4,7 +4,7 @@ Target module: plasticos_automation
 Target model:  plasticos.automation.config
 """
 
-from psycopg2 import IntegrityError
+from psycopg.errors import IntegrityError
 
 from odoo.addons.plasticos_base.test_common import PlasticosTestCase
 from odoo.exceptions import ValidationError

--- a/plasticos_automation/tests/test_automation_log.py
+++ b/plasticos_automation/tests/test_automation_log.py
@@ -8,15 +8,11 @@ Tests cover:
     - Search and filtering
 """
 
+from psycopg.errors import IntegrityError
+
 from odoo.addons.plasticos_base.test_common import PlasticosTestCase
 from odoo.exceptions import ValidationError
 from odoo.tests import tagged
-
-# Odoo 19 may use psycopg3; handle both
-try:
-    from psycopg2 import IntegrityError
-except ImportError:
-    from psycopg.errors import IntegrityError
 
 
 @tagged("post_install", "-at_install")

--- a/plasticos_buyer_match_engine/tests/test_statemachine_match_result.py
+++ b/plasticos_buyer_match_engine/tests/test_statemachine_match_result.py
@@ -5,15 +5,11 @@ States: pending → accepted | rejected | expired
 Source: plasticos_matching/models/match_result.py
 """
 
+from psycopg.errors import IntegrityError
+
 from odoo.addons.plasticos_base.test_common import PlasticosTestCase
 from odoo.exceptions import UserError, ValidationError
 from odoo.tests import tagged
-
-# Odoo 19 may use psycopg3; handle both
-try:
-    from psycopg2 import IntegrityError
-except ImportError:
-    from psycopg.errors import IntegrityError
 
 
 @tagged("post_install", "-at_install")

--- a/plasticos_claims/tests/test_claim.py
+++ b/plasticos_claims/tests/test_claim.py
@@ -1,12 +1,8 @@
+from psycopg.errors import IntegrityError
+
 from odoo.addons.plasticos_base.test_common import PlasticosTestCase
 from odoo.exceptions import UserError, ValidationError
 from odoo.tests import tagged
-
-# Odoo 19 may use psycopg3; handle both
-try:
-    from psycopg2 import IntegrityError
-except ImportError:
-    from psycopg.errors import IntegrityError
 
 
 @tagged("post_install", "-at_install")

--- a/plasticos_claims/tests/test_claim_constraints.py
+++ b/plasticos_claims/tests/test_claim_constraints.py
@@ -5,7 +5,7 @@ Test claim constraints.
 - resolution_note required on resolve
 """
 
-from psycopg2 import IntegrityError
+from psycopg.errors import IntegrityError
 
 from odoo.addons.plasticos_base.test_common import PlasticosTestCase
 from odoo.exceptions import UserError

--- a/plasticos_claims/tests/test_constraints_claims.py
+++ b/plasticos_claims/tests/test_constraints_claims.py
@@ -1,12 +1,8 @@
+from psycopg.errors import IntegrityError
+
 from odoo.addons.plasticos_base.test_common import PlasticosTestCase
 from odoo.exceptions import ValidationError
 from odoo.tests import tagged
-
-# Odoo 19 may use psycopg3; handle both
-try:
-    from psycopg2 import IntegrityError
-except ImportError:
-    from psycopg.errors import IntegrityError
 
 
 @tagged("post_install", "-at_install")

--- a/plasticos_commission/tests/test_commission_rule.py
+++ b/plasticos_commission/tests/test_commission_rule.py
@@ -1,14 +1,10 @@
 import uuid
 
+from psycopg.errors import IntegrityError
+
 from odoo.addons.plasticos_base.test_common import PlasticosTestCase
 from odoo.exceptions import ValidationError
 from odoo.tests import tagged
-
-# Odoo 19 may use psycopg3; handle both
-try:
-    from psycopg2 import IntegrityError
-except ImportError:
-    from psycopg.errors import IntegrityError
 
 
 @tagged("post_install", "-at_install")

--- a/plasticos_documents/tests/test_document_rules.py
+++ b/plasticos_documents/tests/test_document_rules.py
@@ -4,7 +4,7 @@ Target module: plasticos_documents
 Target model:  plasticos.document.rule
 """
 
-from psycopg2 import IntegrityError
+from psycopg.errors import IntegrityError
 
 from odoo.addons.plasticos_base.test_common import PlasticosTestCase
 from odoo.exceptions import ValidationError

--- a/plasticos_documents/tests/test_document_tags.py
+++ b/plasticos_documents/tests/test_document_tags.py
@@ -4,7 +4,7 @@ Test document tags.
 Tests unique code constraint.
 """
 
-from psycopg2 import IntegrityError
+from psycopg.errors import IntegrityError
 
 from odoo.addons.plasticos_base.test_common import PlasticosTestCase
 from odoo.tests import tagged

--- a/plasticos_facility_profile/tests/test_equipment_types.py
+++ b/plasticos_facility_profile/tests/test_equipment_types.py
@@ -4,7 +4,7 @@ Test equipment types.
 Tests unique code constraint.
 """
 
-from psycopg2 import IntegrityError
+from psycopg.errors import IntegrityError
 
 from odoo.addons.plasticos_base.test_common import PlasticosTestCase
 from odoo.tests import tagged

--- a/plasticos_facility_profile/tests/test_facility_crud.py
+++ b/plasticos_facility_profile/tests/test_facility_crud.py
@@ -6,7 +6,7 @@ Test facility profile CRUD operations.
 - partner sync
 """
 
-from psycopg2 import IntegrityError
+from psycopg.errors import IntegrityError
 
 from odoo.addons.plasticos_base.test_common import PlasticosTestCase
 from odoo.tests import tagged

--- a/plasticos_facility_profile/tests/test_partner_types.py
+++ b/plasticos_facility_profile/tests/test_partner_types.py
@@ -4,7 +4,7 @@ Test partner types.
 Tests unique code and lead source mapping.
 """
 
-from psycopg2 import IntegrityError
+from psycopg.errors import IntegrityError
 
 from odoo.addons.plasticos_base.test_common import PlasticosTestCase
 from odoo.tests import tagged

--- a/plasticos_logistics/tests/test_rate_engine.py
+++ b/plasticos_logistics/tests/test_rate_engine.py
@@ -7,7 +7,7 @@ Service:       services/rate_engine.py
 
 from datetime import timedelta
 
-from psycopg2 import IntegrityError
+from psycopg.errors import IntegrityError
 
 from odoo import fields
 from odoo.addons.plasticos_base.test_common import PlasticosTestCase

--- a/plasticos_logistics/tests/test_rate_memory.py
+++ b/plasticos_logistics/tests/test_rate_memory.py
@@ -10,7 +10,7 @@ and update-overwrite behavior.
 import uuid
 from datetime import date, timedelta
 
-from psycopg2 import IntegrityError
+from psycopg.errors import IntegrityError
 
 from odoo import fields
 from odoo.addons.plasticos_base.test_common import PlasticosTestCase

--- a/plasticos_material_profile/tests/test_constraints_material_profile.py
+++ b/plasticos_material_profile/tests/test_constraints_material_profile.py
@@ -1,14 +1,10 @@
 import uuid
 
+from psycopg.errors import IntegrityError
+
 from odoo.addons.plasticos_base.test_common import PlasticosTestCase
 from odoo.exceptions import ValidationError
 from odoo.tests import tagged
-
-# Odoo 19 may use psycopg3; handle both
-try:
-    from psycopg2 import IntegrityError
-except ImportError:
-    from psycopg.errors import IntegrityError
 
 
 def _unique_code(prefix="TEST"):

--- a/plasticos_material_profile/tests/test_filler_type.py
+++ b/plasticos_material_profile/tests/test_filler_type.py
@@ -1,10 +1,6 @@
 import uuid
 
-# Odoo 19 may use psycopg3; handle both
-try:
-    from psycopg2 import IntegrityError
-except ImportError:
-    from psycopg.errors import IntegrityError
+from psycopg.errors import IntegrityError
 
 from odoo.addons.plasticos_base.test_common import PlasticosTestCase
 from odoo.exceptions import ValidationError

--- a/plasticos_material_profile/tests/test_material_attribute.py
+++ b/plasticos_material_profile/tests/test_material_attribute.py
@@ -1,10 +1,6 @@
 import uuid
 
-# Odoo 19 may use psycopg3; handle both
-try:
-    from psycopg2 import IntegrityError
-except ImportError:
-    from psycopg.errors import IntegrityError
+from psycopg.errors import IntegrityError
 
 from odoo.addons.plasticos_base.test_common import PlasticosTestCase
 from odoo.exceptions import ValidationError

--- a/plasticos_material_profile/tests/test_material_color.py
+++ b/plasticos_material_profile/tests/test_material_color.py
@@ -1,10 +1,6 @@
 import uuid
 
-# Odoo 19 may use psycopg3; handle both
-try:
-    from psycopg2 import IntegrityError
-except ImportError:
-    from psycopg.errors import IntegrityError
+from psycopg.errors import IntegrityError
 
 from odoo.addons.plasticos_base.test_common import PlasticosTestCase
 from odoo.exceptions import ValidationError

--- a/plasticos_material_profile/tests/test_material_form.py
+++ b/plasticos_material_profile/tests/test_material_form.py
@@ -1,10 +1,6 @@
 import uuid
 
-# Odoo 19 may use psycopg3; handle both
-try:
-    from psycopg2 import IntegrityError
-except ImportError:
-    from psycopg.errors import IntegrityError
+from psycopg.errors import IntegrityError
 
 from odoo.addons.plasticos_base.test_common import PlasticosTestCase
 from odoo.exceptions import ValidationError

--- a/plasticos_material_profile/tests/test_material_profile_enhanced.py
+++ b/plasticos_material_profile/tests/test_material_profile_enhanced.py
@@ -6,7 +6,7 @@ Target model:  plasticos.material.profile
 
 import uuid
 
-from psycopg2 import IntegrityError
+from psycopg.errors import IntegrityError
 
 from odoo.addons.plasticos_base.test_common import PlasticosTestCase
 from odoo.exceptions import ValidationError

--- a/plasticos_material_profile/tests/test_packaging_type.py
+++ b/plasticos_material_profile/tests/test_packaging_type.py
@@ -1,10 +1,6 @@
 import uuid
 
-# Odoo 19 may use psycopg3; handle both
-try:
-    from psycopg2 import IntegrityError
-except ImportError:
-    from psycopg.errors import IntegrityError
+from psycopg.errors import IntegrityError
 
 from odoo.addons.plasticos_base.test_common import PlasticosTestCase
 from odoo.exceptions import ValidationError

--- a/plasticos_material_profile/tests/test_polymer.py
+++ b/plasticos_material_profile/tests/test_polymer.py
@@ -1,12 +1,8 @@
+from psycopg.errors import IntegrityError
+
 from odoo.addons.plasticos_base.test_common import PlasticosTestCase
 from odoo.exceptions import ValidationError
 from odoo.tests import tagged
-
-# Odoo 19 may use psycopg3; handle both
-try:
-    from psycopg2 import IntegrityError
-except ImportError:
-    from psycopg.errors import IntegrityError
 
 
 @tagged("post_install", "-at_install")

--- a/plasticos_material_profile/tests/test_process_type.py
+++ b/plasticos_material_profile/tests/test_process_type.py
@@ -1,10 +1,6 @@
 import uuid
 
-# Odoo 19 may use psycopg3; handle both
-try:
-    from psycopg2 import IntegrityError
-except ImportError:
-    from psycopg.errors import IntegrityError
+from psycopg.errors import IntegrityError
 
 from odoo.addons.plasticos_base.test_common import PlasticosTestCase
 from odoo.exceptions import ValidationError

--- a/plasticos_material_profile/tests/test_profile_crud.py
+++ b/plasticos_material_profile/tests/test_profile_crud.py
@@ -7,7 +7,7 @@ Test material profile CRUD operations.
 
 import uuid
 
-from psycopg2 import IntegrityError
+from psycopg.errors import IntegrityError
 
 from odoo.addons.plasticos_base.test_common import PlasticosTestCase
 from odoo.tests import tagged

--- a/plasticos_material_profile/tests/test_registry_uniqueness.py
+++ b/plasticos_material_profile/tests/test_registry_uniqueness.py
@@ -14,7 +14,7 @@ Tests all 8 SQL unique constraints:
 
 import uuid
 
-from psycopg2 import IntegrityError
+from psycopg.errors import IntegrityError
 
 from odoo.addons.plasticos_base.test_common import PlasticosTestCase
 from odoo.tests import tagged

--- a/plasticos_material_profile/tests/test_source_type.py
+++ b/plasticos_material_profile/tests/test_source_type.py
@@ -1,10 +1,6 @@
 import uuid
 
-# Odoo 19 may use psycopg3; handle both
-try:
-    from psycopg2 import IntegrityError
-except ImportError:
-    from psycopg.errors import IntegrityError
+from psycopg.errors import IntegrityError
 
 from odoo.addons.plasticos_base.test_common import PlasticosTestCase
 from odoo.exceptions import ValidationError

--- a/plasticos_offer/tests/test_offer.py
+++ b/plasticos_offer/tests/test_offer.py
@@ -1,15 +1,11 @@
 from datetime import timedelta
 
+from psycopg.errors import IntegrityError
+
 from odoo import fields
 from odoo.addons.plasticos_base.test_common import PlasticosTestCase
 from odoo.exceptions import UserError, ValidationError
 from odoo.tests import tagged
-
-# Odoo 19 may use psycopg3; handle both
-try:
-    from psycopg2 import IntegrityError
-except ImportError:
-    from psycopg.errors import IntegrityError
 
 
 @tagged("post_install", "-at_install")

--- a/plasticos_offer/tests/test_offer_constraints.py
+++ b/plasticos_offer/tests/test_offer_constraints.py
@@ -5,15 +5,11 @@ Test offer SQL constraints.
 - quantity > 0
 """
 
+from psycopg.errors import IntegrityError
+
 from odoo.addons.plasticos_base.test_common import PlasticosTestCase
 from odoo.exceptions import ValidationError
 from odoo.tests import tagged
-
-# Odoo 19 may use psycopg3; handle both
-try:
-    from psycopg2 import IntegrityError
-except ImportError:
-    from psycopg.errors import IntegrityError
 
 
 @tagged("post_install", "-at_install")

--- a/plasticos_transaction/tests/test_commission_rule.py
+++ b/plasticos_transaction/tests/test_commission_rule.py
@@ -1,14 +1,10 @@
 import uuid
 
+from psycopg.errors import IntegrityError
+
 from odoo.addons.plasticos_base.test_common import PlasticosTestCase
 from odoo.exceptions import ValidationError
 from odoo.tests import tagged
-
-# Odoo 19 may use psycopg3; handle both
-try:
-    from psycopg2 import IntegrityError
-except ImportError:
-    from psycopg.errors import IntegrityError
 
 
 @tagged("post_install", "-at_install")

--- a/plasticos_transaction/tests/test_transaction_constraints.py
+++ b/plasticos_transaction/tests/test_transaction_constraints.py
@@ -5,7 +5,7 @@ Test transaction SQL and Python constraints.
 - commission_override_pct range (0.0-1.0)
 """
 
-from psycopg2 import IntegrityError
+from psycopg.errors import IntegrityError
 
 from odoo.addons.plasticos_base.test_common import PlasticosTestCase
 from odoo.exceptions import ValidationError

--- a/tests/test_constraints_material_profile.py
+++ b/tests/test_constraints_material_profile.py
@@ -1,14 +1,10 @@
 import uuid
 
+from psycopg.errors import IntegrityError
+
 from odoo.addons.plasticos_base.test_common import PlasticosTestCase
 from odoo.exceptions import ValidationError
 from odoo.tests import tagged
-
-# Odoo 19 may use psycopg3; handle both
-try:
-    from psycopg2 import IntegrityError
-except ImportError:
-    from psycopg.errors import IntegrityError
 
 
 def _unique_code(prefix="TEST"):

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -17,11 +17,7 @@ These tests validate that PlastOS handles errors gracefully:
 
 from unittest.mock import patch
 
-# Odoo 19 may use psycopg3; handle both
-try:
-    from psycopg2 import IntegrityError
-except ImportError:
-    from psycopg.errors import IntegrityError
+from psycopg.errors import IntegrityError
 
 from odoo.addons.plasticos_base.test_common import PlasticosTestCase
 from odoo.exceptions import AccessError, UserError, ValidationError


### PR DESCRIPTION
## Problem

The previous fix (commit `00d36f4`) used a try/except pattern:
```python
try:
    from psycopg2 import IntegrityError
except ImportError:
    from psycopg.errors import IntegrityError
```

This **doesn't work** on Odoo.sh because **psycopg2 is also installed**. The `try` block succeeds, importing psycopg2's `IntegrityError` — but Odoo 19 uses psycopg3 connections. When `assertRaises()` calls `issubclass()` on the psycopg2 `IntegrityError`, it gets a `TypeError` because the class doesn't belong to the psycopg3 exception hierarchy.

Additionally, 13 files had bare `from psycopg2 import IntegrityError` with no fallback at all — those were completely missed.

## Fix

Replaced **all 32 files** with the direct import:
```python
from psycopg.errors import IntegrityError
```

Odoo 19 = psycopg3. No try/except needed.

## Files Changed (32)

Across 10 modules: `plasticos_automation`, `plasticos_buyer_match_engine`, `plasticos_claims`, `plasticos_commission`, `plasticos_documents`, `plasticos_facility_profile`, `plasticos_logistics`, `plasticos_material_profile`, `plasticos_offer`, `plasticos_transaction`, and root `tests/`.

## Verification

- `grep -r 'from psycopg2 import IntegrityError' --include='*.py'` returns **zero results**
- All 32 test files now use `from psycopg.errors import IntegrityError`
- This should resolve all 5 test errors blocking the staging build