### PR TITLE
fix: exception handling + DRY feature gate refactor for buyer matching

### DIFF
--- a/plasticos_base/models/feature_gate_mixin.py
+++ b/plasticos_base/models/feature_gate_mixin.py
@@ -50,6 +50,12 @@ class FeatureGateMixin(models.AbstractModel):
         enabled = (icp.get_param(param_key, "False") or "False").strip().lower()
         return enabled in TRUTHY_PARAM_VALUES
 
+    def _is_feature_stubbed(self, param_key):
+        """Check if a feature flag is set to stubbed/enabled (truthy)."""
+        icp = self.env["ir.config_parameter"].sudo()
+        stubbed = (icp.get_param(param_key, "True") or "True").strip().lower()
+        return stubbed in TRUTHY_PARAM_VALUES
+
     def _check_feature_gate(self, param_key):
         """Raise UserError if the feature flag is not enabled.
 

--- a/plasticos_buyer_match_engine/models/intake_extension.py
+++ b/plasticos_buyer_match_engine/models/intake_extension.py
@@ -2,7 +2,7 @@ import logging
 
 from odoo import _, fields, models
 from odoo.addons.plasticos_base.models.feature_gate_mixin import feature_gated
-from odoo.exceptions import UserError
+from odoo.exceptions import UserError, ValidationError
 
 _logger = logging.getLogger(__name__)
 
@@ -50,6 +50,8 @@ class PlasticosIntake(models.Model):
                     max_results=20,
                     mode=record.match_mode or "strict",
                 )
+            except (UserError, ValidationError):
+                raise
             except Exception as exc:
                 _logger.warning("Buyer matcher unavailable for intake %s: %s", record.id, exc)
                 matches = []

--- a/plasticos_buyer_match_engine/models/intake_graph_hooks.py
+++ b/plasticos_buyer_match_engine/models/intake_graph_hooks.py
@@ -11,6 +11,7 @@ Results are written to plasticos.match.result.
 import logging
 
 from odoo import models
+from odoo.exceptions import UserError, ValidationError
 
 _logger = logging.getLogger(__name__)
 
@@ -44,5 +45,7 @@ class IntakeGraphHooks(models.Model):
                 supplier_partner_id=intake.partner_id.id, intake_id=intake.id, max_results=20
             )
             _logger.info("Auto-match for normalized intake %s: found %d matches", intake.id, len(matches))
+        except (UserError, ValidationError):
+            raise
         except Exception as exc:
             _logger.warning("Buyer match for intake %s skipped: %s", intake.id, exc)

--- a/plasticos_buyer_match_engine/models/matcher.py
+++ b/plasticos_buyer_match_engine/models/matcher.py
@@ -196,8 +196,6 @@ class BuyerMatcher(models.Model):
                         "facility_profile_id": buyer_data["profile"].id,
                     }
                 )
-            except (UserError, ValidationError):
-                raise
             except Exception as e:
                 _logger.error("Error scoring buyer %s: %s", buyer_data["profile"].partner_id.name, str(e))
         return scored_buyers

--- a/plasticos_buyer_match_engine/models/matcher.py
+++ b/plasticos_buyer_match_engine/models/matcher.py
@@ -20,22 +20,23 @@ import logging
 
 from odoo import _, api, models
 from odoo.addons.plasticos_facility_profile.process_codes import check_mfi_compatibility
-from odoo.exceptions import ValidationError
+from odoo.exceptions import UserError, ValidationError
 
 _logger = logging.getLogger(__name__)
 
 
 class BuyerMatcher(models.Model):
     _name = "plasticos.buyer.matcher"
+    _inherit = "plasticos.feature.gate.mixin"
     _description = "Buyer Matching Orchestrator"
 
     @api.model
     def _matching_stub_enabled(self):
         """Return True when buyer matching must run as deterministic empty-result stub."""
-        ICP = self.env["ir.config_parameter"].sudo()
-        enabled = (ICP.get_param("plasticos.matching_engine.enabled", "False") or "False").strip().lower()
-        stubbed = (ICP.get_param("plasticos.matching_engine.stubbed", "True") or "True").strip().lower()
-        return enabled not in {"1", "true", "yes", "on"} or stubbed in {"1", "true", "yes", "on"}
+        return (
+            not self._is_feature_enabled("plasticos.matching_engine.enabled")
+            or self._is_feature_stubbed("plasticos.matching_engine.stubbed")
+        )
 
     @api.model
     def find_matches_for_supplier(self, supplier_partner_id, intake_id=None, max_results=20, mode="strict"):
@@ -152,6 +153,8 @@ class BuyerMatcher(models.Model):
                                 "facility_profile_id": buyer_data["profile"].id,
                             }
                         )
+            except (UserError, ValidationError):
+                raise
             except Exception as e:
                 _logger.error("Error in graph service match_buyers: %s", str(e))
                 scored_buyers = self._fallback_scoring(passed_buyers, supplier_partner_id, material_req, graph_svc)
@@ -193,6 +196,8 @@ class BuyerMatcher(models.Model):
                         "facility_profile_id": buyer_data["profile"].id,
                     }
                 )
+            except (UserError, ValidationError):
+                raise
             except Exception as e:
                 _logger.error("Error scoring buyer %s: %s", buyer_data["profile"].partner_id.name, str(e))
         return scored_buyers


### PR DESCRIPTION
## Summary

- **Exception handling fix (HIGH)**: All 4 buyer matcher invocation try/except blocks now explicitly re-raise `UserError` and `ValidationError` before falling through to the generic `except Exception` handler. This ensures business-rule and validation errors surface in the Odoo UI instead of being silently swallowed by the fallback path (log + empty matches).
- **DRY feature gate refactor (MEDIUM)**: `BuyerMatcher` now inherits `plasticos.feature.gate.mixin` and `_matching_stub_enabled()` delegates to the shared `_is_feature_enabled()` / new `_is_feature_stubbed()` helpers, eliminating duplicated `ir.config_parameter` lookups in `matcher.py`.

### Files changed
| File | Change |
|------|--------|
| `plasticos_base/models/feature_gate_mixin.py` | Add `_is_feature_stubbed()` helper |
| `plasticos_buyer_match_engine/models/matcher.py` | Inherit mixin, DRY `_matching_stub_enabled()`, add `except (UserError, ValidationError): raise` in 2 blocks, add `UserError` import |
| `plasticos_buyer_match_engine/models/intake_extension.py` | Add `except (UserError, ValidationError): raise` before generic handler, add `ValidationError` import |
| `plasticos_buyer_match_engine/models/intake_graph_hooks.py` | Add `except (UserError, ValidationError): raise` before generic handler, add imports |

### Hard constraints met
- No change to business logic
- No behavior change to stub fallback
- Minimal patch footprint (22 insertions, 6 deletions)
- Matching algorithm untouched

## Test plan

- [ ] Existing `test_feature_gate.py` passes (especially `test_matching_action_survives_matcher_failure` — uses `RuntimeError`, still caught by fallback)
- [ ] Existing `test_matcher.py` passes (stub mode, validation errors, gate checks)
- [ ] Manual: trigger a `UserError` (e.g., missing material profile) → verify it surfaces in UI, not swallowed
- [ ] Manual: trigger a `ValidationError` (e.g., invalid supplier ID) → verify it surfaces in UI
- [ ] Manual: trigger a system error (e.g., Neo4j down) → verify fallback path still works (empty matches + log warning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)