### PR TITLE
feat(plasticos_facility_profile): partner taxonomy v5.0.0 — company_role, is_facility, Personal Intel

### DIFF
--- a/plasticos_base/data/partner_tags.xml
+++ b/plasticos_base/data/partner_tags.xml
@@ -1,40 +1,87 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
   <data noupdate="0">
+    <!--
+      PARTNER CATEGORY TAGS — PlasticOS Operational Tags
+      ====================================================
+      Schema v5.0.0: Role taxonomy has moved to company_role (Selection).
+      These tags are OPERATIONAL/administrative only.
 
-    <!-- Partner Role Tags (for categorization) -->
-    <record id="category_partner_roles" model="res.partner.category">
-      <field name="name">Partner Roles</field>
+      Deprecated role tags (Buyer, Supplier, Broker, Carrier, Processor)
+      are NO LONGER created here. They will be removed in Sprint 8.
+    -->
+
+    <record id="category_operational" model="res.partner.category">
+      <field name="name">Operational</field>
+    </record>
+    <record id="tag_needs_enrichment" model="res.partner.category">
+      <field name="parent_id" ref="category_operational"/>
+      <field name="name">Needs Enrichment</field>
+    </record>
+    <record id="tag_do_not_contact" model="res.partner.category">
+      <field name="parent_id" ref="category_operational"/>
+      <field name="name">Do Not Contact</field>
+    </record>
+    <record id="tag_key_account" model="res.partner.category">
+      <field name="parent_id" ref="category_operational"/>
+      <field name="name">Key Account</field>
+    </record>
+    <record id="tag_preferred_carrier" model="res.partner.category">
+      <field name="parent_id" ref="category_operational"/>
+      <field name="name">Preferred Carrier</field>
+    </record>
+    <record id="tag_exporter" model="res.partner.category">
+      <field name="parent_id" ref="category_operational"/>
+      <field name="name">Exporter</field>
+    </record>
+    <record id="tag_toll_processor" model="res.partner.category">
+      <field name="parent_id" ref="category_operational"/>
+      <field name="name">Toll Processor</field>
     </record>
 
-    <record id="tag_buyer" model="res.partner.category">
-      <field name="parent_id" ref="category_partner_roles"/>
-      <field name="name">Buyer</field>
+    <!-- Material Focus parent — child tags anchored here for domain filtering -->
+    <record id="category_material_focus" model="res.partner.category">
+      <field name="name">Material Focus</field>
     </record>
-
-    <record id="tag_supplier" model="res.partner.category">
-      <field name="parent_id" ref="category_partner_roles"/>
-      <field name="name">Supplier</field>
+    <record id="tag_mf_pallets" model="res.partner.category">
+      <field name="parent_id" ref="category_material_focus"/>
+      <field name="name">Pallets</field>
     </record>
-
-    <record id="tag_broker" model="res.partner.category">
-      <field name="parent_id" ref="category_partner_roles"/>
-      <field name="name">Broker</field>
+    <record id="tag_mf_hdpe_drums" model="res.partner.category">
+      <field name="parent_id" ref="category_material_focus"/>
+      <field name="name">HDPE Drums</field>
     </record>
-
-    <record id="tag_carrier" model="res.partner.category">
-      <field name="parent_id" ref="category_partner_roles"/>
-      <field name="name">Carrier</field>
+    <record id="tag_mf_ag_film" model="res.partner.category">
+      <field name="parent_id" ref="category_material_focus"/>
+      <field name="name">AG Film</field>
     </record>
-
-    <record id="tag_processor" model="res.partner.category">
-      <field name="parent_id" ref="category_partner_roles"/>
-      <field name="name">Processor</field>
+    <record id="tag_mf_ldpe_film" model="res.partner.category">
+      <field name="parent_id" ref="category_material_focus"/>
+      <field name="name">LDPE Film</field>
     </record>
-
-    <record id="tag_expense" model="res.partner.category">
-      <field name="parent_id" ref="category_partner_roles"/>
-      <field name="name">Expense</field>
+    <record id="tag_mf_baled_pet" model="res.partner.category">
+      <field name="parent_id" ref="category_material_focus"/>
+      <field name="name">Baled PET</field>
+    </record>
+    <record id="tag_mf_baled_hdpe" model="res.partner.category">
+      <field name="parent_id" ref="category_material_focus"/>
+      <field name="name">Baled HDPE</field>
+    </record>
+    <record id="tag_mf_mixed_rigid" model="res.partner.category">
+      <field name="parent_id" ref="category_material_focus"/>
+      <field name="name">Mixed Rigid</field>
+    </record>
+    <record id="tag_mf_pp_supersacks" model="res.partner.category">
+      <field name="parent_id" ref="category_material_focus"/>
+      <field name="name">PP Supersacks</field>
+    </record>
+    <record id="tag_mf_pvc_pipe" model="res.partner.category">
+      <field name="parent_id" ref="category_material_focus"/>
+      <field name="name">PVC Pipe</field>
+    </record>
+    <record id="tag_mf_stretch_wrap" model="res.partner.category">
+      <field name="parent_id" ref="category_material_focus"/>
+      <field name="name">Stretch Wrap / Pallet Film</field>
     </record>
 
   </data>

