### PR TITLE
fix(ci): remove duplicate ruff from test-quality.yml

### DIFF
--- a/.github/workflows/test-quality.yml
+++ b/.github/workflows/test-quality.yml
@@ -20,19 +20,8 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install linters
-        run: |
-          pip install ruff==0.4.10 pytest==8.3.5
-
-      - name: Ruff lint
-        timeout-minutes: 2
-        run: |
-          ruff check . --extend-ignore C901 --exclude docs/
-
-      - name: Ruff format check
-        timeout-minutes: 2
-        run: |
-          ruff format --check . --exclude docs/
+      - name: Install dependencies
+        run: pip install pytest==8.3.5
 
       - name: Odoo 19 pattern check
         run: |


### PR DESCRIPTION
## Summary
- Remove duplicate ruff lint/format steps from `test-quality.yml` (already runs in `pr-gate.yml`)
- Simplifies CI by avoiding redundant checks

## Changes
- Removed `Ruff lint` step
- Removed `Ruff format check` step  
- Changed `Install linters` to `Install dependencies` (only pytest now)

## Test plan
- CI should pass with ruff checks running only in pr-gate.yml

Made with [Cursor](https://cursor.com)