### PR TITLE
feat: Frontier Agent Governance — AGENTS.md, CLAUDE.md, .claude/ skills & hooks

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -1,0 +1,34 @@
+---
+name: plasticos-code-reviewer
+description: PlasticOS Odoo 19 code reviewer — checks invariants, patterns, and architecture compliance
+---
+
+You are a code reviewer specializing in Odoo 19 development for the PlasticOS repository.
+
+## Your Expertise
+- All 8 PlasticOS invariants (Odoo 19 compliance, DAG integrity, namespace, seed doctrine, Neo4j boundary, partner model, security, test safety)
+- 5-layer module architecture
+- Odoo 19 ORM patterns and deprecations
+- XML view best practices
+
+## Review Checklist
+For every change, check:
+
+1. **Odoo 19 Compliance**: No `_sql_constraints`, `@api.one`, `@api.multi`, `@api.depends("id")`, `category_id` on groups, `numbercall` on crons
+2. **Namespace**: Module `plasticos_*`, models `plasticos.*`, external IDs `plasticos_module.*`
+3. **Dependencies**: All imports have matching `depends` in `__manifest__.py`
+4. **Circular Deps**: No A→B→A cycles in module graph
+5. **Seed Data**: XML with `noupdate="1"`, external IDs, no hardcoded DB IDs
+6. **Security**: ACL csv exists for new models, `sudo()` justified
+7. **Partner Model**: Using `customer_rank`/`supplier_rank` not custom booleans
+8. **Neo4j Boundary**: Graph logic in service classes, never blocking Odoo
+9. **Tests**: New code has corresponding test, seed data not mutated
+10. **Layer Violation**: No reverse dependencies (higher → lower only)
+
+## Output Format
+For each finding:
+- **[blocking/warning/note]** — severity
+- **Invariant**: which rule is relevant
+- **Location**: file:line
+- **Issue**: what's wrong
+- **Fix**: specific suggestion

--- a/.claude/agents/module-auditor.md
+++ b/.claude/agents/module-auditor.md
@@ -1,0 +1,39 @@
+---
+name: module-auditor
+description: Audits PlasticOS module structure, dependencies, and Odoo 19 compliance
+---
+
+You are a module structure auditor for the PlasticOS Odoo 19 repository.
+
+## Your Role
+Audit a specific module or set of modules for structural correctness, dependency integrity, and Odoo 19 compliance.
+
+## Audit Sequence
+
+1. **Manifest check**: Parse `__manifest__.py` — verify version format `19.0.x.x.x`, license, category, depends list
+2. **Dependency integrity**: All models referenced in code have matching `depends` entries
+3. **Circular dependency**: Verify no cycles involving this module
+4. **Namespace check**: Model names `plasticos.*`, external IDs `plasticos_module.*`
+5. **Security**: `security/ir.model.access.csv` exists with entries for all models in `models/`
+6. **Odoo 19 patterns**: No deprecated constructs (`_sql_constraints`, `@api.one`, etc.)
+7. **Seed data**: XML files use `noupdate="1"`, external IDs, no hardcoded DB IDs
+8. **Views**: XPath targets stable anchors, views have unique IDs with module prefix
+9. **Hooks**: If `pre_init_hook`/`post_init_hook` exist, verify they handle missing tables gracefully
+10. **Tests**: At least one test file exercises this module's core logic
+
+## Commands
+```bash
+# Module-specific checks
+python3 scripts/check_module_wiring.py
+python3 ci/check_orphan_model_refs.py
+python3 ci/check_odoo19_xml.py
+python3 ci/check_field_integrity.py
+```
+
+## Output
+For each issue:
+- **[error/warning]** — severity
+- **File**: exact path
+- **Issue**: description
+- **Invariant**: which invariant is violated
+- **Fix**: recommended resolution

--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -1,0 +1,46 @@
+---
+paths:
+  - "plasticos_*/__manifest__.py"
+  - "plasticos_*/models/**/*.py"
+  - "config/**"
+---
+# PlasticOS Architecture — 5-Layer Module Map
+
+## Layer Hierarchy (lower → higher, never reverse dependencies)
+
+```
+Layer 5: TRANSACTION
+  plasticos_transaction, plasticos_logistics, plasticos_claims
+
+Layer 4: COMPLIANCE
+  plasticos_documents, plasticos_documents_native
+
+Layer 3: COMMERCIAL
+  plasticos_accounting, plasticos_offer, plasticos_order_lines
+  plasticos_automation, plasticos_partner_import, plasticos_crm_bridge, plasticos_commission
+
+Layer 2: CAPABILITY
+  plasticos_facility_profile, plasticos_intake, plasticos_intake_normalizer
+  plasticos_matching, plasticos_buyer_match_engine, plasticos_geolocalize
+  plasticos_enrichment, plasticos_web_leads, plasticos_inference_engine
+
+Layer 1: MATERIAL
+  plasticos_base, plasticos_security_base
+  plasticos_material_profile, plasticos_product
+```
+
+## Module Install Order (config/odoo_module_order.yaml)
+Default: accounting → base → material_profile → logistics → facility_profile → intake → product → order_lines → transaction → documents → offer → claims → automation → intake_normalizer → partner_import → geolocalize → security_base
+
+## Handler Pattern (engine/handlers.py equivalents)
+Each module's `models/` directory contains:
+- Main model (e.g., `transaction.py`)
+- Bridge models (e.g., `intake_bridge.py`, `offer_bridge.py`)
+- Service classes (e.g., `commission_service.py`, `transaction_import_service.py`)
+- Odoo model inherits (e.g., `sale_inherit.py`, `purchase_inherit.py`)
+
+## Manifest Rules
+- `depends`: list ALL modules whose models you reference
+- `data`: list ALL XML/CSV files for seed data and views
+- `pre_init_hook` / `post_init_hook`: only for migration/cleanup
+- `installable`: False for dev-only and external microservice modules

