### PR TITLE
feat(plasticos_crm_bridge): CRM lead form — smart buttons, Pipeline tab, Personal Intel tab

### DIFF
--- a/plasticos_crm_bridge/views/crm_lead_views.xml
+++ b/plasticos_crm_bridge/views/crm_lead_views.xml
@@ -151,6 +151,38 @@
                     </group>
 
                 </page>
+
+                <!-- ═══════════════════════════════════════════════════════
+                     PERSONAL INTEL TAB (CRM Lead)
+                     ───────────────────────────────────────────────────────
+                     Surfaces personal_intel from the linked contact
+                     (partner_id) as a related readonly field.
+                     Visible only when partner_id is a person (not company).
+                     Brokers see this before every call — no model changes
+                     to crm.lead required; field lives on res.partner.
+                     ═══════════════════════════════════════════════════════ -->
+                <page string="🧠 Personal Intel"
+                      name="personal_intel_tab"
+                      invisible="not partner_id or partner_id.is_company">
+
+                    <div class="alert alert-warning d-flex align-items-start gap-2 mb-3"
+                         role="note">
+                        <i class="fa fa-lightbulb-o fa-lg mt-1"/>
+                        <span>
+                            <strong>Human-layer notes from the Contact record.</strong>
+                            Edit on the Contact to make changes.
+                            Personality, comms style, rapport hooks, motivators.
+                            <strong>Internal only.</strong>
+                        </span>
+                    </div>
+
+                    <field name="partner_id.personal_intel"
+                           nolabel="1"
+                           readonly="1"
+                           placeholder="No Personal Intel recorded yet. Open the Contact to add notes."/>
+
+                </page>
+
             </xpath>
 
         </field>


### PR DESCRIPTION
## Summary

- CRM lead form: Convert to Intake button, 5 smart buttons (Web Leads, Material Profiles, Matches, Transactions, Intakes)
- PlastOS Pipeline tab: KPI banner, web lead origins, delivery preferences, pipeline summary
- Personal Intel tab: surfaces partner_id.personal_intel readonly from linked contact
- List view: total_match_count, total_transaction_count, partner_last_pickup columns
- Web Lead form/list: crm_lead_id link field

## Test plan
- [ ] CI passes
- [ ] Smart buttons visible when counts > 0
- [ ] Personal Intel tab hidden when partner is a company