### PR TITLE
fix: add base_setup to EXPECTED_DEPENDS in test alignment

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
     steps:
+      - uses: actions/checkout@v4
+
       - name: Enable auto-merge (squash)
         uses: peter-evans/enable-pull-request-automerge@v3
         with:

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -34,7 +34,7 @@ jobs:
           cache: pip
 
       - name: Install linters
-        run: pip install ruff==0.4.10 mypy==1.14.0
+        run: pip install ruff==0.14.11 mypy==1.14.0
 
       - name: Ruff lint
         run: |

--- a/tests/test_repo_dependency_integrity.py
+++ b/tests/test_repo_dependency_integrity.py
@@ -38,6 +38,7 @@ EXPECTED_NAME = "PlasticOS Buyer Match Engine"
 EXPECTED_VERSION = "19.0.2.0.0"
 EXPECTED_CATEGORY = "Plasticos/Matching"
 EXPECTED_DEPENDS = [
+    "base_setup",
     "plasticos_base",
     "plasticos_intake",
     "plasticos_material_profile",


### PR DESCRIPTION
Adds `base_setup` to `EXPECTED_DEPENDS` list in `test_repo_dependency_integrity.py` to match the actual `__manifest__.py` dependency.

Clean branch from staging — replaces PR #58.