--- a/.claude/rules/invariants.md
+++ b/.claude/rules/invariants.md
@@ -1,0 +1,70 @@
+---
+paths:
+  - "plasticos_*/**/*.py"
+  - "plasticos_*/**/*.xml"
+---
+# PlasticOS Invariants
+
+**Meta-Rule**: If code violates an invariant, code is wrong — not the invariant.
+
+## 1. Odoo 19 Compliance
+- ❌ `_sql_constraints` → Use `models.Constraint` / `UniqueConstraint`
+- ❌ `@api.depends("id")` → Remove "id" from depends
+- ❌ `@api.one` / `@api.multi` → Removed in Odoo 13
+- ❌ `category_id` on `res.groups` → Removed in Odoo 19
+- ❌ `numbercall` on `ir.cron` → Deprecated
+- Run: `scripts/check_odoo_patterns.sh`
+
+## 2. Dependency Graph Acyclicity
+- Module dependencies must form a DAG (no cycles)
+- Every import requires matching `depends` in `__manifest__.py`
+- Run: `python3 ci/check_circular_deps.py`
+
+## 3. Namespace Consistency
+- Module names: `plasticos_*`
+- Model names: `plasticos.*`
+- External IDs: `plasticos_module.external_id`
+- ❌ `plastos_` / `plast_` / mixed conventions
+
+## 4. Deterministic Seed Doctrine
+- All reference data in XML with `noupdate="1"`
+- All records have external IDs: `plasticos_module.record_name`
+- ❌ CSV runtime bootstrap
+- ❌ Hardcoded database IDs
+
+## 5. Neo4j Integration Boundaries
+- Graph logic in service classes only
+- Graph failures wrapped in safe boundaries
+- ❌ Neo4j imports in Odoo registry load path
+- ❌ Blocking Odoo startup on Neo4j
+
+## 6. Partner Model Constraints
+- Use native: `company_type`, `customer_rank`, `supplier_rank`
+- Facility capabilities via `plasticos.facility.profile`
+- ❌ Custom partner role booleans
+- ❌ Material profiles directly on `res.partner`
+
+## 7. Security
+- Every model: `security/ir.model.access.csv`
+- Record rules for multi-company isolation
+- ❌ `sudo()` without justification
+- ❌ Sensitive fields without ACL
+
+## 8. Test Safety
+- Tests must not mutate seed data
+- ❌ Test data in production seed files
+- Tag tests requiring seed data for CI exclusion
+
+## CI Audit Scripts (ci/)
+| Script | What it checks |
+|--------|---------------|
+| check_circular_deps.py | Circular module dependencies |
+| check_orphan_model_refs.py | Model references without dependency |
+| check_odoo19_xml.py | XML view Odoo 19 compatibility |
+| check_field_integrity.py | Field reference validity |
+| check_state_guard_bypass.py | State machine bypass safety |
+| check_constraint_patterns.py | Deprecated constraint usage |
+| check_orm_integrity.py | ORM pattern correctness |
+| check_automation_field_refs.py | Automation field references |
+| check_xpath_stability.py | XPath expression stability |
+| check_odoo_antipatterns.py | General Odoo antipatterns |

--- a/.claude/rules/learnings.md
+++ b/.claude/rules/learnings.md
@@ -1,0 +1,10 @@
+# Agent Learnings
+
+Agents should append non-obvious patterns and gotchas discovered while working in this repo.
+Review periodically and promote stable learnings to CLAUDE.md or relevant rule files.
+
+## Format
+- **[date] Category: description** — brief explanation
+
+## Learnings
+<!-- Agents: append new entries below this line -->

--- a/.claude/rules/neo4j.md
+++ b/.claude/rules/neo4j.md
@@ -1,0 +1,44 @@
+---
+paths:
+  - "plasticos_buyer_match_engine/**/*.py"
+  - "plasticos_matching/**/*.py"
+  - "plasticos_enrichment/**/*.py"
+---
+# Neo4j Integration Boundary
+
+## Architecture
+- Neo4j is used for graph-based scoring in `plasticos_buyer_match_engine`
+- Odoo handles all transactional data — Neo4j is read-only augmentation
+- Graph logic lives in service classes, NOT in Odoo model methods
+
+## Hard Rules
+- ✅ Graph logic isolated in service classes (e.g., `graph_service.py`)
+- ✅ Graph failures wrapped in safe boundaries (try/except with graceful fallback)
+- ✅ Neo4j connection lazy-initialized, never at import time
+- ❌ Never import Neo4j driver at module top level (blocks Odoo registry)
+- ❌ Never block Odoo startup on Neo4j connection failure
+- ❌ Never write transaction data to Neo4j — Odoo is source of truth
+- ❌ Never reference Neo4j results in Odoo ORM constraints or computed fields
+
+## Pattern
+```python
+# ✅ GOOD — lazy connection, safe boundary
+class GraphScoringService:
+    def __init__(self):
+        self._driver = None
+
+    def _get_driver(self):
+        if self._driver is None:
+            try:
+                from neo4j import GraphDatabase
+                self._driver = GraphDatabase.driver(uri, auth=(user, pwd))
+            except Exception:
+                _logger.warning("Neo4j unavailable — scoring will use Odoo-only fallback")
+                return None
+        return self._driver
+
+    def score_matches(self, intake_id):
+        driver = self._get_driver()
+        if not driver:
+            return []  # Graceful fallback
+```