--- a/plasticos_facility_profile/__manifest__.py
+++ b/plasticos_facility_profile/__manifest__.py
@@ -1,7 +1,7 @@
 {
     "name": "PlasticOS Facility Profile",
-    "version": "19.0.4.3.1",
-    "summary": "Facility capability profiles — equipment, tolerances, BCP fields, and templates",
+    "version": "19.0.5.0.0",
+    "summary": "Facility capability profiles — equipment, tolerances, BCP fields, company_role, and templates",
     "license": "LGPL-3",
     "author": "Igor Beylin",
     "category": "Hidden",
@@ -16,6 +16,7 @@
     "data": [
         "security/ir.model.access.csv",
         "data/equipment_type_data.xml",
+        "data/utm_source_data.xml",
         "data/partner_type_data.xml",
         "data/facility_template_data.xml",
         "views/partner_type_views.xml",

--- a/plasticos_facility_profile/data/partner_type_data.xml
+++ b/plasticos_facility_profile/data/partner_type_data.xml
@@ -1,79 +1,186 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
   <data noupdate="0">
+    <!--
+      PLASTICOS PARTNER TYPE MASTER REGISTRY — Schema v5.0.0
+      =========================================================
+      code field alignment:
+        company_role Selection    → same code
+        Neo4j node property       → company_role
+        CEG entity_type gate      → via ROLE_ENTITY_MAP in graphservice.py
+        gate_mode                 → CEG matching strictness
+        is_facility               → Facility Profile tab visibility
 
-    <!-- Canonical Partner/Facility Types -->
+      ADDING TYPES → see SCHEMA_TAXONOMY.md at repo root
+    -->
+
+    <record id="partner_type_recycler" model="plasticos.partner.type">
+      <field name="name">Recycler</field>
+      <field name="code">recycler</field>
+      <field name="description">General recycler — buys or collects scrap plastic and
+        processes it for resale. Open-market or undifferentiated service model.
+        Use Commercial Recycler for B2B/C&amp;I service-route operators.
+        Supplier side only.</field>
+      <field name="is_facility">True</field>
+      <field name="sequence">10</field>
+      <field name="gate_mode">flexible</field>
+    </record>
+
+    <record id="partner_type_commercial_recycler" model="plasticos.partner.type">
+      <field name="name">Commercial Recycler</field>
+      <field name="code">commercial_recycler</field>
+      <field name="description">B2B recycler servicing commercial and industrial (C&amp;I) generators.
+        Collects post-industrial scrap, trim, purge, and in-plant scrap directly from
+        commercial accounts via service-route or scheduled pickup model.
+        Primary feedstock: post-industrial, pre-consumer material.
+        Supplier side only.</field>
+      <field name="is_facility">True</field>
+      <field name="sequence">15</field>
+      <field name="gate_mode">flexible</field>
+    </record>
 
     <record id="partner_type_processor" model="plasticos.partner.type">
       <field name="name">Processor</field>
       <field name="code">processor</field>
-      <field name="description">Plastics processor - converts raw materials into products.</field>
+      <field name="description">Plastics processor — converts raw or recycled materials into
+        a higher-value form (pellets, flake, regrind) for resale.
+        Can appear on supply side (sells processed material) or demand side
+        (buys scrap to process).</field>
       <field name="is_facility">True</field>
-      <field name="sequence">10</field>
-    </record>
-
-    <record id="partner_type_broker" model="plasticos.partner.type">
-      <field name="name">Broker</field>
-      <field name="code">broker</field>
-      <field name="description">Material broker - facilitates transactions between buyers and sellers.</field>
-      <field name="is_facility">False</field>
       <field name="sequence">20</field>
-    </record>
-
-    <record id="partner_type_manufacturer" model="plasticos.partner.type">
-      <field name="name">Manufacturer</field>
-      <field name="code">manufacturer</field>
-      <field name="description">Original manufacturer of plastic products.</field>
-      <field name="is_facility">True</field>
-      <field name="sequence">30</field>
-    </record>
-
-    <record id="partner_type_mrf" model="plasticos.partner.type">
-      <field name="name">MRF</field>
-      <field name="code">mrf</field>
-      <field name="description">Materials Recovery Facility - sorts and processes recyclables.</field>
-      <field name="is_facility">True</field>
-      <field name="sequence">40</field>
+      <field name="gate_mode">flexible</field>
     </record>
 
     <record id="partner_type_compounder" model="plasticos.partner.type">
       <field name="name">Compounder</field>
       <field name="code">compounder</field>
-      <field name="description">Compounds and blends polymer materials.</field>
+      <field name="description">Compounds and blends polymer materials — adds fillers, colorants,
+        or modifiers to produce custom resin compounds.
+        CEG equivalence: processor.
+        plasticos_process_type_ids is always 'compounding' for this role.
+        Primarily buyer-side.</field>
       <field name="is_facility">True</field>
-      <field name="sequence">50</field>
+      <field name="sequence">25</field>
+      <field name="gate_mode">flexible</field>
     </record>
 
-    <record id="partner_type_recycler" model="plasticos.partner.type">
-      <field name="name">Recycler</field>
-      <field name="code">recycler</field>
-      <field name="description">Recycles plastic materials for reuse.</field>
+    <record id="partner_type_manufacturer" model="plasticos.partner.type">
+      <field name="name">Manufacturer</field>
+      <field name="code">manufacturer</field>
+      <field name="description">Manufacturer or end user of plastic material — buys resin or regrind
+        as input to a manufacturing process.
+        Includes: injection molders, blow molders, extruders, thermoformers, film producers.
+        NOTE: Do NOT set process_type at import — set via enrichment only.
+        Buyer side only.</field>
       <field name="is_facility">True</field>
-      <field name="sequence">60</field>
+      <field name="sequence">30</field>
+      <field name="gate_mode">strict</field>
+    </record>
+
+    <record id="partner_type_mrf" model="plasticos.partner.type">
+      <field name="name">MRF</field>
+      <field name="code">mrf</field>
+      <field name="description">Materials Recovery Facility — sorts and consolidates recyclables
+        from residential or commercial streams.
+        Supplier side only.
+        Never passes process_type to CEG.
+        Never appears as a buyer in the matching engine.</field>
+      <field name="is_facility">True</field>
+      <field name="sequence">40</field>
+      <field name="gate_mode">flexible</field>
+    </record>
+
+    <record id="partner_type_transfer_station" model="plasticos.partner.type">
+      <field name="name">Transfer Station</field>
+      <field name="code">transfer_station</field>
+      <field name="description">Waste transfer station — aggregates and consolidates material
+        for onward transport to processors or recyclers.
+        Supplier side only. No material transformation.
+        Never appears as a buyer in the matching engine.</field>
+      <field name="is_facility">True</field>
+      <field name="sequence">45</field>
+      <field name="gate_mode">optimistic</field>
+    </record>
+
+    <record id="partner_type_broker" model="plasticos.partner.type">
+      <field name="name">Broker</field>
+      <field name="code">broker</field>
+      <field name="description">Material broker — facilitates transactions between buyers and sellers.
+        Does not hold inventory.
+        Excluded from equipment-based matching gates.
+        Can appear on either or both trade sides.</field>
+      <field name="is_facility">False</field>
+      <field name="sequence">50</field>
+      <field name="gate_mode">flexible</field>
     </record>
 
     <record id="partner_type_distributor" model="plasticos.partner.type">
       <field name="name">Distributor</field>
       <field name="code">distributor</field>
-      <field name="description">Distributes materials to end customers.</field>
+      <field name="description">Distributes materials to end customers.
+        Holds inventory; resells without transformation.
+        Can appear on supply or demand side.</field>
       <field name="is_facility">True</field>
-      <field name="sequence">70</field>
+      <field name="sequence">55</field>
+      <field name="gate_mode">flexible</field>
+    </record>
+
+    <record id="partner_type_distribution_center" model="plasticos.partner.type">
+      <field name="name">Distribution Center</field>
+      <field name="code">distribution_center</field>
+      <field name="description">Distribution center (DC) — generates post-industrial plastic waste
+        (film, pallet wrap, strapping, foam) as a byproduct of logistics operations.
+        Always a SUPPLIER of scrap material.
+        auto-sets trade_role=supplier, origin_sector=distribution_logistics at import.
+        Never a buyer of plastic material in the matching engine.</field>
+      <field name="is_facility">True</field>
+      <field name="sequence">57</field>
+      <field name="gate_mode">optimistic</field>
+    </record>
+
+    <record id="partner_type_grower_farm" model="plasticos.partner.type">
+      <field name="name">Grower / Farm</field>
+      <field name="code">grower_farm</field>
+      <field name="description">Agricultural grower, farm, nursery, or flower grower.
+        Generates agricultural plastic waste: mulch film, silage wrap, drip tape,
+        greenhouse film, nursery pots, supersacks, bale net wrap.
+        auto-sets trade_role=supplier, origin_sector=agriculture at import.</field>
+      <field name="is_facility">True</field>
+      <field name="sequence">60</field>
+      <field name="gate_mode">optimistic</field>
     </record>
 
     <record id="partner_type_carrier" model="plasticos.partner.type">
       <field name="name">Carrier</field>
       <field name="code">carrier</field>
-      <field name="description">Transportation and logistics provider.</field>
+      <field name="description">Transportation and logistics provider.
+        Excluded from material matching entirely.
+        Appears only in load/logistics records.</field>
+      <field name="is_facility">False</field>
+      <field name="sequence">70</field>
+      <field name="gate_mode">flexible</field>
+    </record>
+
+    <record id="partner_type_equipment_supplier" model="plasticos.partner.type">
+      <field name="name">Equipment Supplier</field>
+      <field name="code">equipment_supplier</field>
+      <field name="description">Supplier of equipment (balers, grinders, shredders, wash lines, etc.).
+        Not a material trading counterparty.
+        Excluded from material matching entirely.</field>
       <field name="is_facility">False</field>
       <field name="sequence">80</field>
+      <field name="gate_mode">optimistic</field>
     </record>
 
     <record id="partner_type_other" model="plasticos.partner.type">
       <field name="name">Other</field>
       <field name="code">other</field>
-      <field name="description">Other partner type not classified above.</field>
+      <field name="description">Partner type not classified above.
+        Includes: media, consultants, government, testing labs, industry associations.
+        Excluded from material matching.</field>
       <field name="is_facility">True</field>
       <field name="sequence">999</field>
+      <field name="gate_mode">optimistic</field>
     </record>
 
   </data>

--- a/plasticos_facility_profile/data/utm_source_data.xml
+++ b/plasticos_facility_profile/data/utm_source_data.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+  <data noupdate="1">
+    <!-- VanillaSoft UTM source — applied to all VS-imported partners without a source. -->
+    <record id="utm_source_vanillasoft" model="utm.source">
+      <field name="name">VanillaSoft</field>
+    </record>
+  </data>
+</odoo>

--- a/plasticos_facility_profile/migrations/19.0.5.0.0/post-migrate.py
+++ b/plasticos_facility_profile/migrations/19.0.5.0.0/post-migrate.py
@@ -1,0 +1,34 @@
+import logging
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    """Backfill company_role on existing res.partner records.
+
+    Logic mirrors _derive_company_role() in partner_import_service:
+      supplier_rank > 0 AND customer_rank > 0  ->  both
+      supplier_rank > 0                         ->  supplier
+      customer_rank > 0                         ->  buyer
+      is_company = TRUE, both 0                 ->  prospect
+      is_company = FALSE                        ->  NULL (person contact, no role)
+
+    Idempotent: only touches rows where company_role IS NULL.
+    """
+    _logger.info("[5.0.0 migration] Backfilling company_role on res.partner")
+
+    cr.execute("""
+        UPDATE res_partner
+        SET company_role = CASE
+            WHEN supplier_rank > 0 AND customer_rank > 0 THEN 'both'
+            WHEN supplier_rank > 0                        THEN 'supplier'
+            WHEN customer_rank > 0                        THEN 'buyer'
+            WHEN is_company = TRUE                        THEN 'prospect'
+            ELSE NULL
+        END
+        WHERE company_role IS NULL
+    """)
+
+    cr.execute("SELECT COUNT(*) FROM res_partner WHERE company_role IS NOT NULL")
+    total = cr.fetchone()[0]
+    _logger.info("[5.0.0 migration] company_role backfill complete: %d partners populated", total)

--- a/plasticos_facility_profile/models/res_partner.py
+++ b/plasticos_facility_profile/models/res_partner.py
@@ -5,9 +5,7 @@ from odoo.exceptions import ValidationError
 class ResPartner(models.Model):
     _inherit = "res.partner"
 
-    # Override company_type to be stored (Odoo core has it as computed/non-stored)
-    # This allows searching by company_type in domains
-    # NOTE: Do NOT re-specify selection= here - it's inherited from res.partner core
+    # ── Stored company_type override (enables domain search) ──────────
     company_type = fields.Selection(
         store=True,
         compute="_compute_company_type",
@@ -24,28 +22,30 @@ class ResPartner(models.Model):
         for partner in self:
             partner.is_company = partner.company_type == "company"
 
-    facility_profile_ids = fields.One2many("plasticos.facility.profile", "partner_id", string="Facility Capabilities")
-
+    # ── Facility Profile link ─────────────────────────────────────────
+    facility_profile_ids = fields.One2many(
+        "plasticos.facility.profile", "partner_id", string="Facility Capabilities"
+    )
     facility_profile_count = fields.Integer(
         string="Capabilities",
         compute="_compute_facility_profile_count",
     )
 
+    # ═══════════════════════════════════════════════════════════════════
+    # PARTNER TYPE — canonical plasticos.partner.type record
+    # Single source of truth for facility_role.
+    # ═══════════════════════════════════════════════════════════════════
     partner_type_id = fields.Many2one(
         "plasticos.partner.type",
         string="Partner Type",
         help="Canonical partner/facility type from master registry.",
     )
 
-    # ═══════════════════════════════════════════════════════════════════════
-    # IMPORTANT: facility_role vs company_type
-    # ───────────────────────────────────────────────────────────────────────
-    # company_type (Odoo core) = "person" or "company" (legal entity type)
-    # facility_role (below) = BUSINESS ROLE (broker, processor, mrf, etc.)
-    #
-    # This field is synced to Neo4j as "facility_role" and used in Cypher
-    # to exclude brokers from equipment gates (they resell, not process).
-    # ═══════════════════════════════════════════════════════════════════════
+    # ═══════════════════════════════════════════════════════════════════
+    # FACILITY ROLE — derived from partner_type_id.code
+    # Synced to Neo4j for buyer-match graph traversal.
+    # NOT the same as company_type (person/company).
+    # ═══════════════════════════════════════════════════════════════════
     facility_role = fields.Selection(
         selection=[
             ("processor", "Processor"),
@@ -61,9 +61,11 @@ class ResPartner(models.Model):
         compute="_compute_facility_role",
         inverse="_inverse_facility_role",
         store=True,
-        help="Business role of this facility. Computed from partner_type_id. "
-        "NOT the same as company_type (person/company). "
-        "Synced to Neo4j as 'facility_role' for buyer matching.",
+        help=(
+            "Business role of this facility. Computed from partner_type_id. "
+            "NOT the same as company_type (person/company). "
+            "Synced to Neo4j as 'facility_role' for buyer matching."
+        ),
     )
 
     @api.depends("partner_type_id", "partner_type_id.code")
@@ -75,30 +77,114 @@ class ResPartner(models.Model):
         PartnerType = self.env["plasticos.partner.type"]
         for rec in self:
             if rec.facility_role:
-                partner_type = PartnerType.search([("code", "=", rec.facility_role)], limit=1)
-                rec.partner_type_id = partner_type.id if partner_type else False
+                pt = PartnerType.search([("code", "=", rec.facility_role)], limit=1)
+                rec.partner_type_id = pt.id if pt else False
             else:
                 rec.partner_type_id = False
 
+    # ═══════════════════════════════════════════════════════════════════
+    # COMPANY ROLE — trade-facing classification
+    # (Buyer / Supplier / Both / Carrier / Broker / Internal / Prospect)
+    # Used in import service, CRM bridge, and partner form UX.
+    # NEW FIELD — requires -u plasticos_facility_profile after deploy.
+    # ═══════════════════════════════════════════════════════════════════
+    company_role = fields.Selection(
+        selection=[
+            ("buyer", "Buyer"),
+            ("supplier", "Supplier"),
+            ("both", "Buyer & Supplier"),
+            ("carrier", "Carrier"),
+            ("broker", "Broker"),
+            ("internal", "Internal"),
+            ("prospect", "Prospect"),
+        ],
+        string="Company Role",
+        index=True,
+        tracking=True,
+        help=(
+            "Trade-facing role. Drives supplier_rank / customer_rank visibility, "
+            "partner form UX, and CEG node classification. "
+            "Set during import; can be updated manually on partner record."
+        ),
+    )
+
+    @api.onchange("company_role")
+    def _onchange_company_role(self):
+        """Sync supplier_rank / customer_rank when role changes manually."""
+        SUPPLIER_ROLES = {"supplier", "both", "broker"}
+        CUSTOMER_ROLES = {"buyer", "both"}
+        for rec in self:
+            if rec.company_role in SUPPLIER_ROLES:
+                rec.supplier_rank = max(rec.supplier_rank or 0, 1)
+            if rec.company_role in CUSTOMER_ROLES:
+                rec.customer_rank = max(rec.customer_rank or 0, 1)
+
+    # ═══════════════════════════════════════════════════════════════════
+    # IS_FACILITY — computed gate for Capability Profile tab visibility
+    # True:  child company partners (facility locations)
+    #        standalone companies with no company children
+    # False: top-level parent companies with children; person contacts
+    # ═══════════════════════════════════════════════════════════════════
+    is_facility = fields.Boolean(
+        compute="_compute_is_facility",
+        store=True,
+        index=True,
+        help=(
+            "True when this partner is a facility-level entity: "
+            "a child company location, or a standalone company with no "
+            "child company partners. False for top-level parent companies "
+            "that have children, and for person contacts. "
+            "Controls Capability Profile tab visibility on partner form."
+        ),
+    )
+
+    @api.depends("is_company", "parent_id", "child_ids")
+    def _compute_is_facility(self):
+        for rec in self:
+            if not rec.is_company:
+                rec.is_facility = False
+            elif rec.parent_id:
+                rec.is_facility = True
+            else:
+                has_company_children = any(c.is_company for c in rec.child_ids)
+                rec.is_facility = not has_company_children
+
+    # ── Preferred Contact ─────────────────────────────────────────────
     preferred_contact_id = fields.Many2one(
         "res.partner",
         string="Preferred Contact",
-        help="Last-selected contact for this company/facility. "
-        "Auto-populated when a user selects a contact on an intake. "
-        "Used to auto-fill contact on subsequent intakes.",
+        help=(
+            "Last-selected contact for this company/facility. "
+            "Auto-populated when a user selects a contact on an intake. "
+            "Used to auto-fill contact on subsequent intakes."
+        ),
     )
 
-    # ── PHASE 2: Migrated from plasticos.lead.source → utm.source ──
+    # ── Preferred Supplier Profile (dual-profile support) ────────────
+    preferred_supplier_profile_id = fields.Many2one(
+        "plasticos.facility.profile",
+        string="Preferred Supplier Profile",
+        help=(
+            "When a supplier has multiple facility profiles, this is the "
+            "profile used as source of truth for intake matching. "
+            "Set manually by broker or auto-selected on first profile creation."
+        ),
+    )
+
+    # ── Lead Source ───────────────────────────────────────────────────
     lead_source_id = fields.Many2one(
         "utm.source",
         string="Lead Source",
         tracking=True,
         index=True,
         ondelete="restrict",
-        help="How this counterparty was originally acquired. "
-        "Set automatically when partner is created from a web lead or intake.",
+        help=(
+            "How this counterparty was originally acquired. "
+            "Set automatically when partner is created from a web lead or intake."
+        ),
     )
 
+    # ── Entity Status ─────────────────────────────────────────────────
     entity_status = fields.Selection(
         selection=[
             ("active", "Active"),
@@ -108,20 +194,49 @@ class ResPartner(models.Model):
         string="Entity Status",
         default="active",
         tracking=True,
-        help="Operational status of this entity. "
-        "Active = normal operations. "
-        "Inactive = temporarily paused. "
-        "Blocked = suspended from transactions.",
+        help=(
+            "Operational status of this entity. "
+            "Active = normal operations. "
+            "Inactive = temporarily paused. "
+            "Blocked = suspended from transactions."
+        ),
     )
 
+    # ═══════════════════════════════════════════════════════════════════
+    # PERSONAL INTEL
+    # ───────────────────────────────────────────────────────────────────
+    # Freeform rich-text field for person-level contacts (is_company = False).
+    # Deliberately separate from the standard Notes (comment) field, which
+    # is used for business context.  Personal Intel captures the human side:
+    # personality, communication style, motivators, rapport hooks, family
+    # mentions, hobbies, sports teams — anything that makes a broker
+    # remember who they're talking to before every call.
+    #
+    # VISIBILITY: controlled by view (invisible="is_company").
+    # SECURITY NOTE: contains sensitive personal context.
+    #   - Not exported in standard partner exports.
+    #   - Not surfaced in portal or website views.
+    #   - Access follows standard res.partner record rules.
+    # ═══════════════════════════════════════════════════════════════════
+    personal_intel = fields.Html(
+        string="Personal Intel",
+        sanitize=True,
+        sanitize_overridable=False,
+        help=(
+            "Private broker notes on this contact as a person — "
+            "personality, communication style, motivators, family context, "
+            "hobbies, rapport hooks. Separate from business Notes. "
+            "Visible on person contacts only (not companies or facilities)."
+        ),
+    )
+
+    # ─────────────────────────────────────────────────────────────────
     @api.depends("facility_profile_ids")
     def _compute_facility_profile_count(self):
-        """Count facility profiles linked to this partner."""
         for rec in self:
             rec.facility_profile_count = len(rec.facility_profile_ids)
 
     def action_view_facility_profiles(self):
-        """Navigate to facility profiles for this partner."""
         self.ensure_one()
         return {
             "type": "ir.actions.act_window",
@@ -136,5 +251,7 @@ class ResPartner(models.Model):
         if "parent_id" in vals and not vals.get("parent_id"):
             for rec in self:
                 if rec.facility_profile_ids:
-                    raise ValidationError("Cannot convert facility to parent while capability profile exists.")
+                    raise ValidationError(
+                        "Cannot convert facility to parent while capability profile exists."
+                    )
         return super().write(vals)

--- a/plasticos_facility_profile/security/ir.model.access.csv
+++ b/plasticos_facility_profile/security/ir.model.access.csv
@@ -8,3 +8,5 @@ access_plasticos_equipment_type_all,plasticos.equipment.type.all,model_plasticos
 access_plasticos_partner_type_all,plasticos.partner.type.all,model_plasticos_partner_type,base.group_user,1,1,1,1
 access_plasticos_facility_template_user,plasticos.facility.template.user,model_plasticos_facility_template,base.group_user,1,0,0,0
 access_plasticos_facility_template_admin,plasticos.facility.template.admin,model_plasticos_facility_template,base.group_system,1,1,1,1
+access_plasticos_process_type_user,plasticos.process.type.user,model_plasticos_process_type,base.group_user,1,0,0,0
+access_plasticos_process_type_admin,plasticos.process.type.admin,model_plasticos_process_type,base.group_system,1,1,1,1

--- a/plasticos_facility_profile/views/partner_ux.xml
+++ b/plasticos_facility_profile/views/partner_ux.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
 
-    <!-- ═══════════════════════════════════════════════════════════
-         PARTNER FORM UX — PlasticOS Stat Buttons, Entity Banner,
-         Fix Facility Capabilities Tab Visibility
-         Inherits the EXISTING partner extension from
-         plasticos_facility_profile.view_partner_form_profile_tab
-         ═══════════════════════════════════════════════════════════ -->
+    <!-- ═══════════════════════════════════════════════════════════════
+         PARTNER FORM UX — Schema v5.0.0
+         Adds: entity health banners, stat buttons, company_role badge,
+               5-axis classification block, preferred_supplier_profile,
+               Personal Intel tab, facility tab visibility gate.
+         Inherits: plasticos_facility_profile.view_partner_form_profile_tab
+         ═══════════════════════════════════════════════════════════════ -->
 
     <record id="partner_form_plasticos_ux" model="ir.ui.view">
         <field name="name">res.partner.form.plasticos.ux</field>
@@ -15,10 +16,8 @@
         <field name="priority">25</field>
         <field name="arch" type="xml">
 
-            <!-- ═══ Entity Health Banners + PlasticOS Stat Buttons (single xpath) ═══ -->
+            <!-- ── Entity Health Banners ─────────────────────────────────── -->
             <xpath expr="//div[@name='button_box']" position="before">
-
-                <!-- BLOCKED entity alert -->
                 <div class="alert alert-danger border-danger border-3 d-flex align-items-center"
                      role="alert"
                      invisible="entity_status != 'blocked'">
@@ -26,8 +25,6 @@
                     <strong class="fs-5">⛔ BLOCKED</strong>
                     <span class="ms-2">— This entity is suspended from all PlasticOS transactions.</span>
                 </div>
-
-                <!-- INACTIVE entity warning -->
                 <div class="alert alert-warning d-flex align-items-center"
                      role="alert"
                      invisible="entity_status != 'inactive'">
@@ -35,13 +32,10 @@
                     <strong>INACTIVE</strong>
                     <span class="ms-2">— Operations paused. No new intakes or loads will be routed here.</span>
                 </div>
-
             </xpath>
 
-            <!-- Stat buttons inside button_box (separate xpath, different position) -->
+            <!-- ── Stat Buttons ──────────────────────────────────────────── -->
             <xpath expr="//div[@name='button_box']" position="inside">
-
-                <!-- Facility Profiles count -->
                 <button name="action_view_facility_profiles"
                         type="object"
                         class="oe_stat_button"
@@ -51,20 +45,153 @@
                            string="Capabilities"
                            widget="statinfo"/>
                 </button>
-
-                <!-- NOTE: Material Profiles stat button is in plasticos_material_profile -->
-
             </xpath>
 
-            <!-- ═══ Fix Facility Profile tab visibility ═══
-                 Uses is_facility_location computed field:
-                 True for child partners and standalone companies (no children).
-                 False for parent companies with children and person contacts.
-            -->
+            <!-- ── Company Role badge — before entity_status ─────────────── -->
+            <xpath expr="//field[@name='entity_status']" position="before">
+                <field name="company_role"
+                       widget="badge"
+                       decoration-success="company_role in ('buyer', 'both')"
+                       decoration-info="company_role == 'supplier'"
+                       decoration-warning="company_role == 'prospect'"
+                       decoration-muted="company_role in ('internal', 'broker', 'carrier')"
+                       optional="show"/>
+            </xpath>
+
+            <!-- ── Preferred Supplier Profile — after preferred_contact ──── -->
+            <xpath expr="//field[@name='preferred_contact_id']" position="after">
+                <field name="preferred_supplier_profile_id"
+                       invisible="company_role not in ('supplier', 'both')"
+                       optional="show"/>
+            </xpath>
+
+            <!-- ── Facility Profile tab: visibility gate ─────────────────── -->
             <xpath expr="//page[@name='facility_profile']" position="attributes">
                 <attribute name="invisible">not is_facility</attribute>
             </xpath>
 
+            <!-- ── 5-Axis Classification Block (inside facility_profile tab) -->
+            <xpath expr="//page[@name='facility_profile']//group[1]" position="before">
+
+                <group string="PlasticOS Classification" col="2">
+
+                    <group string="Role">
+                        <field name="partner_type_id"
+                               options="{'no_create': True}"
+                               widget="many2one_avatar"/>
+                        <field name="company_role"
+                               readonly="1"
+                               help="Computed from Partner Type. Set Partner Type to change."/>
+                    </group>
+
+                    <group string="Trade &amp; Status">
+                        <field name="plasticos_trade_role"/>
+                        <field name="entity_status"/>
+                        <field name="lead_source_id"/>
+                    </group>
+
+                </group>
+
+                <group string="Process Types"
+                       invisible="company_role not in ['recycler','commercial_recycler','processor','compounder','manufacturer']">
+                    <field name="plasticos_process_type_ids"
+                           widget="many2many_tags"
+                           options="{'no_create': True}"
+                           help="Set via enrichment or manually. Do NOT set at import."/>
+                    <field name="plasticos_primary_process_type"
+                           readonly="1"
+                           string="Primary (CEG)"
+                           help="Single code sent to CEG InferenceRequest.process_type."/>
+                </group>
+
+                <group string="Origin &amp; Material">
+                    <field name="plasticos_origin_sector"/>
+                    <field name="plasticos_material_focus_ids"
+                           widget="many2many_tags"
+                           string="Material Focus Tags"/>
+                </group>
+
+            </xpath>
+
+            <!-- ── Personal Intel Tab ────────────────────────────────────────
+                 Visible only for person contacts (is_company = False).
+                 Positioned after facility_profile — it's the deeper, human layer.
+                 ─────────────────────────────────────────────────────────────── -->
+            <xpath expr="//page[@name='facility_profile']" position="after">
+                <page name="personal_intel"
+                      string="🧠 Personal Intel"
+                      invisible="is_company">
+
+                    <div class="alert alert-warning d-flex align-items-start gap-2 mb-3"
+                         role="note">
+                        <i class="fa fa-lightbulb-o fa-lg mt-1"/>
+                        <span>
+                            <strong>Human-layer notes — for brokers only.</strong>
+                            Record personality, communication style, rapport hooks,
+                            family context, hobbies, motivators.
+                            Separate from business <em>Notes</em>.
+                            <strong>Internal only — never shared externally.</strong>
+                        </span>
+                    </div>
+
+                    <field name="personal_intel"
+                           nolabel="1"
+                           placeholder="e.g. 'Prefers texts over email. Huge college football fan — always leads with that. Mentions his daughter a lot. Gets defensive if you push on price before rapport is built. Best time to call: Tuesday/Thursday mornings.'"/>
+
+                </page>
+            </xpath>
+
+        </field>
+    </record>
+
+
+    <!-- ═══════════════════════════════════════════════════════════════
+         PARTNER LIST VIEW — company_role + entity_status columns
+         ═══════════════════════════════════════════════════════════════ -->
+    <record id="partner_list_plasticos_ux" model="ir.ui.view">
+        <field name="name">res.partner.list.plasticos.ux</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.view_partner_tree"/>
+        <field name="priority">20</field>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='country_id']" position="before">
+                <field name="company_role"
+                       widget="badge"
+                       decoration-success="company_role in ('buyer', 'both')"
+                       decoration-info="company_role == 'supplier'"
+                       decoration-warning="company_role == 'prospect'"
+                       optional="show"/>
+                <field name="entity_status"
+                       widget="badge"
+                       decoration-danger="entity_status == 'blocked'"
+                       decoration-warning="entity_status == 'inactive'"
+                       decoration-success="entity_status == 'active'"
+                       optional="show"/>
+            </xpath>
+        </field>
+    </record>
+
+
+    <!-- ═══════════════════════════════════════════════════════════════
+         PARTNER SEARCH VIEW — role + status quick filters
+         ═══════════════════════════════════════════════════════════════ -->
+    <record id="partner_search_plasticos_ux" model="ir.ui.view">
+        <field name="name">res.partner.search.plasticos.ux</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.view_res_partner_filter"/>
+        <field name="priority">20</field>
+        <field name="arch" type="xml">
+            <xpath expr="//filter[@name='supplier']" position="after">
+                <filter string="Buyers" name="role_buyer"
+                        domain="['|', ('company_role', '=', 'buyer'), ('company_role', '=', 'both')]"/>
+                <filter string="Suppliers" name="role_supplier"
+                        domain="['|', ('company_role', '=', 'supplier'), ('company_role', '=', 'both')]"/>
+                <filter string="Prospects" name="role_prospect"
+                        domain="[('company_role', '=', 'prospect')]"/>
+                <filter string="Blocked" name="status_blocked"
+                        domain="[('entity_status', '=', 'blocked')]"/>
+                <separator/>
+            </xpath>
         </field>
     </record>
 

--- a/plasticos_partner_import/__manifest__.py
+++ b/plasticos_partner_import/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Plasticos Partner Import",
-    "version": "19.0.2.2.0",
+    "version": "19.0.2.3.0",
     "summary": "Deterministic partner + CRM lead import with wizard UI (Odoo 19)",
     "author": "Igor Beylin",
     "license": "LGPL-3",

--- a/plasticos_partner_import/models/partner_import_service.py
+++ b/plasticos_partner_import/models/partner_import_service.py
@@ -1,3 +1,18 @@
+"""PlasticOS Partner Import Service — schema v5.0.0.
+
+Changes from v4.x:
+  - Full VS_COMPANY_TYPE_MAP: VanillaSoft company_type strings -> company_role codes
+  - _resolve_company_role(): maps CSV role + company_type to company_role
+  - _resolve_trade_role(): auto-sets trade_role from company_role + CSV role column
+  - _resolve_origin_sector(): auto-sets origin_sector for known roles
+  - _apply_vanillasoft_lead_source(): sets lead_source_id to VanillaSoft utm.source
+  - _import_corporate_row(): writes company_role (not facility_role)
+  - _import_facility_row(): writes company_role (not facility_role)
+  - PROCESS TYPE NOTE: we do NOT auto-set plasticos_process_type_ids at import.
+    process types are set via enrichment or manual entry only.
+  - All field writes use company_role key; facility_role shim handles backward compat.
+"""
+
 import csv
 import logging
 import re
@@ -7,36 +22,107 @@ from odoo.exceptions import ValidationError
 
 _logger = logging.getLogger(__name__)
 
-BATCH_SIZE = 100  # Commit every N records
+BATCH_SIZE = 100
 
-# Contact types in Odoo
-CONTACT_TYPE_AR = "invoice"  # AR contact - we pay them
-CONTACT_TYPE_AP = "contact"  # AP contact - they pay us
-CONTACT_TYPE_DELIVERY = "delivery"  # Shipping contact
+CONTACT_TYPE_AR = "invoice"
+CONTACT_TYPE_AP = "contact"
+CONTACT_TYPE_DELIVERY = "delivery"
 
-# Facility types that are invoice/remit addresses
 INVOICE_TYPES = {"Remit", "Inv/Remit", "Invoice", "Primary"}
+
+# ---------------------------------------------------------------------------
+# VS_COMPANY_TYPE_MAP
+# ---------------------------------------------------------------------------
+VS_COMPANY_TYPE_MAP = {
+    "recycler": "recycler",
+    "plastic recycler": "recycler",
+    "plastics recycler": "recycler",
+    "scrap recycler": "recycler",
+    "recycling facility": "recycler",
+    "recycling center": "recycler",
+    "recycling company": "recycler",
+    "commercial recycler": "commercial_recycler",
+    "c&i recycler": "commercial_recycler",
+    "industrial recycler": "commercial_recycler",
+    "route recycler": "commercial_recycler",
+    "processor": "processor",
+    "plastics processor": "processor",
+    "plastic processor": "processor",
+    "regrinder": "processor",
+    "pelletizer": "processor",
+    "compounder": "compounder",
+    "compounding": "compounder",
+    "plastic compounder": "compounder",
+    "manufacturer": "manufacturer",
+    "plastics manufacturer": "manufacturer",
+    "plastic manufacturer": "manufacturer",
+    "molder": "manufacturer",
+    "injection molder": "manufacturer",
+    "blow molder": "manufacturer",
+    "extruder": "manufacturer",
+    "thermoformer": "manufacturer",
+    "film producer": "manufacturer",
+    "end user": "manufacturer",
+    "mrf": "mrf",
+    "materials recovery facility": "mrf",
+    "material recovery facility": "mrf",
+    "transfer station": "transfer_station",
+    "waste transfer": "transfer_station",
+    "broker": "broker",
+    "plastics broker": "broker",
+    "material broker": "broker",
+    "exporter": "broker",
+    "plastics exporter": "broker",
+    "distributor": "distributor",
+    "plastics distributor": "distributor",
+    "distribution center": "distribution_center",
+    "dc": "distribution_center",
+    "warehouse": "distribution_center",
+    "fulfillment center": "distribution_center",
+    "fulfillment": "distribution_center",
+    "grower": "grower_farm",
+    "farm": "grower_farm",
+    "farmer": "grower_farm",
+    "nursery": "grower_farm",
+    "greenhouse": "grower_farm",
+    "flower grower": "grower_farm",
+    "agricultural": "grower_farm",
+    "carrier": "carrier",
+    "trucking": "carrier",
+    "transporter": "carrier",
+    "logistics": "carrier",
+    "freight": "carrier",
+    "equipment supplier": "equipment_supplier",
+    "equipment manufacturer": "equipment_supplier",
+    "baler manufacturer": "equipment_supplier",
+    "other": "other",
+    "unknown": "other",
+}
+
+_SUPPLIER_ONLY_ROLES = frozenset({
+    "recycler", "commercial_recycler", "mrf", "transfer_station",
+    "distribution_center", "grower_farm",
+})
+_BUYER_ONLY_ROLES = frozenset({"manufacturer", "compounder"})
+_ROLE_ORIGIN_SECTOR_DEFAULTS = {
+    "grower_farm": "agriculture",
+    "distribution_center": "distribution_logistics",
+}
 
 
 class PlasticosPartnerImportService(models.AbstractModel):
     _name = "plasticos.partner.import.service"
     _description = "Deterministic Partner Import Service"
 
-    # -------------------------------------------------------------------------
+    # =========================================================================
     # Core upsert
-    # -------------------------------------------------------------------------
+    # =========================================================================
     def _upsert(self, model_name, external_id, values):
-        """Idempotent upsert with external ID tracking.
-
-        Uses skip_automations context to prevent email triggers during import.
-        """
-        # Use context to skip automations during import
         env = self.env
         if not env.context.get("skip_automations"):
             env = env(context=dict(env.context, skip_automations=True, import_mode=True))
 
         record = env.ref(external_id, raise_if_not_found=False)
-
         if record:
             record.write(values)
             _logger.debug("Updated %s via %s", model_name, external_id)
@@ -44,35 +130,83 @@ class PlasticosPartnerImportService(models.AbstractModel):
 
         model = env[model_name]
         rec = model.create(values)
-
-        self.env["ir.model.data"].create(
-            {
-                "name": external_id.split(".")[-1],
-                "module": external_id.split(".")[0],
-                "model": model_name,
-                "res_id": rec.id,
-                "noupdate": True,
-            }
-        )
-
+        self.env["ir.model.data"].create({
+            "name": external_id.split(".")[-1],
+            "module": external_id.split(".")[0],
+            "model": model_name,
+            "res_id": rec.id,
+            "noupdate": True,
+        })
         _logger.debug("Created %s via %s (id=%d)", model_name, external_id, rec.id)
         return rec
 
-    # -------------------------------------------------------------------------
+    # =========================================================================
+    # Schema v5.0.0 role resolution
+    # =========================================================================
+    def _resolve_company_role(self, vs_company_type_str, csv_role_str=None):
+        if vs_company_type_str:
+            normalized = vs_company_type_str.strip().lower()
+            if normalized in VS_COMPANY_TYPE_MAP:
+                return VS_COMPANY_TYPE_MAP[normalized]
+            for key, role in VS_COMPANY_TYPE_MAP.items():
+                if key in normalized or normalized in key:
+                    return role
+        if csv_role_str:
+            role_lower = csv_role_str.lower()
+            if "broker" in role_lower:
+                return "broker"
+            if "carrier" in role_lower or "trucker" in role_lower:
+                return "carrier"
+            if "processor" in role_lower:
+                return "processor"
+            if "manufacturer" in role_lower or "molder" in role_lower:
+                return "manufacturer"
+        return "other"
+
+    def _resolve_trade_role(self, company_role, csv_role_str=None):
+        if company_role in _SUPPLIER_ONLY_ROLES:
+            return "supplier"
+        if company_role in _BUYER_ONLY_ROLES:
+            return "buyer"
+        if company_role in ("broker", "distributor"):
+            return "both"
+        if company_role in ("carrier", "equipment_supplier"):
+            return "other"
+        if csv_role_str:
+            role_lower = csv_role_str.lower()
+            has_supplier = "supplier" in role_lower
+            has_customer = "customer" in role_lower
+            if has_supplier and has_customer:
+                return "both"
+            if has_supplier:
+                return "supplier"
+            if has_customer:
+                return "buyer"
+        return "other"
+
+    def _resolve_origin_sector(self, company_role):
+        return _ROLE_ORIGIN_SECTOR_DEFAULTS.get(company_role, False)
+
+    def _apply_vanillasoft_lead_source(self, partner):
+        if partner.lead_source_id:
+            return
+        vs_source = self.env.ref(
+            "plasticos_facility_profile.utm_source_vanillasoft",
+            raise_if_not_found=False
+        )
+        if vs_source:
+            partner.lead_source_id = vs_source.id
+
+    # =========================================================================
     # Lookup helpers
-    # -------------------------------------------------------------------------
+    # =========================================================================
     def _lookup_user(self, name):
-        """Lookup res.users by name. Returns ID or False."""
         if not name or name in ("FALSE", ""):
             return False
         user = self.env["res.users"].search([("name", "ilike", name.strip())], limit=1)
-        if user:
-            return user.id
-        _logger.warning("User not found: %s", name)
-        return False
+        return user.id if user else False
 
     def _lookup_state(self, state_code, country_id=None):
-        """Lookup res.country.state by code."""
         if not state_code:
             return False
         domain = [("code", "=", state_code.strip().upper())]
@@ -82,178 +216,93 @@ class PlasticosPartnerImportService(models.AbstractModel):
         return state.id if state else False
 
     def _lookup_country(self, country_name):
-        """Lookup res.country by name."""
         if not country_name:
             return False
         country = self.env["res.country"].search(
-            ["|", ("name", "ilike", country_name.strip()), ("code", "=", country_name.strip().upper()[:2])], limit=1
+            ["|",
+             ("name", "ilike", country_name.strip()),
+             ("code", "=", country_name.strip().upper()[:2])],
+            limit=1,
         )
         return country.id if country else False
 
-    def _parse_role(self, role_str):
-        """Parse role string into supplier/customer flags."""
-        if not role_str:
-            return False, False
-        role_lower = role_str.lower()
-        is_supplier = "supplier" in role_lower
-        is_customer = "customer" in role_lower
-        return is_supplier, is_customer
-
     def _lookup_category_tags(self, role_str):
-        """
-        Map role string to partner category tag IDs.
-
-        CSV roles: Supplier, Customer, Expense (comma-separated)
-        Maps to res.partner.category tags defined in plasticos_base/data/partner_tags.xml
-        """
         if not role_str:
             return []
-
         tag_ids = []
         role_lower = role_str.lower()
-
-        # Map CSV roles to XML IDs (Expense excluded - not imported)
-        role_tag_mapping = {
-            "supplier": "plasticos_base.tag_supplier",
-            "customer": "plasticos_base.tag_buyer",  # Customer = Buyer
-            "broker": "plasticos_base.tag_broker",
-            "carrier": "plasticos_base.tag_carrier",
-            "processor": "plasticos_base.tag_processor",
+        operational_tag_mapping = {
+            "exporter": "plasticos_base.tag_exporter",
+            "toll": "plasticos_base.tag_toll_processor",
         }
-
-        for role_key, xml_id in role_tag_mapping.items():
-            if role_key in role_lower:
+        for key, xml_id in operational_tag_mapping.items():
+            if key in role_lower:
                 tag = self.env.ref(xml_id, raise_if_not_found=False)
                 if tag:
                     tag_ids.append(tag.id)
-                else:
-                    _logger.warning("Tag not found: %s", xml_id)
-
         return tag_ids
 
     def _make_external_id(self, prefix, name):
-        """Generate external ID from name."""
-        # Sanitize: lowercase, replace non-alphanum with underscore
         safe = re.sub(r"[^a-z0-9]+", "_", name.lower()).strip("_")
         return f"plasticos_partner_import.{prefix}_{safe}"
 
     def _normalize_email(self, email_str, contact_name=None):
-        """Extract best matching email from potentially messy string.
-
-        If contact_name is provided and there are multiple emails, tries to find
-        an email that matches the contact's name (e.g., "Josh Dingus" matches
-        "josh.dingus@company.com"). Falls back to first valid email if no match.
-        """
         if not email_str:
             return False
-
-        # Split on common separators
         emails = re.split(r"[;,\s]+", email_str.strip())
         valid_emails = [e.strip() for e in emails if "@" in e.strip() and "." in e.strip()]
-
         if not valid_emails:
             return False
-
-        # If only one email or no contact name, return first
         if len(valid_emails) == 1 or not contact_name:
             return valid_emails[0]
-
-        # Try to match contact name to email
-        # Extract name parts (first, last, or combined)
-        name_lower = contact_name.lower().strip()
-        name_parts = re.split(r"[\s&,]+", name_lower)
-        name_parts = [p for p in name_parts if len(p) > 2]  # Skip short words like "and", "&"
-
+        name_parts = [p for p in re.split(r"[\s&,]+", contact_name.lower()) if len(p) > 2]
         for email in valid_emails:
             email_local = email.split("@")[0].lower()
-            # Check if any name part appears in email local part
             for part in name_parts:
                 if part in email_local:
-                    _logger.debug("Matched email '%s' to contact '%s' via '%s'", email, contact_name, part)
                     return email
-
-        # No match found, return first email
         return valid_emails[0]
 
     def _normalize_phone(self, phone_str):
-        """Clean phone number."""
-        if not phone_str:
-            return False
-        return phone_str.strip()
+        return phone_str.strip() if phone_str else False
 
     def _get_default_payment_term(self):
-        """Get default payment term (Net 30) for partners."""
-        # Try XML ID first (from plasticos_accounting)
         term = self.env.ref("plasticos_accounting.payment_term_net_30", raise_if_not_found=False)
         if term:
             return term.id
-        # Fallback: search by name
         term = self.env["account.payment.term"].search([("name", "=", "Net 30")], limit=1)
         return term.id if term else False
 
-    # -------------------------------------------------------------------------
+    # =========================================================================
     # Main import entry points
-    # -------------------------------------------------------------------------
+    # =========================================================================
     def run_full_import(self, corporate=None, facilities=None, contacts=None):
-        """
-        Execute full partner import pipeline.
-
-        Args:
-            corporate: List of corporate dicts (from CSV 1)
-            facilities: List of facility dicts (from CSV 2)
-            contacts: List of contact dicts (optional, for manual contact list)
-
-        Returns:
-            dict with counts
-        """
         _logger.info("Starting partner import pipeline")
-
         self.env["plasticos.partner.import.validation"].validate_reference_integrity()
-
         counts = {
             "corporates": self._load_corporates(corporate or []),
             "facilities": self._load_facilities(facilities or []),
             "contacts": self._load_contacts(contacts or []),
         }
-
         self.env["plasticos.partner.import.validation"].validate_partner_graph()
-
         _logger.info("Partner import complete: %s", counts)
         return counts
 
     def run_csv_import(self, corporate_csv_path, facility_csv_path):
-        """
-        Import from CSV files directly.
-
-        Args:
-            corporate_csv_path: Path to corporate CSV (file 1), or None to skip
-            facility_csv_path: Path to facility CSV (file 2), or None to skip
-
-        Returns:
-            dict with counts (corporates, facilities, contacts; and for wizard: corporates_created, etc.)
-        """
         _logger.info("Starting CSV import: corporate=%s, facility=%s", corporate_csv_path, facility_csv_path)
-
         self.env["plasticos.partner.import.validation"].validate_reference_integrity()
-
-        # Phase 1: Load corporates (only if path provided)
         corporate_count = 0
         if corporate_csv_path:
             corporate_count = self._import_corporate_csv(corporate_csv_path)
-
-        # Phase 2: Load facilities and their contacts (only if path provided)
         facility_count = 0
         contact_count = 0
         if facility_csv_path:
             facility_count, contact_count = self._import_facility_csv(facility_csv_path)
-
         self.env["plasticos.partner.import.validation"].validate_partner_graph()
-
-        counts = {
+        return {
             "corporates": corporate_count,
             "facilities": facility_count,
             "contacts": contact_count,
-            # Wizard-friendly keys (no created/updated split in CSV flow)
             "corporates_created": corporate_count,
             "corporates_updated": 0,
             "facilities_created": facility_count,
@@ -261,19 +310,11 @@ class PlasticosPartnerImportService(models.AbstractModel):
             "contacts_created": contact_count,
             "errors": [],
         }
-        _logger.info("CSV import complete: %s", counts)
-        return counts
 
-    # -------------------------------------------------------------------------
+    # =========================================================================
     # CSV Import: Corporates
-    # -------------------------------------------------------------------------
+    # =========================================================================
     def _import_corporate_csv(self, csv_path):
-        """
-        Import corporates from CSV file.
-
-        CSV columns: ref, role, user_id, alias, name-check, name, street, street2,
-                     city, state_id, zip, country
-        """
         count = 0
         with open(csv_path, encoding="utf-8-sig") as f:
             reader = csv.DictReader(f)
@@ -287,12 +328,10 @@ class PlasticosPartnerImportService(models.AbstractModel):
                 except Exception as e:
                     _logger.error("Error at corporate row %d: %s", i, e)
                     raise
-
         _logger.info("Loaded %d corporates from CSV", count)
         return count
 
     def _import_corporate_row(self, row, row_num):
-        """Import single corporate row."""
         name = row.get("name", "").strip()
         if not name:
             _logger.warning("Skipping corporate row %d: empty name", row_num)
@@ -301,15 +340,18 @@ class PlasticosPartnerImportService(models.AbstractModel):
         ref = row.get("ref", "").strip()
         external_id = self._make_external_id("corp", ref or name)
 
-        # Lookups
         country_id = self._lookup_country(row.get("country", ""))
         state_id = self._lookup_state(row.get("state_id", ""), country_id)
         user_id = self._lookup_user(row.get("user_id", ""))
-        role_str = row.get("role", "")
-        is_supplier, is_customer = self._parse_role(role_str)
-        category_tag_ids = self._lookup_category_tags(role_str)
+        csv_role_str = row.get("role", "")
+        vs_company_type_str = row.get("company_type", "")
 
-        # Get default payment term
+        company_role = self._resolve_company_role(vs_company_type_str, csv_role_str)
+        trade_role = self._resolve_trade_role(company_role, csv_role_str)
+        origin_sector = self._resolve_origin_sector(company_role)
+        is_supplier = trade_role in ("supplier", "both")
+        is_customer = trade_role in ("buyer", "both")
+        category_tag_ids = self._lookup_category_tags(csv_role_str)
         default_payment_term_id = self._get_default_payment_term()
 
         vals = {
@@ -327,35 +369,29 @@ class PlasticosPartnerImportService(models.AbstractModel):
             "user_id": user_id,
             "supplier_rank": 1 if is_supplier else 0,
             "customer_rank": 1 if is_customer else 0,
+            "company_role": company_role,
+            "plasticos_trade_role": trade_role,
         }
-
-        # Assign category tags based on role (Supplier, Customer/Buyer, Expense, etc.)
+        if origin_sector:
+            vals["plasticos_origin_sector"] = origin_sector
         if category_tag_ids:
             vals["category_id"] = [(6, 0, category_tag_ids)]
-
-        # Assign payment terms based on role
         if is_customer and default_payment_term_id:
             vals["property_payment_term_id"] = default_payment_term_id
         if is_supplier and default_payment_term_id:
             vals["property_supplier_payment_term_id"] = default_payment_term_id
 
-        return self._upsert("res.partner", external_id, vals)
+        partner = self._upsert("res.partner", external_id, vals)
+        self._apply_vanillasoft_lead_source(partner)
+        return partner
 
-    # -------------------------------------------------------------------------
+    # =========================================================================
     # CSV Import: Facilities
-    # -------------------------------------------------------------------------
+    # =========================================================================
     def _import_facility_csv(self, csv_path):
-        """
-        Import facilities from CSV file.
-
-        CSV columns: partner_id, Type, is_remit, is_invoice_entity, is_facility,
-                     Alias, company_id, address, adderess2, city, state, zip,
-                     country, Contact, Phone, Email
-        """
         facility_count = 0
         contact_count = 0
-        contacts_created = {}  # Track contacts by (parent_id, name, email) to dedupe
-
+        contacts_created = {}
         with open(csv_path, encoding="utf-8-sig") as f:
             reader = csv.DictReader(f)
             for i, row in enumerate(reader):
@@ -367,56 +403,35 @@ class PlasticosPartnerImportService(models.AbstractModel):
                         contact_count += 1
                     if (facility_count + contact_count) % BATCH_SIZE == 0:
                         self.env.cr.commit()
-                        _logger.info("Facilities progress: %d facilities, %d contacts", facility_count, contact_count)
                 except Exception as e:
                     _logger.error("Error at facility row %d: %s", i, e)
                     raise
-
         _logger.info("Loaded %d facilities, %d contacts from CSV", facility_count, contact_count)
         return facility_count, contact_count
 
     def _import_facility_row(self, row, row_num, contacts_created):
-        """Import single facility row with its contact."""
         partner_name = row.get("partner_id", "").strip()
         if not partner_name:
-            _logger.warning("Skipping facility row %d: empty partner_id", row_num)
             return None, None
 
         facility_type = row.get("Type", "").strip()
         alias = row.get("Alias", "").strip()
-
-        # Find parent corporate
         parent = self._find_corporate_by_name(partner_name)
         if not parent:
             _logger.warning("Skipping facility row %d: parent '%s' not found", row_num, partner_name)
             return None, None
 
-        # Determine facility name
         facility_name = alias if alias and alias != "INVOICE" else f"{partner_name} - {facility_type}"
-
-        # Lookups
         country_id = self._lookup_country(row.get("country", ""))
         state_id = self._lookup_state(row.get("state", ""), country_id)
 
-        # Determine partner type based on facility type
-        if facility_type in INVOICE_TYPES:
-            partner_type = "invoice"
-            facility_role = False
-        elif facility_type == "Location":
-            partner_type = "contact"  # Will be company with parent
-            facility_role = "other"
-        else:
-            partner_type = "contact"
-            facility_role = "other"
-
-        # Build external ID
+        parent_company_role = parent.company_role or False
+        parent_trade_role = parent.plasticos_trade_role or False
+        parent_origin_sector = parent.plasticos_origin_sector or False
+        partner_type_odoo = "invoice" if facility_type in INVOICE_TYPES else "contact"
         external_id = self._make_external_id("fac", f"{partner_name}_{alias or facility_type}_{row_num}")
-
-        # Inherit tags from parent
         parent_tag_ids = parent.category_id.ids if parent.category_id else []
 
-        # For Location type, create as company child
-        # For Invoice types, create as address
         if facility_type == "Location":
             vals = {
                 "name": facility_name,
@@ -424,21 +439,23 @@ class PlasticosPartnerImportService(models.AbstractModel):
                 "is_company": True,
                 "type": "contact",
                 "parent_id": parent.id,
-                "facility_role": facility_role,
                 "street": row.get("address", "").strip() or False,
-                "street2": row.get("adderess2", "").strip() or False,  # Note: typo in CSV
+                "street2": row.get("adderess2", "").strip() or False,
                 "city": row.get("city", "").strip() or False,
                 "state_id": state_id,
                 "zip": row.get("zip", "").strip() or False,
                 "country_id": country_id,
+                "company_role": parent_company_role,
+                "plasticos_trade_role": parent_trade_role,
             }
+            if parent_origin_sector:
+                vals["plasticos_origin_sector"] = parent_origin_sector
         else:
-            # Invoice/Remit address
             vals = {
                 "name": facility_name,
                 "company_type": "person",
                 "is_company": False,
-                "type": partner_type,
+                "type": partner_type_odoo,
                 "parent_id": parent.id,
                 "street": row.get("address", "").strip() or False,
                 "street2": row.get("adderess2", "").strip() or False,
@@ -448,87 +465,54 @@ class PlasticosPartnerImportService(models.AbstractModel):
                 "country_id": country_id,
             }
 
-        # Inherit category tags from parent corporate
         if parent_tag_ids:
             vals["category_id"] = [(6, 0, parent_tag_ids)]
 
         facility = self._upsert("res.partner", external_id, vals)
+        self._apply_vanillasoft_lead_source(facility)
 
-        # Create contact if Contact/Phone/Email provided
         contact = None
         contact_name = row.get("Contact", "").strip()
         contact_phone = self._normalize_phone(row.get("Phone", ""))
-        # Pass contact_name to match email to the named contact when multiple emails exist
         contact_email = self._normalize_email(row.get("Email", ""), contact_name)
-
         if contact_name and contact_name not in ("Primary", "United States"):
             contact = self._create_facility_contact(
-                facility, parent, contact_name, contact_phone, contact_email, facility_type, contacts_created
+                facility, parent, contact_name, contact_phone,
+                contact_email, facility_type, contacts_created
             )
-
         return facility, contact
 
     def _find_corporate_by_name(self, name):
-        """Find corporate partner by name."""
-        # Try exact match first
         partner = self.env["res.partner"].search(
-            [
-                ("name", "=", name),
-                ("parent_id", "=", False),
-                ("is_company", "=", True),
-            ],
+            [("name", "=", name), ("parent_id", "=", False), ("is_company", "=", True)],
             limit=1,
         )
         if partner:
             return partner
-
-        # Try ilike match
-        partner = self.env["res.partner"].search(
-            [
-                ("name", "ilike", name),
-                ("parent_id", "=", False),
-                ("is_company", "=", True),
-            ],
+        return self.env["res.partner"].search(
+            [("name", "ilike", name), ("parent_id", "=", False), ("is_company", "=", True)],
             limit=1,
         )
-        return partner
 
     def _create_facility_contact(self, facility, corporate, name, phone, email, facility_type, contacts_created):
-        """
-        Create contact under facility with AR/AP logic.
-
-        Rules:
-        - If corporate is Supplier → AR contact (type='invoice')
-        - If corporate is Customer → AP contact (type='contact')
-        - If both → AR contact (AR takes priority, no duplicate)
-        - Dedupe by (corporate_id, name, email)
-        """
-        # Dedupe key
         dedup_key = (corporate.id, name.lower(), (email or "").lower())
         if dedup_key in contacts_created:
-            _logger.debug("Skipping duplicate contact: %s", name)
             return None
 
-        # Determine contact type based on corporate's supplier/customer status
-        is_supplier = corporate.supplier_rank > 0
-        is_customer = corporate.customer_rank > 0
+        trade_role = corporate.plasticos_trade_role or ""
+        is_supplier = trade_role in ("supplier", "both") or corporate.supplier_rank > 0
+        is_customer = trade_role in ("buyer", "both") or corporate.customer_rank > 0
 
         if is_supplier:
-            # AR contact - we pay them, this is their receivables contact
             contact_type = CONTACT_TYPE_AR
         elif is_customer:
-            # AP contact - they pay us, this is their payables contact
             contact_type = CONTACT_TYPE_AP
         else:
-            # Default to contact
             contact_type = "contact"
-
-        # For Location types, use delivery contact type
         if facility_type == "Location":
             contact_type = CONTACT_TYPE_DELIVERY
 
         external_id = self._make_external_id("contact", f"{corporate.name}_{name}_{facility.id}")
-
         vals = {
             "name": name,
             "company_type": "person",
@@ -538,25 +522,21 @@ class PlasticosPartnerImportService(models.AbstractModel):
             "phone": phone,
             "email": email,
         }
-
         contact = self._upsert("res.partner", external_id, vals)
         contacts_created[dedup_key] = contact.id
-
-        _logger.debug("Created %s contact '%s' under %s", contact_type, name, facility.name)
         return contact
 
-    # -------------------------------------------------------------------------
-    # Legacy methods (for backward compatibility)
-    # -------------------------------------------------------------------------
+    # =========================================================================
+    # Legacy dict-based methods (backward compat)
+    # =========================================================================
     def _load_corporates(self, rows):
-        """Load corporate-level partners from dict list."""
         count = 0
         default_payment_term_id = self._get_default_payment_term()
-
         for i, r in enumerate(rows):
             if not r.get("external_id"):
                 raise ValidationError(f"BLOCKER: MISSING_EXTERNAL_ID at row {i}")
-
+            company_role = r.get("company_role") or r.get("facility_role") or "other"
+            trade_role = self._resolve_trade_role(company_role, r.get("role", ""))
             vals = {
                 "name": r["name"],
                 "company_type": "company",
@@ -565,75 +545,61 @@ class PlasticosPartnerImportService(models.AbstractModel):
                 "country_id": r.get("country_id"),
                 "state_id": r.get("state_id"),
                 "user_id": r.get("user_id"),
+                "company_role": company_role,
+                "plasticos_trade_role": trade_role,
             }
-
-            # Assign payment terms if provided or use default
             if r.get("property_payment_term_id"):
                 vals["property_payment_term_id"] = r["property_payment_term_id"]
             elif r.get("is_customer") and default_payment_term_id:
                 vals["property_payment_term_id"] = default_payment_term_id
-
             if r.get("property_supplier_payment_term_id"):
                 vals["property_supplier_payment_term_id"] = r["property_supplier_payment_term_id"]
             elif r.get("is_supplier") and default_payment_term_id:
                 vals["property_supplier_payment_term_id"] = default_payment_term_id
-
             self._upsert("res.partner", r["external_id"], vals)
             count += 1
-
             if count % BATCH_SIZE == 0:
                 self.env.cr.commit()
-                _logger.info("Corporates progress: %d/%d", count, len(rows))
-
         _logger.info("Loaded %d corporates", count)
         return count
 
     def _load_facilities(self, rows):
-        """Load facility-level partners from dict list."""
         count = 0
         for i, r in enumerate(rows):
             if not r.get("external_id"):
                 raise ValidationError(f"BLOCKER: MISSING_EXTERNAL_ID at facility row {i}")
-
             parent = self.env.ref(r["parent_external_id"], raise_if_not_found=False)
             if not parent:
                 raise ValidationError(
                     f"BLOCKER: FACILITY_PARENT_MISSING - {r['parent_external_id']} "
                     f"not found for facility '{r.get('name')}'"
                 )
-
+            company_role = r.get("company_role") or r.get("facility_role") or parent.company_role or "other"
             vals = {
                 "name": r["name"],
                 "company_type": "company",
                 "is_company": True,
                 "parent_id": parent.id,
-                "facility_role": r.get("facility_role", "other"),
+                "company_role": company_role,
             }
-
             self._upsert("res.partner", r["external_id"], vals)
             count += 1
-
             if count % BATCH_SIZE == 0:
                 self.env.cr.commit()
-                _logger.info("Facilities progress: %d/%d", count, len(rows))
-
         _logger.info("Loaded %d facilities", count)
         return count
 
     def _load_contacts(self, rows):
-        """Load contact-level partners from dict list."""
         count = 0
         for i, r in enumerate(rows):
             if not r.get("external_id"):
                 raise ValidationError(f"BLOCKER: MISSING_EXTERNAL_ID at contact row {i}")
-
             parent = self.env.ref(r["parent_external_id"], raise_if_not_found=False)
             if not parent:
                 raise ValidationError(
                     f"BLOCKER: CONTACT_PARENT_MISSING - {r['parent_external_id']} "
                     f"not found for contact '{r.get('name')}'"
                 )
-
             vals = {
                 "name": r["name"],
                 "company_type": "person",
@@ -644,13 +610,9 @@ class PlasticosPartnerImportService(models.AbstractModel):
                 "function": r.get("function"),
                 "type": r.get("type", "contact"),
             }
-
             self._upsert("res.partner", r["external_id"], vals)
             count += 1
-
             if count % BATCH_SIZE == 0:
                 self.env.cr.commit()
-                _logger.info("Contacts progress: %d/%d", count, len(rows))
-
         _logger.info("Loaded %d contacts", count)
         return count


### PR DESCRIPTION
## Summary

- plasticos_facility_profile v4.3.1 → 5.0.0: adds company_role (Selection), is_facility (computed/stored), preferred_supplier_profile_id, personal_intel (Html), merged 5-axis form + list + search views
- Migration 19.0.5.0.0: backfills company_role from supplier_rank/customer_rank — idempotent
- Partner type registry v5.0.0: 13 types with code, gate_mode, is_facility, sequence
- New seed: utm_source_data.xml (VanillaSoft, noupdate=1)
- plasticos_partner_import v2.2.0 → 2.3.0: full VS_COMPANY_TYPE_MAP, resolve_trade_role, resolve_origin_sector, apply_vanillasoft_lead_source
- plasticos_base partner_tags.xml: removes deprecated role tags, adds Operational + Material Focus categories

## Deploy
```
docker compose run --rm odoo -u plasticos_facility_profile,plasticos_partner_import
```

## Test plan
- [ ] CI passes
- [ ] All companies have company_role after migration
- [ ] CSV import writes company_role correctly
- [ ] Partner form: company_role badge, 5-axis block, Personal Intel tab
- [ ] Facility Profile tab hidden for parent companies with children