### PR TITLE
docs: add PlasticOS module README suite to docs/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,12 @@ Files To Harvest/
 PlasticOS/
 _Source Files/
 addons/
-docs/
+docs/*.ai
+docs/*.pdf
+docs/*.png
+docs/*.jpg
+docs/*.jpeg
+docs/adr/
 l9_trace/
 odoo-enterprise/
 telemetry/

--- a/docs/README_INDEX.md
+++ b/docs/README_INDEX.md
@@ -1,0 +1,132 @@
+# PlasticOS IB-Odoo 19 — README Bundle Index
+
+**Generated:** 2026-03-22
+**Branch:** staging
+**Scope:** Modules with significant development, debugging, and architectural work performed during the pre-launch optimization phase.
+
+---
+
+## Bundle Contents
+
+| File | Module / Topic | Deploy Trigger |
+|---|---|---|
+| `README_plasticos_intake.md` | `plasticos_intake` — Core pipeline entry point | `-u plasticos_intake` |
+| `README_plasticos_intake_normalizer.md` | `plasticos_intake_normalizer` — CEG packet assembly | `-u plasticos_intake_normalizer` |
+| `README_plasticos_offer.md` | `plasticos_offer` — Offer lifecycle | `-u plasticos_offer` |
+| `README_plasticos_transaction.md` | `plasticos_transaction` — Deal record, financials, compliance | `-u plasticos_transaction` |
+| `README_plasticos_facility_profile.md` | `plasticos_facility_profile` — Facility capability profiles | `-u plasticos_facility_profile` |
+| `README_plasticos_material_profile.md` | `plasticos_material_profile` — Material master + registries | `-u plasticos_material_profile` |
+| `README_plasticos_commission.md` | `plasticos_commission` — Broker commission + payout + dashboard | `-u plasticos_commission` |
+| `README_plasticos_partner_import.md` | `plasticos_partner_import` — Bulk CSV import tooling | `-u plasticos_partner_import` |
+| `README_backup_github_actions.md` | GitHub Actions S3 disaster recovery | N/A — infra |
+
+---
+
+## Module Dependency Chain (simplified)
+
+```
+plasticos_base
+  └─ plasticos_material_profile          ← owns PROCESS_SELECTION, is_facility field
+       └─ plasticos_facility_profile     ← facility capability profiles
+            └─ plasticos_intake          ← pipeline entry
+                 └─ plasticos_intake_normalizer
+                 └─ plasticos_offer      ← offer lifecycle
+                      └─ plasticos_transaction  ← deal record
+                           └─ plasticos_commission  ← broker payout
+                           └─ plasticos_logistics
+                           └─ plasticos_accounting
+  └─ plasticos_security_base             ← groups, ACL base
+  └─ plasticos_partner_import            ← standalone import tooling
+```
+
+---
+
+## Critical Architecture Decisions (Cross-Module)
+
+### 1. `process_codes.py` lives in `plasticos_material_profile`
+Canonical import: `from odoo.addons.plasticos_material_profile.process_codes import PROCESS_SELECTION`
+Do NOT move it back to `plasticos_facility_profile` — circular dependency.
+
+### 2. `is_facility` computed field lives in `plasticos_material_profile`
+Both `plasticos_facility_profile` and `plasticos_intake` use this field for tab visibility and facility selection. It is defined once in `plasticos_material_profile.models.res_partner`. Do not redefine.
+
+### 3. `action_view_claims()` lives in `plasticos_claims` bridge
+The claims bridge uses `_inherit = 'plasticos.transaction'` to inject this method. Do not add it to `transaction.py` — it would shadow the bridge and break module separation.
+
+### 4. Boolean material flags (`has_metal`, `is_metalized`, `has_fr`) are computed
+These are `@api.depends('material_attribute_ids')`, `store=True`. `material_attribute_ids` is the single source of truth. Old bidirectional `onchange` sync was removed. Do not reintroduce separate stored booleans.
+
+### 5. `plasticos.material.profile` has no `name` field
+Profile identity = `(partner_id, polymer_id)`. Never set `name` in create vals. Use `display_name` for chatter body.
+
+### 6. x_ field cleanup completed
+All `x_` prefixed fields were migration artifacts. All live code references corrected:
+- `x_preferred_contact_id` → `preferred_contact_id` (intake, contract tests)
+- `x_vanillasoft_id` → `vanillasoft_id` (partner import)
+- `x_facility_role` → `facility_role` (partner import wizard)
+- `x_plasticos_doc_id` etc. → cleaned in `documents_native` and `documents`
+
+---
+
+## Ignored / Out-of-Scope Modules
+
+These are **gitignored and cursorignored**. Do not reference, import from, or add dependencies to them:
+
+| Module | Reason |
+|---|---|
+| `plasticos_buyer_match_engine` | Future microservice — external repo (`Cognitive.Engine.Graphs`) |
+| `plasticos_inference_engine` | Future microservice — `pipeline_v2.py` is broken, never activate |
+| `plasticos_graph_engine` | Future microservice |
+| `plasticos_graph_intelligence` | Future microservice |
+| `plasticos_graph_integration` | Future microservice |
+| `plasticos_graph_3d_embedding` | Future microservice |
+| `plasticos_enrichment` | Out of scope for launch |
+| `plasticos_enrichment_bridge` | Out of scope for launch |
+| `plasticos_website` | Out of scope for launch |
+| `plasticos_dev_tools` | Dev-only — never install in production |
+| `plasticos_documents_native` | Uninstallable — enterprise layer fallback |
+
+---
+
+## Active Crons (as of 2026-03-17)
+
+16 active PlasticOS crons confirmed in DB. Key ones:
+
+| Cron | Module | Schedule |
+|---|---|---|
+| PlasticOS Invoice Overdue Reminder | `plasticos_accounting` | Daily |
+| PlasticOS Load SLA Breach Check | `plasticos_logistics` | Daily |
+| PlasticOS Supplier Readiness Follow-up | `plasticos_automation` | Every 6 hours |
+| PlasticOS Sale Approval Flag | `plasticos_transaction` | Daily |
+| PlasticOS Midnight Time-Based Field Recompute | `plasticos_transaction` | Daily 00:05 |
+| PlasticOS Offer Expiry | `plasticos_offer` | Daily |
+| PlasticOS Contract Renewal Alert | `plasticos_automation` | Daily |
+| PlasticOS Escalation Monitor | `plasticos_automation` | Every 2 hours |
+
+---
+
+## Config Parameters Required Before Go-Live
+
+| Key | Module | Description |
+|---|---|---|
+| `plasticos.graphengine.url` | `plasticos_intake` | CEG endpoint URL |
+| `plasticos.graphengine.apikey` | `plasticos_intake` | CEG bearer token |
+| `plasticos.matching.engine.enabled` | `plasticos_intake` | `True` to enable live matching |
+| `plasticos.offer.expiry_days` | `plasticos_offer` | Default: 14 |
+| `plasticos.intake.expiry_days` | `plasticos_intake` | Default: 90 |
+| `plasticos.commission.default_rate_pct` | `plasticos_commission` | Fallback rate if no rule matches |
+
+---
+
+## Go-Live Gates
+
+- [ ] Remove `--dev=reload` from `docker-compose.yml` command
+- [ ] Set `admin_passwd` to non-default strong password in `odoo.conf`
+- [ ] Set `list_db = False` in `odoo.conf`
+- [ ] Set `db_filter = ^odoo$` in `odoo.conf`
+- [ ] Set `proxy_mode = True` (behind nginx)
+- [ ] Set `workers = 2`, `max_cron_threads = 1` in `odoo.conf`
+- [ ] Confirm `plasticos_dev_tools` is uninstallable/disabled
+- [ ] CEG config params set in Settings → Technical → System Parameters
+- [ ] GitHub Actions backup workflow deployed and first backup confirmed in S3
+

--- a/docs/README_backup_github_actions.md
+++ b/docs/README_backup_github_actions.md
@@ -1,0 +1,167 @@
+# PlasticOS Disaster Recovery — External Backup via GitHub Actions
+
+**File:** `.github/workflows/backup-to-s3.yml`
+**Strategy:** External pull — backups are pulled by infrastructure you own, running on GitHub's schedule, storing to your S3 bucket. Odoo.sh never sees the AWS credentials.
+
+---
+
+## Why External Pull
+
+Any backup mechanism running *inside* Odoo.sh is also compromised if Odoo.sh is hacked — including cron jobs, S3 credentials stored as system parameters, and the backup module itself. The GitHub Actions approach runs entirely outside Odoo.sh. Odoo.sh has zero visibility into the S3 destination.
+
+---
+
+## Architecture
+
+```
+GitHub Actions (runs daily 3 AM UTC / Sunday 4 AM UTC)
+  │
+  ├─ SSH into Odoo.sh → SCP /home/odoo/backup.daily/*.sql.gz
+  │
+  ├─ Validate (reject if < 1MB — likely corrupt)
+  │
+  ├─ Upload to S3 → backups/daily/ or backups/weekly/
+  │
+  └─ S3 Object Lock (COMPLIANCE mode) → nobody can delete backups for 90 days
+```
+
+---
+
+## Required Secrets (GitHub → Settings → Secrets and Variables → Actions)
+
+| Secret | Value |
+|---|---|
+| `ODOOSH_SSH_KEY` | Private key for the `plasticos-backup-bot` SSH keypair |
+| `ODOOSH_SSH_HOST` | `<build-id>@<project>.odoo.com` (from Odoo.sh SSH tab) |
+| `AWS_ACCESS_KEY_ID` | Write-only IAM user key |
+| `AWS_SECRET_ACCESS_KEY` | Write-only IAM user secret |
+| `S3_BUCKET` | `plasticos-disaster-recovery` |
+| `ODOO_DB_NAME` | Your production DB name (run `echo $PGDATABASE` in Odoo.sh shell) |
+
+**SSH Key setup:**
+```bash
+ssh-keygen -t ed25519 -C "plasticos-backup-bot" -f ~/.ssh/plasticos_backup_bot
+# Add public key to: Odoo.sh Dashboard → Project → Settings → SSH Keys
+```
+
+---
+
+## S3 Bucket Configuration
+
+### Create with Object Lock (must be enabled at creation time)
+
+```bash
+aws s3api create-bucket \
+  --bucket plasticos-disaster-recovery \
+  --region us-east-1
+
+aws s3api put-bucket-versioning \
+  --bucket plasticos-disaster-recovery \
+  --versioning-configuration Status=Enabled
+
+aws s3api put-object-lock-configuration \
+  --bucket plasticos-disaster-recovery \
+  --object-lock-configuration '{
+    "ObjectLockEnabled": "Enabled",
+    "Rule": {
+      "DefaultRetention": {
+        "Mode": "COMPLIANCE",
+        "Days": 90
+      }
+    }
+  }'
+```
+
+**COMPLIANCE mode:** Not even the AWS root account can delete objects during the 90-day retention period.
+
+### IAM Policy (Write-Only)
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Action": ["s3:PutObject", "s3:PutObjectTagging"],
+    "Resource": "arn:aws:s3:::plasticos-disaster-recovery/*"
+  }]
+}
+```
+
+This IAM user **cannot read, list, or delete** existing backups. Leaked credentials cannot destroy your recovery point.
+
+### Lifecycle Policy
+
+```json
+{
+  "Rules": [
+    {
+      "ID": "DailyExpire30Days",
+      "Filter": { "Prefix": "backups/daily/" },
+      "Status": "Enabled",
+      "Expiration": { "Days": 30 }
+    },
+    {
+      "ID": "WeeklyToGlacierDeepArchive",
+      "Filter": { "Prefix": "backups/weekly/" },
+      "Status": "Enabled",
+      "Transitions": [
+        { "Days": 90, "StorageClass": "GLACIER_DEEP_ARCHIVE" }
+      ]
+    }
+  ]
+}
+```
+
+Daily backups expire at 30 days. Weekly archives move to Glacier Deep Archive (~$0.00099/GB/month) at 90 days and stay forever.
+
+---
+
+## Workflow Behavior
+
+| Schedule | Backup Type | S3 Prefix | Retention |
+|---|---|---|---|
+| Daily 3 AM UTC | Latest `.sql.gz` from Odoo.sh | `backups/daily/` | 30 days |
+| Sunday 4 AM UTC | Same file | `backups/weekly/` | Forever (→ Glacier at 90d) |
+| Manual (`workflow_dispatch`) | On-demand | `backups/daily/` | 30 days |
+
+**Validation gate:** Backup is rejected before upload if file size < 1MB (likely corrupt or empty DB export). GitHub Actions will email on failure.
+
+---
+
+## Threat Model Coverage
+
+| Threat | Mitigation |
+|---|---|
+| Odoo.sh fully compromised | Backups already in S3; GitHub Actions doesn't run on Odoo.sh |
+| Attacker gets AWS write credentials | Write-only policy — can't read, list, or delete existing backups |
+| Attacker gets AWS root account | COMPLIANCE Object Lock — physical deletion blocked for 90 days |
+| Corrupt backup uploaded | < 1MB size check rejects before upload |
+| Silent backup failure | GitHub Actions emails on workflow failure |
+| Accidental deletion | Versioning + Object Lock |
+
+---
+
+## Belt-and-Suspenders (Optional Secondary Layer)
+
+The `auto_backup_sh` module (Yentech/Yenthe666) can run inside Odoo.sh and push the daily backup to a separate SFTP server you control. Install via `requirements.txt` with `pysftp`. This gives a **second independent stream** — if GitHub Actions fails, SFTP still runs.
+
+The GitHub Actions external pull is your **primary lifeline**. SFTP is belt-and-suspenders.
+
+---
+
+## Recovery Procedure
+
+```bash
+# List available backups
+aws s3 ls s3://plasticos-disaster-recovery/backups/daily/ --recursive
+
+# Download most recent
+aws s3 cp s3://plasticos-disaster-recovery/backups/daily/plasticos_20260319T030000Z.sql.gz .
+
+# Restore to local Postgres
+gunzip plasticos_20260319T030000Z.sql.gz
+psql -U odoo -d odoo_restore < plasticos_20260319T030000Z.sql
+
+# Or restore to Odoo.sh via the Odoo.sh platform backup restore UI
+```
+

--- a/docs/README_plasticos_commission.md
+++ b/docs/README_plasticos_commission.md
@@ -1,0 +1,140 @@
+# plasticos_commission
+
+**Version:** 19.0.1.2.0
+**Category:** PlasticOS / Finance
+**Depends:** `plasticos_base`, `plasticos_transaction`, `plasticos_security_base`
+
+---
+
+## Purpose
+
+Calculates, tracks, and pays broker commissions on closed transactions. The module provides a rule engine (`commission_service.py`), a payout workflow model (`plasticos.commission.payout`), and a read-only SQL VIEW dashboard (`plasticos.sales.dashboard`) for broker pipeline visibility.
+
+---
+
+## Models
+
+### `plasticos.commission`
+
+One commission record per closed transaction.
+
+| Field | Type | Notes |
+|---|---|---|
+| `transaction_id` | `Many2one(plasticos.transaction)` | Parent |
+| `broker_id` | `Many2one(res.users)` | Assigned broker |
+| `commission_locked_amount` | `Float` | Final amount — locked when payout is confirmed |
+| `override_pct` | `Float` | Manual override rate (takes priority over rule engine) |
+| `commission_rule_id` | `Many2one(plasticos.commission.rule)` | Applied rule |
+| `state` | `Selection` | `draft / confirmed / paid` |
+| `payout_id` | `Many2one(plasticos.commission.payout)` | Batch payout this commission belongs to |
+
+---
+
+### `plasticos.commission.rule`
+
+Rate rules evaluated in priority order against transaction attributes (polymer, volume, customer tier, etc.).
+
+| Field | Type | Notes |
+|---|---|---|
+| `name` | `Char` | |
+| `priority` | `Integer` | Lower = evaluated first |
+| `polymer_ids` | `Many2many(plasticos.polymer)` | If set, rule applies only to these polymers |
+| `min_volume_lbs` | `Float` | Volume floor for rule eligibility |
+| `rate_pct` | `Float` | Commission rate |
+| `is_default` | `Boolean` | Fallback if no other rule matches |
+
+---
+
+### `plasticos.commission.payout`
+
+**One payout record per broker per period.** Aggregates `commission_locked_amount` from confirmed commissions.
+
+| Field | Type | Notes |
+|---|---|---|
+| `name` | `Char` | Sequence: `PAY-YYYY-NNNN` |
+| `broker_id` | `Many2one(res.users)` | |
+| `period_start` / `period_end` | `Date` | |
+| `total_amount` | `Float` | Computed sum of linked commission amounts |
+| `state` | `Selection` | `draft / confirmed / paid` |
+| `payment_date` | `Date` | Required to move to `paid` |
+| `payment_reference` | `Char` | Required to move to `paid` |
+| `commission_ids` | `One2many(plasticos.commission)` | Linked commissions |
+
+**Workflow:** `Draft → Confirmed` (accounting locks the list, no more commissions can join) → `Paid` (requires `payment_date` + `payment_reference`). Full chatter trail.
+
+---
+
+### `plasticos.sales.dashboard`
+
+A `_auto=False` **SQL VIEW** model — read-only, computed at the DB level. Reps see one row per active deal.
+
+Columns: financials, weight source badge, load state, four doc traffic lights (BOL / Scale Ticket / Invoice / CO), commission pay status.
+
+Five drill-through buttons:
+- Track Load
+- View Scale Ticket
+- View BOL
+- View Payout Details
+- All Documents
+
+**Security:** `group_sales_rep` users see only their own deals (`user_id = uid` record rule). Managers and accounting see all.
+
+---
+
+## Commission Service: `commission_service.py`
+
+Priority-chain calculation engine. Replaces the original stub that always returned `0.0`.
+
+**Resolution chain:**
+
+1. `commission_locked_amount` — if already locked (confirmed payout), return as-is
+2. `override_pct` — if manually overridden, apply to `transaction.gross_margin`
+3. Rule engine — iterate rules by `priority` ASC, first match wins
+4. ICP default rate — `ir.config_parameter` key `plasticos.commission.default_rate_pct`
+5. `0.0` — fallback, logged at `WARNING` level
+
+Every resolution path logged at `DEBUG`. `WARNING` fired if fallback to 0.0.
+
+---
+
+## Security
+
+- `ir.model.access.csv` — ACL entries for `plasticos.commission`, `plasticos.commission.rule`, `plasticos.commission.payout`, `plasticos.sales.dashboard`
+- `security/record_rules_dashboard.xml` — `group_sales_rep` → `user_id = uid` on dashboard and payout models
+
+---
+
+## Deployment
+
+```bash
+docker compose -p odoo19 run --rm odoo \
+  -d odoo --db-host db --db-port 5432 --db-user odoo --db-password odoo \
+  -u plasticos_commission --stop-after-init
+```
+
+**Requires `--update`** for:
+- New stored fields on `plasticos.commission`
+- SQL VIEW creation (first install)
+- ACL changes
+
+**Before running `--update`:** verify these fields exist on `plasticos.transaction` — the SQL VIEW query will fail at `init()` if any are missing:
+- `broker_id`, `gross_margin`, `weight_lbs`, `load_id`, `freight_cost`, `sale_price`, `buy_price`
+
+---
+
+## Integration Points
+
+| Module | Direction | Notes |
+|---|---|---|
+| `plasticos_transaction` | Inbound | Commission triggered when `transaction.state = closed` |
+| `plasticos_security_base` | Groups | `group_sales_rep`, `group_accounting`, `group_manager` |
+
+---
+
+## Pending
+
+| Item | Priority |
+|---|---|
+| Commission auto-trigger on `transaction.state = closed` | **High** — `commission_service.calculate()` not yet called from transaction write |
+| `action_generate_for_rep()` cron or wizard | Medium — payout batch generation |
+

--- a/docs/README_plasticos_facility_profile.md
+++ b/docs/README_plasticos_facility_profile.md
@@ -1,0 +1,150 @@
+# plasticos_facility_profile
+
+**Version:** 19.0.4.1.0
+**Category:** PlasticOS / Operations
+**Depends:** `plasticos_base`, `plasticos_material_profile`, `plasticos_security_base`
+
+---
+
+## Purpose
+
+Manages physical facility profiles for supplier and buyer partners. A **facility profile** is a structured capability record attached to a `res.partner` location — capturing what materials a site can process, at what volumes, to what quality standards, and under what operational constraints.
+
+Facility profiles are the primary data contract between Odoo and the Cognitive Engine Graph (CEG). Every time a profile is created or updated, its capability packet is available for sync to the graph, keeping match quality current.
+
+---
+
+## Architecture
+
+### Key Model: `plasticos.facility.profile`
+
+Extends `res.partner` at the location level. A profile may only be attached to:
+- A **child partner** (location under a parent company), OR
+- A **standalone company** with no child partners (the company itself is the facility)
+
+Person contacts and parent companies with children are explicitly excluded via the `is_facility` computed field (sourced from `plasticos_material_profile.models.res_partner`).
+
+### Partner Extension
+
+`models/res_partner.py` — adds `is_facility` computed boolean (`store=True`, `index=True`) to every `res.partner` record. Logic:
+
+| Condition | `is_facility` |
+|---|---|
+| Has `parent_id` (child/location partner) | `True` |
+| Standalone company, no `child_ids` | `True` |
+| Company with child locations | `False` |
+| Individual person contact | `False` |
+
+**Dependency chain:** `plasticos_facility_profile` depends on `plasticos_material_profile` (which owns the `is_facility` field definition). Do **not** attempt to import from `plasticos_facility_profile` in `plasticos_material_profile` — circular dependency.
+
+---
+
+## Data Model
+
+### `plasticos.facility.profile`
+
+| Field | Type | Description |
+|---|---|---|
+| `partner_id` | `Many2one(res.partner)` | The location-level partner this profile belongs to |
+| `supplier_profile_id` | `Many2one(res.partner)` | Source of truth for dual-supplier resolution |
+| `process_type` | `Selection` | Process codes sourced from `plasticos_material_profile.process_codes.PROCESS_SELECTION` |
+| `feedstock_type` | `Selection` | Inline selection (single-use — acceptable) |
+| `max_monthly_throughput_lbs` | `Float` | Capacity ceiling used in match scoring |
+| `typical_buy_price` | `Float` | Price anchor written to `plasticos.intake.match.typical_price` during matching |
+| `previously_washed` | `Boolean` | |
+| `previously_pelletized` | `Boolean` | |
+| `equipment_type_ids` | `Many2many(plasticos.equipment.type)` | |
+| `certification_ids` | `Many2many(plasticos.certification)` | |
+| `is_food_grade` | `Boolean` | Hard gate in CEG matching |
+| `can_remove_metal` | `Boolean` | Hard gate — Gate 7 in CEG |
+| `can_filter_fr` | `Boolean` | Hard gate — Gate 8 in CEG |
+| `preferred_contact_id` | `Many2one(res.partner)` | Auto-populated when a contact is selected on an intake record for this facility |
+
+### `plasticos.equipment.type` / `plasticos.partner.type`
+
+Master data models for facility equipment and partner role classification.
+
+---
+
+## Process Codes Registry
+
+`process_codes.py` — canonical source for `PROCESS_SELECTION`. All consumers import from here:
+
+```python
+from odoo.addons.plasticos_material_profile.process_codes import PROCESS_SELECTION
+```
+
+> **History:** `process_codes.py` was moved from `plasticos_facility_profile` → `plasticos_material_profile` to eliminate a circular dependency. All consumers updated. Do not move it back.
+
+---
+
+## Views
+
+| View | Description |
+|---|---|
+| `facility_profile_views.xml` | Full form (5 tabs: Capability, Tolerances, Equipment, Quality/Certifications, Operational), list view, search |
+| `facility_profile_actions.xml` | `ir.actions.act_window` + menu item under PlasticOS top-level menu |
+| `facility_profile_ux.xml` | Partner form XPath — injects the **Facility Profile** tab (visible only when `is_facility = True`) |
+| `partner_ux.xml` | Additional partner-level UX overrides |
+| `partner_type_views.xml` | CRUD views for `plasticos.partner.type` master data |
+
+**Tab visibility rule:** The Facility Profile tab on `res.partner` form is controlled by `invisible="not is_facility"`. This field is inherited from `plasticos_material_profile`. Do **not** redefine it here.
+
+---
+
+## Constraints
+
+```python
+@api.constrains('partner_id')
+def _check_partner_is_facility(self):
+    # Profile may only be saved on a child partner or standalone company
+    # Enforced at ORM level — complements the is_facility visibility in views
+```
+
+This constraint is intentionally **complementary** to the view visibility logic, not redundant. The view hides the tab; the constraint blocks saving if somehow reached via API.
+
+---
+
+## Security
+
+- ACL in `security/ir.model.access.csv` — all plasticos groups get appropriate read/write/create/unlink
+- No record rules on this model — all authenticated users with group access can see all facility profiles
+
+---
+
+## Deployment
+
+```bash
+# Odoo.sh: bump version in __manifest__.py, push to staging branch
+# Local Docker (dev only):
+docker compose -p odoo19 run --rm odoo \
+  -d odoo --db-host db --db-port 5432 --db-user odoo --db-password odoo \
+  -u plasticos_facility_profile --stop-after-init
+```
+
+**Requires `--update`** when:
+- Adding new stored computed fields (triggers recompute across all `res.partner`)
+- Changing `ir.model.access.csv`
+- Adding new `ir.actions.act_window` or menu items
+
+---
+
+## Known Gaps / Deferred
+
+| Item | Status |
+|---|---|
+| `emit_capability_packet` method | **Removed** — was dead code (built packet, assigned to local var, discarded). Removed in debt cleanup. |
+| `typical_buy_price` population from market data | Deferred — currently set manually |
+| Freight Bill auto-link to facility | Deferred — manual linking for launch |
+
+---
+
+## Integration Points
+
+| Consumer | How Used |
+|---|---|
+| `plasticos_intake` | `action_match_to_buyers` reads facility profiles for matching; `onchange_facility_id` reads `preferred_contact_id` |
+| `plasticos_material_profile` | Provides `is_facility` computed field used in tab visibility |
+| CEG (external) | Facility sync via `POST /v1/execute` `action=sync` — sends capability packet on profile write |
+| `plasticos_logistics` | Load records reference facility for origin/destination |
+

--- a/docs/README_plasticos_intake.md
+++ b/docs/README_plasticos_intake.md
@@ -1,0 +1,214 @@
+# plasticos_intake
+
+**Version:** 19.0.5.2.0
+**Category:** PlasticOS / Core Pipeline
+**Depends:** `plasticos_base`, `plasticos_material_profile`, `plasticos_facility_profile`, `plasticos_intake_normalizer`, `plasticos_offer`, `plasticos_security_base`
+
+---
+
+## Purpose
+
+`plasticos_intake` is the **entry point of the PlasticOS brokerage pipeline**. It captures a supplier's material availability, drives it through normalization, matching, and offer dispatch — producing `plasticos.offer` records that brokers send to buyers.
+
+This is the highest-traffic module in the system. Every brokerage deal begins here.
+
+---
+
+## Pipeline Overview
+
+```
+Intake Created (draft)
+  │
+  ├─ Normalized (intake_normalizer assembles structured packet)
+  │
+  ├─ action_match_to_buyers() → CEG HTTP POST → match lines written → status: matched
+  │
+  ├─ Broker selects buyers on match lines
+  │
+  ├─ action_send_offers() → plasticos.offer.create() per selected match line → status: offer_sent
+  │
+  └─ Offer accepted → Transaction created → Pipeline complete
+```
+
+---
+
+## Models
+
+### `plasticos.intake`
+
+The primary intake record. ~42KB model.
+
+**Status field** (`status`, not `state`) — selection with the following valid values:
+
+| Value | Label | Set By |
+|---|---|---|
+| `draft` | Draft | Default on create |
+| `processing` | Processing | System (normalizer running) |
+| `matched` | Matched | `action_match_to_buyers()` on success |
+| `offer_sent` | Offers Sent | `action_send_offers()` on success |
+| `won` | Won | Linked transaction closed |
+| `lost` | Lost | Manual or cron expiry |
+| `expired` | Expired | Cron — system-set terminal state, NOT shown in statusbar |
+
+**Statusbar order:** `draft → matched → offer_sent → processing → won/lost`
+`expired` is intentionally excluded from the statusbar widget — it is not a user-navigable step.
+
+#### Key Fields
+
+| Field | Type | Notes |
+|---|---|---|
+| `partner_id` | `Many2one(res.partner)` | Supplier company |
+| `facility_id` | `Many2one(res.partner)` | Location-level partner (`is_facility=True`) |
+| `contact_id` | `Many2one(res.partner)` | Auto-populated from `facility.preferred_contact_id` |
+| `polymer_id` | `Many2one(plasticos.polymer)` | |
+| `form_id` | `Many2one(plasticos.material.form)` | Current form of material |
+| `origin_form_id` | `Many2one(plasticos.material.form)` | What the material was before processing |
+| `origin_process_type` | `Selection` | Imported from `PROCESS_SELECTION` in `plasticos_material_profile.process_codes` |
+| `quantity_per_load_lbs` | `Float` | Used in offer creation and CEG payload |
+| `mfi_value` | `Float` | Melt flow index |
+| `density_value` | `Float` | |
+| `moisture_pct` | `Float` | **Note:** field is `moisture_pct`, NOT `moisture_ppm` — normalizer packet key was corrected |
+| `contamination_pct` | `Float` | |
+| `material_attribute_ids` | `Many2many(plasticos.material.attribute)` | Single source of truth for all condition flags |
+| `has_metal` | `Boolean` | **Computed** from `material_attribute_ids` — `store=True` |
+| `is_metalized` | `Boolean` | **Computed** from `material_attribute_ids` — `store=True` |
+| `has_fr` | `Boolean` | **Computed** from `material_attribute_ids` — `store=True` |
+| `has_residue` | `Boolean` | **Computed** from `contamination_pct` — different pattern, not attribute-synced |
+| `match_line_ids` | `One2many(plasticos.intake.match)` | Written by `action_match_to_buyers()` |
+| `offer_count` | `Integer` | Computed — drives the smart button |
+| `lat` / `lon` | `Float` | Geolocation — passed to CEG for distance scoring |
+| `target_price` | `Float` | Passed to CEG query payload |
+
+#### Boolean Flags — Important History
+
+`has_metal`, `is_metalized`, `has_fr` are **computed** from `material_attribute_ids`. They were previously stored fields with bidirectional `onchange` sync — that pattern was removed as redundant. `material_attribute_ids` is now the single source of truth. The computed values are wired to `store=True` so CEG consumers can still query them via SQL.
+
+`has_residue` is a **separate computed field** derived from `contamination_pct` — it is NOT attribute-synced and was deliberately left as-is.
+
+---
+
+### `plasticos.intake.match`
+
+One record per buyer candidate returned by the CEG.
+
+| Field | Type | Notes |
+|---|---|---|
+| `intake_id` | `Many2one(plasticos.intake)` | Parent |
+| `buyer_partner_id` | `Many2one(res.partner)` | Matched buyer |
+| `buyer_name` | `Char` | Denormalized from CEG response |
+| `match_score` | `Float` | 0–100, normalized from CEG 0–1 |
+| `match_reason` | `Text` | Gate failure summary |
+| `facility_profile_id` | `Many2one(plasticos.facility.profile)` | Buyer's matching facility |
+| `typical_price` | `Float` | From `facility.typical_buy_price` — price anchor for offer creation |
+| `is_selected` | `Boolean` | Broker selects/deselects per row before sending offers |
+
+---
+
+## Key Methods
+
+### `action_match_to_buyers()`
+
+**Entry point for matching.** Calls `create_material_profile_from_intake()` to ensure a material profile exists, then makes an HTTP POST to the CEG:
+
+```
+POST {plasticos.graphengine.url}/v1/execute
+Authorization: Bearer {plasticos.graphengine.apikey}
+{
+  "action": "match",
+  "tenant": "plasticos",
+  "payload": {
+    "match_direction": "intake_to_buyer",
+    "query": { ...intake fields... },
+    "top_n": 20
+  }
+}
+```
+
+On success: clears stale `match_line_ids`, writes new match lines, advances `status` to `matched`.
+
+**Config params required:**
+- `plasticos.graphengine.url` (e.g., `https://ceg.yourdomain.com`)
+- `plasticos.graphengine.apikey`
+- `plasticos.matching.engine.enabled` → `True`
+
+### `action_send_offers()`
+
+Loops over **selected** match lines → creates one `plasticos.offer` per line → advances `status` to `offer_sent` → returns list view of created offers.
+
+```python
+# Offer creation per selected match line:
+self.env['plasticos.offer'].create({
+    'intake_id': self.id,
+    'buyer_partner_id': match.buyer_partner_id.id,
+    'match_line_id': match.id,
+    'offered_price': match.typical_price or 0.0,
+    'quantity': self.quantity_per_load_lbs,
+})
+```
+
+### `create_material_profile_from_intake()`
+
+Creates a `plasticos.material.profile` from intake data if one doesn't exist for this partner/polymer/form combination.
+
+**Key fix applied:** `name` key was removed from `profilevals` — `plasticos.material.profile` has no `name` field. Profile identity is defined by `(partner_id, polymer_id)` order.
+
+### `onchange_facility_id()`
+
+Auto-populates `contact_id` from `facility.preferred_contact_id`. Uses the correct field name (`preferred_contact_id`, not `x_preferred_contact_id` — migration renamed it).
+
+---
+
+## Views
+
+| File | Description |
+|---|---|
+| `intake_views.xml` | Full form (Specs, Facility Info, Normalization tabs), list, search, kanban |
+| `intake_match_views.xml` | Embedded list of match lines with `is_selected` toggle and score |
+
+**Smart button — Offers:** `offer_count` field + `action_view_offers()` → drives the "X Offers" smart button on the intake form.
+
+---
+
+## Crons
+
+| Cron | Action | Schedule |
+|---|---|---|
+| PlasticOS Intake Expiry | Sets `status = expired` on intakes past threshold | Daily |
+
+`ir.config_parameter` key: `plasticos.intake.expiry_days` (default: 90)
+
+---
+
+## Deployment
+
+```bash
+docker compose -p odoo19 run --rm odoo \
+  -d odoo --db-host db --db-port 5432 --db-user odoo --db-password odoo \
+  -u plasticos_intake --stop-after-init
+```
+
+**Requires `--update`** when adding stored fields, changing ACL, or adding new cron XML.
+
+---
+
+## Integration Points
+
+| Module / System | Direction | Notes |
+|---|---|---|
+| `plasticos_intake_normalizer` | Outbound | `assemble_packet()` builds the structured dict for CEG |
+| `plasticos_material_profile` | Bidirectional | Profile created from intake; `origin_process_type` sourced from shared registry |
+| `plasticos_offer` | Outbound | `action_send_offers()` creates offer records |
+| CEG (external repo) | HTTP POST | `POST /v1/execute` — match action |
+| `plasticos_claims` | Inbound bridge | Claims bridge injects `action_view_claims()` via `_inherit` — do NOT redefine on this model |
+
+---
+
+## Known Gaps / Pending
+
+| Item | Priority | Notes |
+|---|---|---|
+| CEG HTTP client (`graphservice.py`) | **GATE** | Without this, `action_match_to_buyers()` returns no results |
+| `typical_price` population | High | Populated once CEG returns `typical_buy_price` from facility profile |
+| `offer_count` smart button | Medium | Field exists; XML button may need review |
+| Intake expiry cron | Medium | XML + Python method — 15-min write |
+

--- a/docs/README_plasticos_intake_normalizer.md
+++ b/docs/README_plasticos_intake_normalizer.md
@@ -1,0 +1,96 @@
+# plasticos_intake_normalizer
+
+**Version:** 19.0.2.0.0
+**Category:** PlasticOS / Data Processing
+**Depends:** `plasticos_base`, `plasticos_intake`, `plasticos_material_profile`, `plasticos_facility_profile`
+
+---
+
+## Purpose
+
+Normalizes raw intake form data into a structured, typed packet suitable for the Cognitive Engine Graph (CEG) and downstream matching logic. This module adds the **Normalization tab** to the intake form and owns the `assemble_packet()` method.
+
+Think of this module as the intake data adapter — it translates human-entered form values (text, selections, floats) into a clean, schema-validated dict that the CEG can consume.
+
+---
+
+## Model: `plasticos.intake.normalizer`
+
+Extends `plasticos.intake` via `_inherit`.
+
+### Key Method: `assemble_packet()`
+
+Builds the CEG query payload from the current intake record. Called by `action_match_to_buyers()` before the HTTP POST.
+
+**Packet structure:**
+
+```python
+{
+    "polymer": self.polymer_id.code,
+    "form": self.form_id.code,
+    "origin_form": self.origin_form_id.code if self.origin_form_id else None,
+    "origin_process": self.origin_process_type,
+    "source_type": self.source_type_id.name if self.source_type_id else None,
+    "volume": {
+        "qty_per_load_lbs": self.quantity_per_load_lbs,
+        "loads_per_month": self.loads_per_month,
+    },
+    "quality": {
+        "mfi_value": self.mfi_value or None,
+        "density_value": self.density_value or None,
+        "moisture_pct": self.moisture_pct or None,      # ← correct field name (was moisture_ppm — fixed)
+        "contamination_total_pct": self.contamination_total_pct or None,
+    },
+    "condition": {
+        "material_attributes": self.material_attribute_ids.mapped('code'),
+    },
+    "geo": {
+        "lat": self.lat,
+        "lon": self.lon,
+    },
+    "target_price": self.target_price,
+}
+```
+
+**Critical fix history:** Line 395 previously referenced `self.moisture_ppm` — field does not exist on `plasticos.intake`. Corrected to `self.moisture_pct`. Dict key also corrected from `moisture_ppm` → `moisture_pct`. When the L9/CEG adapter is wired, any PPM conversion (`moisture_pct * 10000`) belongs at the adapter boundary, not here.
+
+---
+
+## Views
+
+| File | Description |
+|---|---|
+| `intake_normalizer_views.xml` | Adds the **Normalization** tab to `plasticos.intake` form via XPath |
+
+The Normalization tab displays the assembled packet fields and provides a "Re-Normalize" action for manual refresh.
+
+---
+
+## Process Codes
+
+`origin_process_type` is a `Selection` field. Imported from:
+```python
+from odoo.addons.plasticos_material_profile.process_codes import PROCESS_SELECTION
+```
+
+---
+
+## Deployment
+
+```bash
+docker compose -p odoo19 run --rm odoo \
+  -d odoo --db-host db --db-port 5432 --db-user odoo --db-password odoo \
+  -u plasticos_intake_normalizer --stop-after-init
+```
+
+No DB migration needed for packet logic changes (all computed, no stored fields modified).
+
+---
+
+## Integration Points
+
+| Consumer | How Used |
+|---|---|
+| `plasticos_intake.action_match_to_buyers()` | Calls `assemble_packet()` to build CEG POST body |
+| CEG (external) | Consumes the packet dict via the HTTP POST body |
+

--- a/docs/README_plasticos_material_profile.md
+++ b/docs/README_plasticos_material_profile.md
@@ -1,0 +1,159 @@
+# plasticos_material_profile
+
+**Version:** 19.0.4.2.0
+**Category:** PlasticOS / Master Data
+**Depends:** `plasticos_base`
+
+---
+
+## Purpose
+
+Owns the **canonical material master registries** for PlasticOS: polymer types, material forms, colors, source types, process codes, and all master data that defines what a material *is*. Every other module that classifies materials depends on this one.
+
+Also manages `plasticos.material.profile` — the structured material capability record attached to a partner (buyer or supplier) that captures their material preferences, tolerances, and specifications.
+
+---
+
+## Registries Owned
+
+### `process_codes.py` — `PROCESS_SELECTION`
+
+**Canonical source for all process type selection lists.** Located at `plasticos_material_profile/process_codes.py`.
+
+Import pattern used by all consumers:
+```python
+from odoo.addons.plasticos_material_profile.process_codes import PROCESS_SELECTION
+```
+
+> **History:** Previously lived in `plasticos_facility_profile`. Moved here to eliminate a circular dependency (`plasticos_facility_profile` depends on `plasticos_material_profile` — the reverse import would be circular). All 3 in-repo consumers updated. External consumers in `plasticos_buyer_match_engine` / `plasticos_inference_engine` will be updated when those microservice repos are wired.
+
+### Master Data Models
+
+| Model | Description |
+|---|---|
+| `plasticos.polymer` | Polymer type master (HDPE, LDPE, PP, PET, etc.) |
+| `plasticos.material.form` | Material form (Pellets, Regrind, Flake, Film, etc.) |
+| `plasticos.material.color` | Color classification |
+| `plasticos.source.type` | Material origin/source type |
+| `plasticos.material.attribute` | Attribute tags (with_metal, metalized, flame_retardant, etc.) |
+| `plasticos.process.type` | Process type master records |
+| `plasticos.filler.type` | Filler type master (fiberglass, talc, carbon black, etc.) |
+
+---
+
+## Model: `plasticos.material.profile`
+
+Structured material record attached to a `res.partner`. Identity is defined by `(partner_id, polymer_id)` — there is **no `name` field**.
+
+> **Critical:** Do not attempt to set `name` in `create()` vals — `plasticos.material.profile` has no `name` field. The ORM will raise `ValueError: Invalid field 'name' in 'plasticos.material.profile'`. Profile display uses `display_name` (falls back to `polymer_id.name + partner_id.name`).
+
+### Key Fields
+
+| Field | Type | Notes |
+|---|---|---|
+| `partner_id` | `Many2one(res.partner)` | Determines profile ownership |
+| `polymer_id` | `Many2one(plasticos.polymer)` | |
+| `form_id` | `Many2one(plasticos.material.form)` | |
+| `origin_form_id` | `Many2one(plasticos.material.form)` | What the material was before processing — distinct from `form_id` |
+| `origin_process_type` | `Selection(PROCESS_SELECTION)` | From `process_codes.py` |
+| `color_id` | `Many2one(plasticos.material.color)` | |
+| `source_type_id` | `Many2one(plasticos.source.type)` | |
+| `material_attribute_ids` | `Many2many(plasticos.material.attribute)` | Single source of truth for condition flags |
+| `has_metal` | `Boolean` | **Computed** from `material_attribute_ids` — `store=True` |
+| `is_metalized` | `Boolean` | **Computed** from `material_attribute_ids` — `store=True` |
+| `has_fr` | `Boolean` | **Computed** from `material_attribute_ids` — `store=True` |
+| `moisture_percent` | `Float` | |
+| `contamination_percent` | `Float` | |
+| `melt_flow_index` | `Float` | |
+| `density` | `Float` | |
+| `filler_type_id` | `Many2one(plasticos.filler.type)` | |
+| `filler_pct` | `Float` | |
+| `previously_washed` | `Boolean` | |
+| `previously_pelletized` | `Boolean` | |
+
+### `is_facility` Computed Field
+
+`models/res_partner.py` adds `is_facility` to every `res.partner`:
+
+```python
+is_facility = fields.Boolean(
+    compute='_compute_is_facility',
+    store=True, index=True
+)
+```
+
+Logic mirrors the facility profile constraint: child partners → True; standalone companies (no children) → True; parent companies with children → False; person contacts → False.
+
+**This field is the source of truth** used by `plasticos_facility_profile` views to control Facility Profile tab visibility. Do not redefine it in `plasticos_facility_profile`.
+
+### Boolean Flags — History
+
+`has_metal`, `is_metalized`, `has_fr` were previously stored fields with bidirectional `onchange` sync (± `material_attribute_ids`). That pattern was removed — booleans are now **computed** from attributes. `material_attribute_ids` is the single source of truth.
+
+**`has_residue` was deliberately left** as a computed field from `contamination_pct` — different semantic, different pattern. Not attribute-synced.
+
+### `emit_material_packet()`
+
+Builds the material capability packet dict for CEG sync:
+
+```python
+{
+    "polymer": rec.polymer_id.code,
+    "form": rec.form_id.code,
+    "source_type_name": rec.source_type_id.name,
+    "origin_process": rec.origin_process_type,
+    "condition": {
+        "has_metal": rec.has_metal,
+        "is_metalized": rec.is_metalized,
+        "has_fr": rec.has_fr,
+    },
+    "filler": {
+        "type": rec.filler_type_id.code if rec.filler_type_id else None,
+        "pct": rec.filler_pct,
+    },
+    # ... full packet
+}
+```
+
+---
+
+## `plasticos.material.attribute`
+
+Master tag model for material condition flags.
+
+| Field | Notes |
+|---|---|
+| `code` | Machine-readable code (`with_metal`, `metalized`, `flame_retardant`, etc.) |
+| `name` | Display label |
+
+> **Cleanup note:** `boolean_field` and `boolean_value` metadata fields were removed from this model — they referenced the deleted boolean sync onchanges and were vestigial. The XML data file was also cleaned.
+
+---
+
+## Constraint
+
+```python
+@api.constrains('partner_id')
+def _check_partner_is_facility(self):
+    # Profiles may only be created for partners where is_facility = True
+```
+
+After the boolean cleanup, this constraint was updated to use `is_facility` (from `plasticos_material_profile.res_partner`) instead of `parent_id`. Standalone companies can now have material profiles.
+
+---
+
+## Security
+
+- `ir.model.access.csv` — full ACL for all registry models
+- No record rules — master data is globally readable by all authenticated users
+
+---
+
+## Deployment
+
+```bash
+docker compose -p odoo19 run --rm odoo \
+  -d odoo --db-host db --db-port 5432 --db-user odoo --db-password odoo \
+  -u plasticos_material_profile --stop-after-init
+```
+

--- a/docs/README_plasticos_offer.md
+++ b/docs/README_plasticos_offer.md
@@ -1,0 +1,100 @@
+# plasticos_offer
+
+**Version:** 19.0.3.1.0
+**Category:** PlasticOS / Core Pipeline
+**Depends:** `plasticos_base`, `plasticos_intake`, `plasticos_material_profile`, `plasticos_security_base`
+
+---
+
+## Purpose
+
+`plasticos_offer` manages the offer records sent to buyers after intake matching. An offer represents a specific broker proposal: "we have X lbs of Y polymer from Z supplier, at P price per lb — are you interested?"
+
+Offers are created automatically by `plasticos_intake.action_send_offers()` and drive the intake status machine from `matched` → `offer_sent`.
+
+---
+
+## Model: `plasticos.offer`
+
+~16KB model with a full state machine.
+
+### States
+
+| Value | Label | Transition |
+|---|---|---|
+| `draft` | Draft | Default on create |
+| `sent` | Sent | Auto-set when offer is created via `action_send_offers()` |
+| `accepted` | Accepted | Buyer confirms interest |
+| `declined` | Declined | Buyer passes |
+| `expired` | Expired | Cron — system-set terminal state |
+| `cancelled` | Cancelled | Manual |
+
+### Key Fields
+
+| Field | Type | Notes |
+|---|---|---|
+| `intake_id` | `Many2one(plasticos.intake)` | Parent intake |
+| `buyer_partner_id` | `Many2one(res.partner)` | Buyer the offer was sent to |
+| `match_line_id` | `Many2one(plasticos.intake.match)` | Source match line (carries `match_score`, `facility_profile_id`) |
+| `offered_price` | `Float` | Seeded from `match_line.typical_price`; broker can override |
+| `quantity` | `Float` | In lbs — from `intake.quantity_per_load_lbs` |
+| `expiry_date` | `Date` | Set on creation from `ir.config_parameter` `plasticos.offer.expiry_days` |
+| `transaction_id` | `Many2one(plasticos.transaction)` | Populated when offer is accepted and transaction created |
+| `broker_id` | `Many2one(res.users)` | Assigned broker |
+
+### Key Methods
+
+| Method | Description |
+|---|---|
+| `action_accept()` | Advances to `accepted`; posts chatter notification to broker; sets `intake` to `won` if all offers resolved |
+| `action_decline()` | Advances to `declined`; posts chatter |
+| `action_create_transaction()` | Creates `plasticos.transaction` from accepted offer; links back via `transaction_id` |
+
+---
+
+## Crons
+
+| Cron | Action | Schedule |
+|---|---|---|
+| PlasticOS Offer Expiry | Sets `state = expired` on offers past `expiry_date` | Daily |
+
+Config param: `plasticos.offer.expiry_days` (default: 14)
+
+---
+
+## Views
+
+| File | Description |
+|---|---|
+| `offer_views.xml` | Form, list, search, kanban grouped by `state` |
+
+---
+
+## Deployment
+
+```bash
+docker compose -p odoo19 run --rm odoo \
+  -d odoo --db-host db --db-port 5432 --db-user odoo --db-password odoo \
+  -u plasticos_offer --stop-after-init
+```
+
+---
+
+## Integration Points
+
+| Module | Direction | Notes |
+|---|---|---|
+| `plasticos_intake` | Inbound | `action_send_offers()` calls `plasticos.offer.create()` |
+| `plasticos_transaction` | Outbound | `action_create_transaction()` creates a transaction on acceptance |
+| `plasticos_commission` | Downstream | Commission calculated when linked transaction is won |
+
+---
+
+## Pending
+
+| Item | Priority |
+|---|---|
+| Offer accept → chatter notification to broker (activity + message) | High |
+| Offer expiry cron XML | Medium |
+| "View Offers" smart button on intake form (`offer_count`) | Medium |
+

--- a/docs/README_plasticos_partner_import.md
+++ b/docs/README_plasticos_partner_import.md
@@ -1,0 +1,85 @@
+# plasticos_partner_import
+
+**Version:** 19.0.2.1.0
+**Category:** PlasticOS / Data Operations
+**Depends:** `plasticos_base`, `plasticos_facility_profile`, `plasticos_material_profile`, `plasticos_security_base`
+
+---
+
+## Purpose
+
+Provides bulk partner import tooling for loading CRM leads, supplier contacts, and facility data from external CSV sources (VanillaSoft CRM, broker spreadsheets, historical records). Used for initial data migration and ongoing batch imports from sales tooling.
+
+---
+
+## Models
+
+### `plasticos.partner.import.wizard` (TransientModel)
+
+The primary import UI. Accepts a CSV file, maps columns to `res.partner` fields, previews the mapping, and executes the import with deduplication logic.
+
+**Key fields:**
+
+| Field | Notes |
+|---|---|
+| `import_file` | Binary CSV upload |
+| `file_name` | |
+| `facility_role` | Role to assign imported partners — was `x_facility_role` (x-field), renamed via migration, fixed in code |
+| `import_mode` | `create_only / update_only / upsert` |
+| `dedup_key` | Field to use for deduplication (email, phone, vanillasoft_id) |
+| `preview_line_ids` | `One2many` — first 10 rows shown in form before commit |
+| `result_summary` | Text summary after import |
+
+---
+
+## Service: `crm_lead_import_service.py`
+
+Processes CRM lead CSVs exported from VanillaSoft. Maps VanillaSoft fields to Odoo `res.partner` and `crm.lead` fields.
+
+**Key field rename history:**
+- `x_vanillasoft_id` → `vanillasoft_id` (migration 19.0.1.x renamed the DB column)
+- `x_facility_role` → `facility_role` (same migration sweep)
+- All code references corrected during the x-field cleanup sweep
+
+**Deduplication logic:** Checks existing partners by `vanillasoft_id` first, then falls back to email, then phone. Creates new or updates existing depending on `import_mode`.
+
+---
+
+## Views
+
+| File | Description |
+|---|---|
+| `partner_import_wizard_views.xml` | Import wizard form — file upload, column mapping, preview grid, result summary |
+
+**Button labels:** All reference `facility_role` (not `x_facility_role`) after the rename fix.
+
+---
+
+## Migrations
+
+| Version | Change |
+|---|---|
+| `19.0.1.1.0` | Renames `x_vanillasoft_id` → `vanillasoft_id` in DB |
+| `19.0.1.2.0` | Renames `x_facility_role` → `facility_role` in DB |
+
+**Note:** Migration scripts reference the old `x_` names intentionally — that is correct behavior for migration files. Do not treat those as bugs.
+
+---
+
+## Deployment
+
+```bash
+docker compose -p odoo19 run --rm odoo \
+  -d odoo --db-host db --db-port 5432 --db-user odoo --db-password odoo \
+  -u plasticos_partner_import --stop-after-init
+```
+
+---
+
+## Integration Points
+
+| Module | Notes |
+|---|---|
+| `plasticos_facility_profile` | Imported partners can be assigned facility profiles post-import |
+| `plasticos_crm_bridge` | CRM leads created from import can be bridged to the plasticos pipeline |
+

--- a/docs/README_plasticos_transaction.md
+++ b/docs/README_plasticos_transaction.md
@@ -1,0 +1,140 @@
+# plasticos_transaction
+
+**Version:** 19.0.6.1.0
+**Category:** PlasticOS / Core Pipeline
+**Depends:** `plasticos_base`, `plasticos_offer`, `plasticos_material_profile`, `plasticos_facility_profile`, `plasticos_logistics`, `plasticos_accounting`, `plasticos_commission`, `plasticos_security_base`
+
+---
+
+## Purpose
+
+The transaction model is the **financial and operational record** of a closed deal. It bridges supplier intake, buyer offer, logistics, accounting, and commission into a single lifecycle record. This is the most complete model in the codebase (~54KB).
+
+Every won deal has a transaction. Transactions drive gross margin reporting, commission calculation, freight bill linking, and document compliance tracking.
+
+---
+
+## Model: `plasticos.transaction`
+
+### States
+
+| Value | Label | Notes |
+|---|---|---|
+| `draft` | Draft | Default |
+| `active` | Active | Deal in progress |
+| `in_transit` | In Transit | Load picked up |
+| `delivered` | Delivered | Load confirmed delivered |
+| `invoiced` | Invoiced | Invoice raised |
+| `closed` | Closed | Fully settled |
+| `cancelled` | Cancelled | |
+| `dispute` | Dispute | Claims triggered |
+
+**Statusbar visible:** `draft, active, closed` (current — see Pending section for full-state expansion).
+
+---
+
+### Key Fields
+
+| Field | Type | Notes |
+|---|---|---|
+| `offer_id` | `Many2one(plasticos.offer)` | Source offer |
+| `intake_id` | `Many2one(plasticos.intake)` | Source intake (via offer) |
+| `supplier_id` | `Many2one(res.partner)` | |
+| `buyer_id` | `Many2one(res.partner)` | |
+| `supplier_profile_id` | `Many2one(plasticos.facility.profile)` | **Source of truth** for dual-supplier resolution |
+| `material_profile_id` | `Many2one(plasticos.material.profile)` | |
+| `load_id` | `Many2one(plasticos.load)` | Linked logistics load |
+| `freight_bill_id` | `Many2one(account.move)` | Freight invoice — currently **manual link** |
+| `sale_price` | `Float` | What the buyer pays |
+| `buy_price` | `Float` | What the supplier is paid |
+| `freight_cost` | `Float` | |
+| `gross_margin` | `Float` | **Computed:** `sale_price - buy_price - freight_cost` |
+| `amount_total` | `Float` | **Computed** — `@api.depends` must include `state` for accrual-basis accuracy |
+| `weight_lbs` | `Float` | Actual shipped weight |
+| `commission_id` | `Many2one(plasticos.commission)` | Populated when commission is calculated |
+| `broker_id` | `Many2one(res.users)` | |
+| `line_ids` | `One2many(plasticos.transaction.line)` | |
+| `claim_ids` | `One2many(plasticos.claim)` | Via bridge in `plasticos_claims` |
+| `document_ids` | `One2many(plasticos.document)` | Compliance doc attachments |
+
+### `amount_total` — Important
+
+`amount_total` uses accrual-basis logic. **`@api.depends` must include `state`** — without it, the gross margin KPI banners in `transaction_ux.xml` can display stale values when a deal is cancelled or reverted to draft.
+
+---
+
+## Smart Buttons
+
+| Button | Method | Source |
+|---|---|---|
+| Claims | `action_view_claims()` | **Defined in `plasticos_claims` bridge** — do NOT redefine here |
+| Lines | `action_view_lines()` | Defined in `transaction.py` — added in GMP-001 |
+| Load | `action_view_load()` | Defined in `transaction.py` |
+| Commission | `action_view_commission()` | Defined in `transaction.py` |
+
+> **Critical:** `action_view_claims()` is injected by `plasticos_claims` via `_inherit = 'plasticos.transaction'`. Adding a duplicate in `transaction.py` would shadow the bridge method. Never redefine it here.
+
+---
+
+## Views
+
+| File | Description |
+|---|---|
+| `transaction_views.xml` | Primary form (tabs: General, Financials, Logistics, Documents, Commission), list, search |
+| `transaction_ux.xml` | KPI banner overlays, gross margin highlights |
+
+---
+
+## Import Wizard
+
+`wizards/transaction_import_wizard.py` — imports historical transaction data from a CIETrade CSV export.
+
+**Default file:** `cieTrade.WksDetail.Test.csv` at the **repo root** (51-line test file). The production file (`cieTrade.WksDetail.csv`, 16,417+ rows) is excluded from the default path.
+
+Path resolution: `os.path.join(module_path, os.pardir, DEFAULT_CSV)` — looks one level up from the module directory (repo root).
+
+---
+
+## Crons
+
+| Cron | Action | Schedule |
+|---|---|---|
+| PlasticOS Sale Approval Flag | Flags transactions needing approval | Daily |
+| PlasticOS Midnight Time-Based Field Recompute | Recomputes time-sensitive computed fields | Nightly 00:05 |
+
+---
+
+## Deployment
+
+```bash
+docker compose -p odoo19 run --rm odoo \
+  -d odoo --db-host db --db-port 5432 --db-user odoo --db-password odoo \
+  -u plasticos_transaction --stop-after-init
+```
+
+**No `--update` needed** for method additions (no new stored fields). Required for new fields, ACL changes.
+
+---
+
+## Integration Points
+
+| Module | Direction | Notes |
+|---|---|---|
+| `plasticos_offer` | Inbound | Created from `offer.action_create_transaction()` |
+| `plasticos_logistics` | Bidirectional | `load_id` links to shipment; load state drives transaction state |
+| `plasticos_accounting` | Outbound | `freight_bill_id` links to `account.move` — currently manual |
+| `plasticos_commission` | Outbound | Commission calculated on `state = closed` |
+| `plasticos_claims` | Bridge | Claims bridge injects `action_view_claims()` and `claim_ids` |
+
+---
+
+## Known Gaps / Pending
+
+| Item | Priority | Notes |
+|---|---|---|
+| `amount_total @api.depends` missing `state` | High | KPI banners show stale values on cancel/revert |
+| `supplier_profile_id` as source of truth | High | Currently informational; downstream views still use `supplier_id` directly |
+| Freight Bill Auto-Link | Low | Complex heuristic (weight ±5%, date ±7 days, same carrier) — manual for launch |
+| Full statusbar (all 8 states) | Medium | Currently only shows `draft, active, closed` |
+| Commission auto-trigger on `state = closed` | High | `commission_service.calculate()` not yet called from transaction write |
+


### PR DESCRIPTION
## Summary

- 10 README files added to docs/ covering all major PlasticOS modules
- .gitignore updated: docs/*.ai, *.pdf, *.png, *.jpg kept local; docs/README_*.md now tracked

## Modules documented
commission, facility_profile, intake, intake_normalizer, material_profile, offer, partner_import, transaction + index + backup/github-actions guide

## Test plan
- [ ] CI passes (docs-only change)