--- a/.claude/rules/security.md
+++ b/.claude/rules/security.md
@@ -1,0 +1,41 @@
+---
+paths:
+  - "plasticos_*/security/**"
+  - "plasticos_security_base/**"
+---
+# PlasticOS Security Model
+
+## Group Hierarchy (plasticos_security_base)
+
+```
+plasticos_privilege_manager (Full Access)
+  ├── implied → base.group_system, base.group_erp_manager
+  └── CRUD on all models
+
+plasticos_privilege_user (Standard User)
+  ├── implied → base.group_user
+  └── Read all, write own records
+
+plasticos_privilege_readonly (Reports Only)
+  └── Read-only all models
+
+plasticos_group_sales → implied → privilege_user
+plasticos_group_logistics → implied → privilege_user
+plasticos_group_compliance → implied → privilege_user
+plasticos_group_accounting → implied → account.group_account_invoice
+```
+
+## ACL Requirements
+- Every new model MUST have `security/ir.model.access.csv`
+- Format: `id,name,model_id/id,group_id/id,perm_read,perm_write,perm_create,perm_unlink`
+- At minimum: manager=CRUD, user=CRU, readonly=R
+
+## Record Rules
+- Multi-company isolation on all business models
+- Sales rep data scoping (own records only for sales group)
+- Use `['|', ('company_id', '=', False), ('company_id', 'in', company_ids)]` pattern
+
+## Forbidden
+- ❌ `sudo()` without explicit justification in code comment
+- ❌ Sensitive fields without ACL protection
+- ❌ Exposing financial data to non-accounting groups

--- a/.claude/rules/system-state.md
+++ b/.claude/rules/system-state.md
@@ -1,0 +1,21 @@
+# System State
+
+Update this file when significant changes merge.
+
+## Branches
+- `staging` — active development, PRs target here
+- `main` — production, merged from staging
+
+## Module Status
+| Status | Modules |
+|--------|---------|
+| Production | base, security_base, material_profile, product, facility_profile, intake, accounting, offer, order_lines, transaction, logistics, documents, claims, automation, partner_import, geolocalize |
+| Beta | intake_normalizer, web_leads, enrichment, crm_bridge, commission |
+| Dev-only | dev_tools (installable=False) |
+| External | inference_engine (installable=False), matching (installable=False), documents_native (Enterprise only) |
+| New | website, buyer_match_engine |
+
+## Known Issues
+- mypy type check runs as advisory (continue-on-error in CI)
+- ruff excludes inference_engine, buyer_match_engine, matching from lint (pre-existing)
+- Some pre-existing Odoo pattern violations tracked separately from new PRs

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,0 +1,34 @@
+---
+paths:
+  - "tests/**/*.py"
+---
+# Testing Rules
+
+## Test Types
+- **Contract tests** (`tests/contracts/`): 8 files — API signatures, bridge wiring, computed deps, CRM leads, intake, partner, selection, transaction
+- **Integration tests** (`tests/integration/`): 10 files — account-move links, compliance, cron idempotency, graph hooks, intake cascade, match guards, offer state, polymer sync, sale-order autocreate, write/unlink guards
+- **Unit tests** (`tests/test_*.py`): 20+ files — constraints, state machines, golden flows, security ACL, performance, Odoo 19 compat
+
+## Rules
+- Tests must not mutate seed data
+- Use `tests/common.py` and `tests/conftest.py` for shared fixtures
+- ❌ Never commit test data to production seed files
+- Tag tests requiring seed data for CI exclusion
+- New models/fields need at least one test
+- Run `python -m pytest tests/ -v` to execute all
+
+## Odoo Test Patterns
+```python
+# ✅ GOOD — use TransactionCase, proper setup, explicit assertions
+from odoo.tests import TransactionCase
+
+class TestPlasticosOffer(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.partner = cls.env["res.partner"].create({"name": "Test Supplier", "supplier_rank": 1})
+
+    def test_offer_state_transition(self):
+        offer = self.env["plasticos.offer"].create({"supplier_id": self.partner.id})
+        self.assertEqual(offer.state, "draft")
+```

--- a/.claude/rules/xml-views.md
+++ b/.claude/rules/xml-views.md
@@ -1,0 +1,32 @@
+---
+paths:
+  - "plasticos_*/views/**/*.xml"
+  - "plasticos_*/data/**/*.xml"
+---
+# XML View & Data Rules
+
+## View Rules (Odoo 19)
+- Use `<field>` with explicit `widget=` when needed
+- XPath expressions must target stable anchors (not position-dependent)
+- ❌ Never use `position="replace"` on base Odoo views without strong justification
+- Prefer `position="after"` or `position="inside"` for extending views
+- All custom views need unique `id` with `plasticos_module.` prefix
+
+## Seed Data Rules (Deterministic Seed Doctrine)
+- Wrap in `<odoo noupdate="1">` for reference data
+- Every record needs external ID: `id="plasticos_module.record_name"`
+- ❌ Never hardcode database IDs in `ref=""` — always use external IDs
+- ❌ Never bootstrap data via CSV at runtime
+- Partner tags, material taxonomy, payment terms, chart of accounts = XML seed
+
+## Cron (ir.cron) Rules
+- ❌ Never use `numbercall` → deprecated in Odoo 19
+- Always include `interval_number` and `interval_type`
+- Default: `active` eval="False" for new crons (enable via feature flag)
+- Use advisory locks for crons that must not overlap: `SELECT pg_try_advisory_lock()`
+- Run: `python3 tools/cron_invariant_check.py`
+
+## Validation
+- Run: `python3 ci/check_odoo19_xml.py`
+- Run: `python3 ci/check_xpath_stability.py`
+- All XML must pass `xmllint --noout` (checked in CI)

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,36 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'CMD=\"$CLAUDE_TOOL_INPUT\"; for PAT in \"_sql_constraints\" \"@api.one\" \"@api.multi\" \"numbercall\" \"eval()\" \"exec()\"; do if echo \"$CMD\" | grep -q \"$PAT\" 2>/dev/null; then echo \"{\\\"decision\\\": \\\"block\\\", \\\"reason\\\": \\\"Blocked: $PAT is a deprecated/banned Odoo 19 pattern. See AI Agent Files/INVARIANTS.md.\\\"}\" && exit 0; fi; done; echo \"{\\\"decision\\\": \\\"approve\\\"}\"'"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'FILE=\"$CLAUDE_FILE_PATH\"; if [[ \"$FILE\" == *.py ]] && command -v ruff &>/dev/null; then ruff check \"$FILE\" 2>/dev/null || true; fi; if [[ \"$FILE\" == *.xml ]] && command -v xmllint &>/dev/null; then xmllint --noout \"$FILE\" 2>/dev/null || echo \"XML validation warning: $FILE\"; fi'"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'if [ -f scripts/check_module_wiring.py ]; then python3 scripts/check_module_wiring.py 2>/dev/null || echo \"Module wiring issues detected — review before committing\"; fi; if [ -f ci/check_circular_deps.py ]; then python3 ci/check_circular_deps.py 2>/dev/null || echo \"Circular dependency detected\"; fi'"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/audit-check/SKILL.md
+++ b/.claude/skills/audit-check/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: audit-check
+description: Run the full PlasticOS audit and CI check suite
+disable-model-invocation: true
+---
+
+# Audit & CI Check Suite
+
+## Quick Checks (run before every commit)
+```bash
+ruff check .
+ruff format --check .
+python3 scripts/check_module_wiring.py
+python3 ci/check_circular_deps.py
+```
+
+## Full Audit (run before PRs)
+```bash
+# Odoo 19 compliance
+./scripts/check_odoo_patterns.sh
+
+# XML validation
+find . -name "*.xml" -not -path "./.git/*" | xargs xmllint --noout
+python3 ci/check_odoo19_xml.py
+
+# Dependency integrity
+python3 ci/check_circular_deps.py
+python3 ci/check_orphan_model_refs.py
+python3 ci/audit_cross_module_deps.py
+
+# Field and ORM integrity
+python3 ci/check_field_integrity.py
+python3 ci/check_orm_integrity.py
+python3 ci/check_model_inheritance.py
+
+# State machine and automation
+python3 ci/check_state_guard_bypass.py
+python3 ci/check_automation_field_refs.py
+python3 ci/check_disabled_actions.py
+
+# Cron safety
+python3 tools/cron_invariant_check.py
+
+# View stability
+python3 ci/check_xpath_stability.py
+
+# Constraint patterns (Odoo 19)
+python3 ci/check_constraint_patterns.py
+```
+
+## Semgrep (custom Odoo rules)
+```bash
+semgrep --config .semgrep/odoo-patterns.yml
+```
+Catches: hardcoded model strings, commented-out code, bare except

--- a/.claude/skills/new-model-field/SKILL.md
+++ b/.claude/skills/new-model-field/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: new-field
+description: Add a new field or model to an existing PlasticOS module
+---
+
+# New Model / Field
+
+## Adding a Field to Existing Model
+
+1. Open the model file in `plasticos_{module}/models/`
+2. Add field following this pattern:
+   ```python
+   new_field = fields.{Type}(
+       string="Human Label",
+       help="Explain what this field stores and how it's used.",
+       tracking=True,  # for business-relevant fields
+       index=True,     # for fields used in search/filter
+   )
+   ```
+3. If the field is a `Many2one`, add:
+   - Model string constant at top: `TARGET_MODEL = "plasticos.target"`
+   - `domain=` for filtering
+   - `ondelete="restrict"` or `"cascade"` explicitly
+4. If the field is a `Selection`, define choices as module-level constant
+5. If `compute=`, declare `@api.depends()` with all actual dependencies
+6. Update views in `views/` to display the new field
+7. Update `security/ir.model.access.csv` if new model
+8. Write a test in `tests/` verifying the field behavior
+9. Run `pre-commit run --all-files`
+
+## Adding a New Model
+
+1. Create model file in `plasticos_{module}/models/{model_name}.py`
+2. Import in `models/__init__.py`
+3. Follow naming: `_name = "plasticos.{model_name}"`
+4. Add `_description`, inherit `mail.thread` for business models
+5. Create `security/ir.model.access.csv` entry
+6. Create views (form + tree + search minimum)
+7. Add menu item in `views/menu.xml`
+8. Write tests
+
+## Computed Field Rules
+- `@api.depends()` must list ALL actual field dependencies
+- ❌ Never use `@api.depends("id")` — crashes in Odoo 19
+- Use `store=True` for fields used in search/sort/group
+- Run: `python3 ci/check_field_integrity.py`

--- a/.claude/skills/new-odoo-module/SKILL.md
+++ b/.claude/skills/new-odoo-module/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: new-module
+description: Create a new PlasticOS Odoo 19 module with proper structure and conventions
+---
+
+# New Odoo Module
+
+## Steps
+
+1. **Determine the layer** (1–5) this module belongs to per ARCHITECTURE.md
+2. **Create directory**: `plasticos_{name}/`
+3. **Create `__manifest__.py`**:
+   - `name`: "PlasticOS {Name}"
+   - `version`: "19.0.1.0.0"
+   - `license`: "LGPL-3"
+   - `author`: "Igor Beylin"
+   - `category`: "PlasticOS"
+   - `depends`: list all required modules (check layer — never depend on higher layers)
+   - `data`: list all XML/CSV data files
+   - `installable`: True (False for dev-only)
+4. **Create `__init__.py`** with `from . import models`
+5. **Create `models/__init__.py`** importing all model files
+6. **Create model files** in `models/` following patterns:
+   - Model string constants at top: `RES_PARTNER = "res.partner"`
+   - `_name = "plasticos.{model_name}"`
+   - `_description` required
+   - `_inherit = ["mail.thread"]` for business models
+   - Fields with `help=`, `tracking=True`, `index=True` where appropriate
+7. **Create `security/ir.model.access.csv`** with ACL for all groups
+8. **Create `views/` directory** with form/tree/search views
+9. **Create `data/` directory** for seed data XML (noupdate="1", external IDs)
+10. **Update `config/odoo_module_order.yaml`** with install position
+11. **Run checks**:
+    ```bash
+    python3 scripts/check_module_wiring.py
+    python3 ci/check_circular_deps.py
+    pre-commit run --all-files
+    ```
+
+## Checklist
+- [ ] Module name uses `plasticos_` prefix
+- [ ] Model names use `plasticos.` prefix
+- [ ] External IDs use `plasticos_{module}.` prefix
+- [ ] `__manifest__.py` dependencies declared
+- [ ] `security/ir.model.access.csv` exists
+- [ ] No deprecated Odoo patterns
+- [ ] Module wiring check passes
+- [ ] Circular dependency check passes

--- a/.claude/skills/pr-workflow/SKILL.md
+++ b/.claude/skills/pr-workflow/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: pr-workflow
+description: Branch, commit, and open a PR following PlasticOS conventions
+disable-model-invocation: true
+---
+
+# PR Workflow
+
+## Branch Naming
+- `feat/short-description` — new features
+- `fix/short-description` — bug fixes
+- `docs/short-description` — documentation
+- `refactor/short-description` — restructuring
+- `test/short-description` — test additions
+
+## Target Branch
+- PRs target `staging` (not `main`)
+- `main` is production — merged from staging only
+
+## Pre-Commit Checklist
+1. `ruff check .` — lint passes
+2. `ruff format --check .` — format check passes
+3. `python3 scripts/check_module_wiring.py` — dependency graph OK
+4. `python3 ci/check_circular_deps.py` — no cycles
+5. `xmllint --noout` on changed XML files
+6. `pre-commit run --all-files` — all hooks pass
+
+## Commit Message Format
+```
+feat(module): add field to transaction model
+fix(views): resolve xpath targeting in offer form
+docs: update module architecture diagram
+refactor(intake): extract normalization service
+test(integration): add offer state machine test
+```
+
+## CI Pipeline (runs on PR)
+- Python lint + format (ruff)
+- XML + shell validation
+- Odoo 19 pattern checks
+- Module manifest validation
+- Secret detection (gitleaks)

--- a/.claude/skills/xml-view/SKILL.md
+++ b/.claude/skills/xml-view/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: xml-view
+description: Create or modify Odoo XML views following PlasticOS conventions
+---
+
+# XML View Development
+
+## Creating a New View
+
+1. Create file in `plasticos_{module}/views/{model}_views.xml`
+2. Add to `__manifest__.py` `data` list
+3. Include form, tree, and search views:
+
+```xml
+<odoo>
+  <!-- Tree View -->
+  <record id="plasticos_{module}.{model}_tree" model="ir.ui.view">
+    <field name="name">plasticos.{model}.tree</field>
+    <field name="model">plasticos.{model}</field>
+    <field name="arch" type="xml">
+      <list>
+        <field name="name"/>
+        <field name="state" widget="badge"
+               decoration-info="state == 'draft'"
+               decoration-success="state == 'active'"/>
+      </list>
+    </field>
+  </record>
+
+  <!-- Form View -->
+  <record id="plasticos_{module}.{model}_form" model="ir.ui.view">
+    <field name="name">plasticos.{model}.form</field>
+    <field name="model">plasticos.{model}</field>
+    <field name="arch" type="xml">
+      <form>
+        <header>
+          <field name="state" widget="statusbar"/>
+        </header>
+        <sheet>
+          <group>
+            <field name="name"/>
+          </group>
+        </sheet>
+        <chatter/>
+      </form>
+    </field>
+  </record>
+</odoo>
+```
+
+## Extending Existing Views (XPath)
+
+- Target stable anchors (field names, not positions)
+- ✅ `<xpath expr="//field[@name='partner_id']" position="after">`
+- ❌ `<xpath expr="//group[2]/field[3]" position="replace">` (fragile)
+- Prefer `position="after"` or `position="inside"` over `position="replace"`
+- Run: `python3 ci/check_xpath_stability.py`
+
+## Validation
+- `xmllint --noout` on all XML files (checked in CI)
+- `python3 ci/check_odoo19_xml.py` for Odoo 19 compatibility

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,136 @@
+# AGENTS.md — PlasticOS (Odoo 19)
+
+Cross-tool agent instructions for the IB-Odoo_19 repository. Read by Claude Code, Codex, Cursor, Copilot, Jules, Aider, CodeRabbit, and all AGENTS.md-compatible tools.
+
+## Project Overview
+
+- **Name**: PlasticOS — Plastics Recycling Brokerage ERP
+- **Type**: Odoo 19 custom module suite (27 modules, ~53K lines Python, ~159 XML views)
+- **Stage**: Production (staging branch → main)
+- **Stack**: Python 3.12, Odoo 19, PostgreSQL 16, Neo4j (graph scoring), Docker
+
+## Commands
+
+```bash
+# Linting
+ruff check .                              # Python lint
+ruff format --check .                     # Format check
+ruff format .                             # Auto-format
+
+# Pre-commit (runs all hooks including Odoo-specific)
+pre-commit run --all-files
+
+# Odoo-specific checks
+python3 scripts/check_module_wiring.py    # Dependency graph integrity
+python3 ci/check_circular_deps.py         # Circular dependency detection
+python3 ci/check_orphan_model_refs.py     # Orphan model references
+python3 ci/check_odoo19_xml.py            # XML view validation
+python3 tools/cron_invariant_check.py     # Cron safety invariants
+
+# Docker
+docker-compose up -d                      # Start Odoo + PostgreSQL + Redis
+docker-compose exec web odoo -u plasticos_base --stop-after-init  # Update module
+
+# Tests (requires running Odoo instance)
+python -m pytest tests/ -v                # All tests
+python -m pytest tests/contracts/ -v      # Contract tests
+python -m pytest tests/integration/ -v    # Integration tests
+```
+
+## Testing
+
+- Contract tests: `tests/contracts/` — 8 contract test files
+- Integration tests: `tests/integration/` — 10 integration test files
+- Unit tests: `tests/test_*.py` — 20+ standalone test files
+- Every new model/field needs at least one test
+- Tests must not mutate seed data
+- Run `pre-commit run --all-files` before opening a PR
+
+## Project Structure
+
+```
+plasticos_base/              # Layer 1: Core seed data, feature gates, partner tags
+plasticos_security_base/     # Layer 1: RBAC roles, record rules, ACL
+plasticos_material_profile/  # Layer 1: Material master (polymer, form, color, source)
+plasticos_product/           # Layer 1: Scrap plastic product catalog
+plasticos_facility_profile/  # Layer 2: Facility capabilities, equipment, tolerances
+plasticos_intake/            # Layer 2: Material intake with contact intelligence
+plasticos_intake_normalizer/ # Layer 2: L9 packet normalization
+plasticos_matching/          # Layer 2: Match result storage
+plasticos_buyer_match_engine/# Layer 2: 10-gate filtering + Neo4j graph scoring
+plasticos_geolocalize/       # Layer 2: Auto-geocode + nightly backfill
+plasticos_enrichment/        # Layer 2: AI web intelligence extraction
+plasticos_web_leads/         # Layer 2: AI lead triage (Cognito → LLM → HOT/COLD)
+plasticos_inference_engine/  # Layer 2: Deterministic polymer inference (YAML KB)
+plasticos_accounting/        # Layer 3: Chart of accounts, payment terms, incoterms
+plasticos_offer/             # Layer 3: Offer lifecycle (match → negotiation → deal)
+plasticos_order_lines/       # Layer 3: PO/SO lines with material specs
+plasticos_automation/        # Layer 3: Workflow automation, SLA monitoring
+plasticos_partner_import/    # Layer 3: Partner import wizard
+plasticos_crm_bridge/        # Layer 3: CRM integration bridge
+plasticos_commission/        # Layer 3: Commission calculation engine
+plasticos_documents/         # Layer 4: Document validation matrices
+plasticos_documents_native/  # Layer 4: Enterprise Documents bridge
+plasticos_transaction/       # Layer 5: Transaction spine + commission
+plasticos_logistics/         # Layer 5: Load management, BOL, dispatch
+plasticos_claims/            # Layer 5: QC cases, claims, chargebacks
+plasticos_website/           # UI: Website extensions
+plasticos_dev_tools/         # Dev-only: audit scripts, integrity checks
+tests/                       # Cross-module test suite
+ci/                          # 20+ CI audit scripts
+tools/                       # Cron checks, validators
+```
+
+## Code Style
+
+- Python 3.12+, Odoo 19 ORM patterns
+- `ruff format` (120-char line length) before commit
+- Model names: `plasticos.model_name` (always `plasticos.` prefix)
+- External IDs: `plasticos_module.external_id`
+- Module names: `plasticos_*` prefix
+- Model string constants at module top: `RES_PARTNER = "res.partner"`
+- Logging: `_logger = logging.getLogger(__name__)`
+- Fields: Odoo `fields.*` with `help=`, `tracking=True` for business fields
+- No `@api.one` or `@api.multi` (removed in Odoo 13)
+- No `_sql_constraints` (use `models.Constraint` in Odoo 19)
+
+## Git Workflow
+
+- Branch from `staging`, PR to `staging`
+- Merge `staging` → `main` for production
+- Commit messages: conventional commits (`feat:`, `fix:`, `docs:`, `refactor:`, `test:`)
+- PRs require passing CI: ruff + XML validation + Odoo pattern checks + secret scan
+
+## Boundaries
+
+### ✅ Always
+- Use `plasticos_` prefix for all module/model/external ID names
+- Add `security/ir.model.access.csv` for every new model
+- Use `sanitize_label()` patterns — no f-string SQL/Cypher
+- Declare dependencies in `__manifest__.py` before importing
+- Seed data in XML with `noupdate="1"` and external IDs
+- Run `python3 scripts/check_module_wiring.py` before commit
+
+### ⚠️ Ask First
+- Adding new modules (affects dependency graph and install order)
+- Modifying `plasticos_base` (affects all downstream modules)
+- Changing security groups or record rules
+- Adding new `ir.cron` scheduled actions
+- Neo4j integration changes (graph boundary rules apply)
+- Schema changes to `res.partner` (partner model constraints)
+
+### 🚫 Never
+- Use `_sql_constraints` → use `models.Constraint` (Odoo 19)
+- Use `@api.depends("id")` → remove "id" from depends
+- Use `@api.one` / `@api.multi` → removed in Odoo 13
+- Use `category_id` on `res.groups` → removed in Odoo 19
+- Use `numbercall` on `ir.cron` → deprecated
+- Create circular dependencies between modules
+- Import Neo4j in Odoo registry load path
+- Block Odoo startup on Neo4j connection
+- Hardcode database IDs → use external IDs
+- Bootstrap data via CSV at runtime → use XML seed data
+- Use `sudo()` without explicit justification
+- Create custom partner role booleans → use native `customer_rank`/`supplier_rank`
+- Commit test data to production seed files
+- Attach material profiles directly to `res.partner` → use `plasticos.facility.profile`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,124 @@
+# CLAUDE.md — PlasticOS (Odoo 19)
+
+@AGENTS.md
+
+## Design Principles
+
+1. **Deterministic Seed Doctrine** — all reference data versioned in XML with `noupdate="1"`. No CSV runtime bootstrap. No hardcoded database IDs.
+2. **Layer Isolation** — 5 layers (Material → Capability → Commercial → Compliance → Transaction). Higher layers depend on lower, never reverse.
+3. **Graph Augmentation** — Neo4j for scoring/matching, Odoo for transactions. Graph failures never block Odoo.
+4. **Partner Hierarchy** — native Odoo fields (`customer_rank`, `supplier_rank`) + facility capability profiles. No custom partner booleans.
+5. **Intake-First Flow** — supplier intake drives buyer matching. Material profile → intake → match → offer → transaction.
+6. **Odoo 19 Strict** — zero deprecated patterns. `models.Constraint` not `_sql_constraints`. No `@api.one`. No `category_id` on groups.
+
+## Code Style Examples
+
+```python
+# ✅ GOOD — model constant, proper field declaration, tracking, help text
+RES_PARTNER = "res.partner"
+PLASTICOS_TRANSACTION = "plasticos.transaction"
+
+class PlasticosOffer(models.Model):
+    _name = "plasticos.offer"
+    _description = "Plasticos Offer"
+    _inherit = ["mail.thread"]
+
+    supplier_id = fields.Many2one(
+        RES_PARTNER,
+        string="Supplier",
+        domain=[("is_company", "=", True), ("supplier_rank", ">", 0)],
+        tracking=True,
+        index=True,
+        help="Supplier partner for this offer.",
+    )
+    state = fields.Selection(
+        [("draft", "Draft"), ("sent", "Sent"), ("accepted", "Accepted"), ("cancelled", "Cancelled")],
+        default="draft",
+        tracking=True,
+    )
+
+# 🚫 BAD — hardcoded model string, no tracking, no help, deprecated pattern
+class PlasticosOffer(models.Model):
+    _name = "plasticos.offer"
+    _sql_constraints = [("name_uniq", "unique(name)", "Name must be unique!")]  # ❌ Odoo 19: use models.Constraint
+
+    supplier_id = fields.Many2one("res.partner")  # ❌ hardcoded string, no domain/tracking/help
+    is_supplier = fields.Boolean()  # ❌ custom partner boolean — use supplier_rank
+```
+
+```xml
+<!-- ✅ GOOD — seed data with noupdate, external ID, proper ref -->
+<odoo noupdate="1">
+  <record id="plasticos_base.partner_tag_buyer" model="res.partner.category">
+    <field name="name">Buyer</field>
+    <field name="active" eval="True"/>
+  </record>
+</odoo>
+
+<!-- 🚫 BAD — no noupdate, no external ID prefix, hardcoded ID -->
+<odoo>
+  <record id="tag_buyer" model="res.partner.category">
+    <field name="name">Buyer</field>
+  </record>
+</odoo>
+```
+
+```python
+# ✅ GOOD — Odoo 19 constraint pattern
+from odoo.models import Constraint, UniqueConstraint
+
+class PlasticosMaterialProfile(models.Model):
+    _name = "plasticos.material.profile"
+    _constraints = [
+        UniqueConstraint("polymer_code", "form_code", name="unique_polymer_form"),
+    ]
+
+# 🚫 BAD — deprecated _sql_constraints (Odoo 19 removes this)
+class PlasticosMaterialProfile(models.Model):
+    _name = "plasticos.material.profile"
+    _sql_constraints = [("unique_polymer_form", "unique(polymer_code, form_code)", "Must be unique")]
+```
+
+## Boundaries
+
+### ✅ Always
+- Declare `__manifest__.py` dependencies before importing from other modules
+- Add `security/ir.model.access.csv` for every new model
+- Use `plasticos_` namespace for modules, `plasticos.` for models
+- Run `pre-commit run --all-files` before committing
+- Check `AI Agent Files/INVARIANTS.md` for full invariant list
+
+### ⚠️ Ask Before
+- Creating new modules (affects dependency graph + install order)
+- Modifying `plasticos_base` or `plasticos_security_base`
+- Adding/changing `ir.cron` scheduled actions
+- Schema changes to `res.partner`
+- Neo4j integration changes
+
+### 🚫 Never
+- `_sql_constraints` → `models.Constraint`
+- `@api.one` / `@api.multi` → removed
+- `@api.depends("id")` → remove "id"
+- `category_id` on `res.groups` → removed in Odoo 19
+- Circular module dependencies
+- `sudo()` without justification
+- Hardcoded database IDs → use external IDs
+
+## Imports
+
+```python
+@AI Agent Files/AGENT.md
+@AI Agent Files/ARCHITECTURE.md
+@AI Agent Files/INVARIANTS.md
+```
+
+## References
+
+Detailed reference material loads from `.claude/rules/` when editing relevant files:
+- **Invariants & Contracts** → `.claude/rules/invariants.md`
+- **Module Architecture** → `.claude/rules/architecture.md`
+- **Security Model** → `.claude/rules/security.md`
+- **Testing** → `.claude/rules/testing.md`
+- **XML Views** → `.claude/rules/xml-views.md`
+- **Neo4j Boundary** → `.claude/rules/neo4j.md`
+- **System State** → `.claude/rules/system-state.md`


### PR DESCRIPTION
Adds frontier-standard agent governance to the PlasticOS repository, based on the same framework deployed on CEG. 18 files implementing the full agent-native governance stack.

## What's included

### Cross-Tool Portability
- `AGENTS.md` — Linux Foundation standard read by Claude Code, Codex, Cursor, Copilot, Jules, Aider, CodeRabbit (8+ tools). Covers commands, testing, project structure, code style, git workflow, and ✅/⚠️/🚫 boundaries.

### Claude Code Integration
- `CLAUDE.md` — 124-line slim file with @AGENTS.md import, 3 good/bad code example pairs (Python models, XML seed data, Odoo 19 constraints), graduated boundary tiers, and references to .claude/rules/ for on-demand context.

### Path-Scoped Rules (.claude/rules/ — 8 files)
Context loads only when editing relevant files:
- `invariants.md` — all 8 PlasticOS invariants + CI audit script reference (plasticos_*/)
- `architecture.md` — 5-layer module map + install order (__manifest__.py, models/)
- `security.md` — RBAC group hierarchy + ACL requirements (security/)
- `xml-views.md` — view and seed data rules (views/, data/)
- `testing.md` — test types, patterns, Odoo TransactionCase example (tests/)
- `neo4j.md` — graph integration boundary with safe-connection pattern (buyer_match_engine/)
- `system-state.md` — module status matrix + known issues
- `learnings.md` — agent-appendable gotcha file

### Enforcement Hooks (.claude/settings.json)
- PreToolUse: blocks `_sql_constraints`, `@api.one`, `@api.multi`, `numbercall`, `eval()`, `exec()` in real-time
- PostToolUse: runs `ruff check` on Python, `xmllint` on XML after every edit
- Stop: runs `check_module_wiring.py` + `check_circular_deps.py` before session ends

### Skills (5)
- `/new-module` — create a new PlasticOS Odoo 19 module with checklist
- `/new-field` — add fields/models with Odoo 19 patterns
- `/xml-view` — XML view development with templates
- `/pr-workflow` — branch naming, commit format, CI checklist
- `/audit-check` — full audit suite (20+ scripts)

### Agent Personas (2)
- `code-reviewer.md` — reviews against all 8 invariants + Odoo 19 patterns
- `module-auditor.md` — 10-step module structure audit sequence

## Note
This does NOT modify or conflict with the existing `AI Agent Files/` directory — these are complementary. `AI Agent Files/` contains deep reference docs (architecture, invariants, security model). The new files provide the delivery mechanism that agents actually consume at session start.