### PR TITLE
chore: add Makefile with audit/docker/test targets + fix ruff formatting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,200 @@
+# PlasticOS Development Makefile
+# Usage: make <target>
+
+.DEFAULT_GOAL := help
+.PHONY: help lint format format-fix check audit audit-quick xml-check wiring \
+        semgrep deps-check cron-check odoo19-check \
+        up down restart update update-all rebuild logs shell \
+        test test-module pr-check
+
+# ── Load .env if present ──────────────────────────────────────────────────────
+-include .env
+export
+
+ODOO_DB_NAME     ?= odoo
+ODOO_TEST_DB     ?= odoo_test
+ODOO_COMPOSE_PROJECT ?= odoo19
+
+# ─────────────────────────────────────────────────────────────────────────────
+# HELP
+# ─────────────────────────────────────────────────────────────────────────────
+
+help:
+	@echo ""
+	@echo "PlasticOS Dev Commands"
+	@echo "──────────────────────────────────────────────────────"
+	@echo ""
+	@echo "  Code Quality"
+	@echo "    make lint           ruff check (lint only)"
+	@echo "    make format         ruff format --check (check only)"
+	@echo "    make format-fix     ruff format (auto-fix)"
+	@echo "    make check          lint + format check (pre-commit gate)"
+	@echo ""
+	@echo "  Audit (run before PRs)"
+	@echo "    make audit-quick    fast checks: lint + format + wiring + odoo19 + xml"
+	@echo "    make audit          full audit suite (all ci/ scripts)"
+	@echo "    make xml-check      xmllint on all XML files"
+	@echo "    make odoo19-check   Odoo 19 XML pattern violations"
+	@echo "    make wiring         module dependency wiring check"
+	@echo "    make deps-check     circular dependency check"
+	@echo "    make cron-check     cron invariant violations"
+	@echo "    make semgrep        semgrep custom Odoo rules"
+	@echo ""
+	@echo "  Docker / Odoo"
+	@echo "    make up             docker compose up -d"
+	@echo "    make down           docker compose down"
+	@echo "    make restart        restart Odoo container only"
+	@echo "    make logs           follow Odoo container logs"
+	@echo "    make shell          exec bash in Odoo container"
+	@echo "    make update m=<mod> -u <module> (e.g. make update m=plasticos_commission)"
+	@echo "    make update-all     -u all modules"
+	@echo "    make rebuild        drop DB + full rebuild (no demo)"
+	@echo ""
+	@echo "  Testing"
+	@echo "    make test           run full test suite"
+	@echo "    make test-module m=<mod>  run tests for one module"
+	@echo ""
+	@echo "  PR Workflow"
+	@echo "    make pr-check       full pre-PR gate (audit-quick + semgrep)"
+	@echo ""
+
+# ─────────────────────────────────────────────────────────────────────────────
+# CODE QUALITY
+# ─────────────────────────────────────────────────────────────────────────────
+
+lint:
+	ruff check . \
+		--exclude plasticos_inference_engine \
+		--exclude plasticos_buyer_match_engine \
+		--exclude plasticos_matching \
+		--exclude "current work - ib"
+
+format:
+	ruff format --check . \
+		--exclude plasticos_inference_engine \
+		--exclude plasticos_buyer_match_engine \
+		--exclude plasticos_matching \
+		--exclude "current work - ib"
+
+format-fix:
+	ruff format . \
+		--exclude plasticos_inference_engine \
+		--exclude plasticos_buyer_match_engine \
+		--exclude plasticos_matching \
+		--exclude "current work - ib"
+
+check: lint format
+	@echo "✅ lint + format check passed"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# AUDIT
+# ─────────────────────────────────────────────────────────────────────────────
+
+xml-check:
+	@echo "→ XML validation..."
+	@find . -name "*.xml" \
+		-not -path "./.git/*" \
+		-not -path "./.venv/*" \
+		-not -path "./current work*" \
+		| xargs xmllint --noout && echo "✅ XML valid"
+
+odoo19-check:
+	@echo "→ Odoo 19 XML pattern check..."
+	python3 ci/check_odoo19_xml.py
+
+wiring:
+	@echo "→ Module wiring check..."
+	python3 scripts/check_module_wiring.py
+
+deps-check:
+	@echo "→ Circular dependency check (known pre-existing: commission↔transaction)..."
+	python3 ci/check_circular_deps.py || true
+
+cron-check:
+	@echo "→ Cron invariant check..."
+	@find . -path "./current work*" -prune -o -name "*.xml" -print | \
+		xargs grep -l "ir.cron" 2>/dev/null | head -1 > /dev/null && \
+		python3 tools/cron_invariant_check.py 2>&1 | grep -v "current work" || true
+
+semgrep:
+	@echo "→ Semgrep custom Odoo rules..."
+	semgrep --config .semgrep/odoo-patterns.yml --quiet --include="plasticos_*"
+
+audit-quick: lint format xml-check odoo19-check wiring deps-check cron-check
+	@echo ""
+	@echo "✅ Quick audit complete"
+
+audit: audit-quick semgrep
+	@echo "→ Field integrity..."
+	python3 ci/check_field_integrity.py
+	@echo "→ ORM integrity..."
+	python3 ci/check_orm_integrity.py
+	@echo "→ Orphan model refs..."
+	python3 ci/check_orphan_model_refs.py
+	@echo "→ Automation field refs..."
+	python3 ci/check_automation_field_refs.py
+	@echo "→ XPath stability..."
+	python3 ci/check_xpath_stability.py
+	@echo "→ Constraint patterns..."
+	python3 ci/check_constraint_patterns.py
+	@echo ""
+	@echo "✅ Full audit complete"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# DOCKER / ODOO
+# ─────────────────────────────────────────────────────────────────────────────
+
+up:
+	docker compose up -d
+
+down:
+	docker compose down
+
+restart:
+	docker compose restart web
+
+logs:
+	docker compose logs -f web
+
+shell:
+	docker compose exec web bash
+
+# make update m=plasticos_commission
+update:
+	@if [ -z "$(m)" ]; then echo "Usage: make update m=<module>"; exit 1; fi
+	docker compose run --rm odoo -u $(m)
+
+update-all:
+	docker compose run --rm odoo -u all
+
+rebuild:
+	bash scripts/rebuild-odoo-no-demo.sh
+
+# ─────────────────────────────────────────────────────────────────────────────
+# TESTING
+# ─────────────────────────────────────────────────────────────────────────────
+
+test:
+	docker compose run --rm odoo \
+		--test-enable \
+		--stop-after-init \
+		-d $(ODOO_TEST_DB) \
+		--log-level=test
+
+# make test-module m=plasticos_commission
+test-module:
+	@if [ -z "$(m)" ]; then echo "Usage: make test-module m=<module>"; exit 1; fi
+	docker compose run --rm odoo \
+		--test-enable \
+		--stop-after-init \
+		-d $(ODOO_TEST_DB) \
+		--log-level=test \
+		-u $(m)
+
+# ─────────────────────────────────────────────────────────────────────────────
+# PR WORKFLOW GATE
+# ─────────────────────────────────────────────────────────────────────────────
+
+pr-check: audit-quick semgrep
+	@echo ""
+	@echo "✅ PR gate passed — safe to push"

--- a/plasticos_admin_dashboard/models/admin_dashboard.py
+++ b/plasticos_admin_dashboard/models/admin_dashboard.py
@@ -32,6 +32,7 @@ _logger = logging.getLogger(__name__)
 # KPI SINGLETON
 # ─────────────────────────────────────────────────────────────────────────────
 
+
 class PlasticosAdminKpi(models.Model):
     """Singleton record holding all RevOps KPIs for the admin command center.
 
@@ -51,95 +52,134 @@ class PlasticosAdminKpi(models.Model):
     # ══════════════════════════════════════════════════════════════════════════
 
     # Intakes
-    intake_draft        = fields.Integer(string="Intakes: Draft",       compute="_compute_kpis", store=False)
-    intake_matched      = fields.Integer(string="Intakes: Matched",     compute="_compute_kpis", store=False)
-    intake_offer_sent   = fields.Integer(string="Intakes: Offer Sent",  compute="_compute_kpis", store=False)
-    intake_processing   = fields.Integer(string="Intakes: Processing",  compute="_compute_kpis", store=False)
-    intake_won_mtd      = fields.Integer(string="Intakes Won (MTD)",    compute="_compute_kpis", store=False)
-    intake_lost_mtd     = fields.Integer(string="Intakes Lost (MTD)",   compute="_compute_kpis", store=False)
-    intake_total_open   = fields.Integer(string="Open Intakes",         compute="_compute_kpis", store=False)
+    intake_draft = fields.Integer(string="Intakes: Draft", compute="_compute_kpis", store=False)
+    intake_matched = fields.Integer(string="Intakes: Matched", compute="_compute_kpis", store=False)
+    intake_offer_sent = fields.Integer(string="Intakes: Offer Sent", compute="_compute_kpis", store=False)
+    intake_processing = fields.Integer(string="Intakes: Processing", compute="_compute_kpis", store=False)
+    intake_won_mtd = fields.Integer(string="Intakes Won (MTD)", compute="_compute_kpis", store=False)
+    intake_lost_mtd = fields.Integer(string="Intakes Lost (MTD)", compute="_compute_kpis", store=False)
+    intake_total_open = fields.Integer(string="Open Intakes", compute="_compute_kpis", store=False)
 
     # Offers
-    offer_draft         = fields.Integer(string="Offers: Draft",        compute="_compute_kpis", store=False)
-    offer_sent          = fields.Integer(string="Offers: Sent",         compute="_compute_kpis", store=False)
-    offer_responded     = fields.Integer(string="Offers: Responded",    compute="_compute_kpis", store=False)
-    offer_accepted_mtd  = fields.Integer(string="Offers Accepted (MTD)",compute="_compute_kpis", store=False)
-    offer_rejected_mtd  = fields.Integer(string="Offers Rejected (MTD)",compute="_compute_kpis", store=False)
-    offer_expired_mtd   = fields.Integer(string="Offers Expired (MTD)", compute="_compute_kpis", store=False)
-    offer_expiring_soon = fields.Integer(string="Expiring ≤3 Days",     compute="_compute_kpis", store=False)
+    offer_draft = fields.Integer(string="Offers: Draft", compute="_compute_kpis", store=False)
+    offer_sent = fields.Integer(string="Offers: Sent", compute="_compute_kpis", store=False)
+    offer_responded = fields.Integer(string="Offers: Responded", compute="_compute_kpis", store=False)
+    offer_accepted_mtd = fields.Integer(string="Offers Accepted (MTD)", compute="_compute_kpis", store=False)
+    offer_rejected_mtd = fields.Integer(string="Offers Rejected (MTD)", compute="_compute_kpis", store=False)
+    offer_expired_mtd = fields.Integer(string="Offers Expired (MTD)", compute="_compute_kpis", store=False)
+    offer_expiring_soon = fields.Integer(string="Expiring ≤3 Days", compute="_compute_kpis", store=False)
 
     # Deal Conversion
-    offer_accept_rate_mtd = fields.Float(string="Offer Accept Rate %",  compute="_compute_kpis", store=False,
-        digits=(5,1), help="Accepted / (Accepted+Rejected) × 100 MTD")
-    intake_win_rate_mtd   = fields.Float(string="Intake Win Rate %",    compute="_compute_kpis", store=False,
-        digits=(5,1), help="Won / (Won+Lost) × 100 MTD")
-    avg_intake_age_days   = fields.Float(string="Avg Intake Age (days)",compute="_compute_kpis", store=False,
-        digits=(5,1))
+    offer_accept_rate_mtd = fields.Float(
+        string="Offer Accept Rate %",
+        compute="_compute_kpis",
+        store=False,
+        digits=(5, 1),
+        help="Accepted / (Accepted+Rejected) × 100 MTD",
+    )
+    intake_win_rate_mtd = fields.Float(
+        string="Intake Win Rate %",
+        compute="_compute_kpis",
+        store=False,
+        digits=(5, 1),
+        help="Won / (Won+Lost) × 100 MTD",
+    )
+    avg_intake_age_days = fields.Float(
+        string="Avg Intake Age (days)", compute="_compute_kpis", store=False, digits=(5, 1)
+    )
 
     # Transaction Pipeline
-    tx_open             = fields.Integer(string="Open Transactions",    compute="_compute_kpis", store=False)
-    tx_in_motion        = fields.Integer(string="In Motion",            compute="_compute_kpis", store=False)
+    tx_open = fields.Integer(string="Open Transactions", compute="_compute_kpis", store=False)
+    tx_in_motion = fields.Integer(string="In Motion", compute="_compute_kpis", store=False)
     tx_delivered_uninvoiced = fields.Integer(string="Delivered-Uninvoiced", compute="_compute_kpis", store=False)
-    tx_missing_docs     = fields.Integer(string="Missing Docs",         compute="_compute_kpis", store=False)
-    tx_negative_margin  = fields.Integer(string="Negative Margin ⚠",   compute="_compute_kpis", store=False)
-    tx_sup_not_ready    = fields.Integer(string="Supplier Not Ready ⚠", compute="_compute_kpis", store=False)
+    tx_missing_docs = fields.Integer(string="Missing Docs", compute="_compute_kpis", store=False)
+    tx_negative_margin = fields.Integer(string="Negative Margin ⚠", compute="_compute_kpis", store=False)
+    tx_sup_not_ready = fields.Integer(string="Supplier Not Ready ⚠", compute="_compute_kpis", store=False)
     tx_stalled_followup = fields.Integer(string="3+ Followups No Resp ⚠", compute="_compute_kpis", store=False)
-    tx_closed_mtd       = fields.Integer(string="Closed (MTD)",         compute="_compute_kpis", store=False)
+    tx_closed_mtd = fields.Integer(string="Closed (MTD)", compute="_compute_kpis", store=False)
 
     # Web Leads
-    lead_received_today = fields.Integer(string="Leads Today",          compute="_compute_kpis", store=False)
-    lead_received_wtd   = fields.Integer(string="Leads WTD",            compute="_compute_kpis", store=False)
-    lead_received_mtd   = fields.Integer(string="Leads MTD",            compute="_compute_kpis", store=False)
-    lead_hot_mtd        = fields.Integer(string="HOT Leads MTD",        compute="_compute_kpis", store=False)
-    lead_cold_mtd       = fields.Integer(string="COLD Leads MTD",       compute="_compute_kpis", store=False)
-    lead_error_open     = fields.Integer(string="Lead Errors (open)",   compute="_compute_kpis", store=False)
-    lead_hot_rate_mtd   = fields.Float(string="Lead→HOT Rate %",        compute="_compute_kpis", store=False,
-        digits=(5,1))
+    lead_received_today = fields.Integer(string="Leads Today", compute="_compute_kpis", store=False)
+    lead_received_wtd = fields.Integer(string="Leads WTD", compute="_compute_kpis", store=False)
+    lead_received_mtd = fields.Integer(string="Leads MTD", compute="_compute_kpis", store=False)
+    lead_hot_mtd = fields.Integer(string="HOT Leads MTD", compute="_compute_kpis", store=False)
+    lead_cold_mtd = fields.Integer(string="COLD Leads MTD", compute="_compute_kpis", store=False)
+    lead_error_open = fields.Integer(string="Lead Errors (open)", compute="_compute_kpis", store=False)
+    lead_hot_rate_mtd = fields.Float(string="Lead→HOT Rate %", compute="_compute_kpis", store=False, digits=(5, 1))
 
     # ══════════════════════════════════════════════════════════════════════════
     # SECTION B — FINANCIAL SNAPSHOT
     # ══════════════════════════════════════════════════════════════════════════
 
-    revenue_mtd         = fields.Float(string="Revenue MTD",            compute="_compute_kpis", store=False)
-    revenue_ytd         = fields.Float(string="Revenue YTD",            compute="_compute_kpis", store=False)
-    gm_mtd              = fields.Float(string="Gross Margin MTD",       compute="_compute_kpis", store=False)
-    gm_ytd              = fields.Float(string="Gross Margin YTD",       compute="_compute_kpis", store=False)
-    gm_pct_mtd          = fields.Float(string="GM % MTD",               compute="_compute_kpis", store=False,
-        digits=(5,1))
-    gm_pct_ytd          = fields.Float(string="GM % YTD",               compute="_compute_kpis", store=False,
-        digits=(5,1))
-    net_margin_mtd      = fields.Float(string="Net Margin MTD",         compute="_compute_kpis", store=False)
-    net_margin_ytd      = fields.Float(string="Net Margin YTD",         compute="_compute_kpis", store=False)
-    commission_mtd      = fields.Float(string="Commission MTD",         compute="_compute_kpis", store=False)
-    commission_ytd      = fields.Float(string="Commission YTD",         compute="_compute_kpis", store=False)
-    commission_unlocked = fields.Integer(string="Comm Unlocked (closed)",compute="_compute_kpis", store=False)
-    pipeline_value_open = fields.Float(string="Open Pipeline Value",    compute="_compute_kpis", store=False,
-        help="Sum of revenue_total on non-closed, non-cancelled transactions")
+    revenue_mtd = fields.Float(string="Revenue MTD", compute="_compute_kpis", store=False)
+    revenue_ytd = fields.Float(string="Revenue YTD", compute="_compute_kpis", store=False)
+    gm_mtd = fields.Float(string="Gross Margin MTD", compute="_compute_kpis", store=False)
+    gm_ytd = fields.Float(string="Gross Margin YTD", compute="_compute_kpis", store=False)
+    gm_pct_mtd = fields.Float(string="GM % MTD", compute="_compute_kpis", store=False, digits=(5, 1))
+    gm_pct_ytd = fields.Float(string="GM % YTD", compute="_compute_kpis", store=False, digits=(5, 1))
+    net_margin_mtd = fields.Float(string="Net Margin MTD", compute="_compute_kpis", store=False)
+    net_margin_ytd = fields.Float(string="Net Margin YTD", compute="_compute_kpis", store=False)
+    commission_mtd = fields.Float(string="Commission MTD", compute="_compute_kpis", store=False)
+    commission_ytd = fields.Float(string="Commission YTD", compute="_compute_kpis", store=False)
+    commission_unlocked = fields.Integer(string="Comm Unlocked (closed)", compute="_compute_kpis", store=False)
+    pipeline_value_open = fields.Float(
+        string="Open Pipeline Value",
+        compute="_compute_kpis",
+        store=False,
+        help="Sum of revenue_total on non-closed, non-cancelled transactions",
+    )
 
     # ══════════════════════════════════════════════════════════════════════════
     # SECTION C — AI ENGINE STATS
     # ══════════════════════════════════════════════════════════════════════════
 
-    ai_leads_normalized_mtd  = fields.Integer(string="AI Normalized MTD",   compute="_compute_kpis", store=False,
-        help="Leads processed with ai_normalized != null MTD")
-    ai_leads_vision_mtd      = fields.Integer(string="Vision Analyzed MTD", compute="_compute_kpis", store=False,
-        help="Leads with ai_vision_results != null MTD")
-    ai_hot_auto_mtd          = fields.Integer(string="Auto-HOT MTD",        compute="_compute_kpis", store=False,
-        help="HOT leads auto-classified by AI (not manually overridden)")
-    ai_cold_auto_mtd         = fields.Integer(string="Auto-COLD MTD",       compute="_compute_kpis", store=False)
-    ai_error_mtd             = fields.Integer(string="AI Errors MTD",       compute="_compute_kpis", store=False,
-        help="Leads that hit state=error during triage MTD")
-    ai_hot_rate_mtd          = fields.Float(string="AI HOT Rate %",         compute="_compute_kpis", store=False,
-        digits=(5,1))
-    ai_intakes_auto_created  = fields.Integer(string="Auto-Intakes MTD",    compute="_compute_kpis", store=False,
-        help="Intakes created automatically from HOT web leads MTD")
-    ai_manual_override_mtd   = fields.Integer(string="Manual Overrides MTD",compute="_compute_kpis", store=False,
-        help="Cold leads manually forced to HOT by admin MTD")
-    ai_pending_review        = fields.Integer(string="Pending Review",      compute="_compute_kpis", store=False,
-        help="HOT intakes from web leads with no partner yet (need buyer-match action)")
-    ai_normalized_enabled    = fields.Boolean(string="AI Normalizer Active",compute="_compute_ai_config", store=False)
-    ai_vision_enabled        = fields.Boolean(string="Vision Active",       compute="_compute_ai_config", store=False)
-    ai_openai_key_set        = fields.Boolean(string="OpenAI Key Set",      compute="_compute_ai_config", store=False)
+    ai_leads_normalized_mtd = fields.Integer(
+        string="AI Normalized MTD",
+        compute="_compute_kpis",
+        store=False,
+        help="Leads processed with ai_normalized != null MTD",
+    )
+    ai_leads_vision_mtd = fields.Integer(
+        string="Vision Analyzed MTD",
+        compute="_compute_kpis",
+        store=False,
+        help="Leads with ai_vision_results != null MTD",
+    )
+    ai_hot_auto_mtd = fields.Integer(
+        string="Auto-HOT MTD",
+        compute="_compute_kpis",
+        store=False,
+        help="HOT leads auto-classified by AI (not manually overridden)",
+    )
+    ai_cold_auto_mtd = fields.Integer(string="Auto-COLD MTD", compute="_compute_kpis", store=False)
+    ai_error_mtd = fields.Integer(
+        string="AI Errors MTD",
+        compute="_compute_kpis",
+        store=False,
+        help="Leads that hit state=error during triage MTD",
+    )
+    ai_hot_rate_mtd = fields.Float(string="AI HOT Rate %", compute="_compute_kpis", store=False, digits=(5, 1))
+    ai_intakes_auto_created = fields.Integer(
+        string="Auto-Intakes MTD",
+        compute="_compute_kpis",
+        store=False,
+        help="Intakes created automatically from HOT web leads MTD",
+    )
+    ai_manual_override_mtd = fields.Integer(
+        string="Manual Overrides MTD",
+        compute="_compute_kpis",
+        store=False,
+        help="Cold leads manually forced to HOT by admin MTD",
+    )
+    ai_pending_review = fields.Integer(
+        string="Pending Review",
+        compute="_compute_kpis",
+        store=False,
+        help="HOT intakes from web leads with no partner yet (need buyer-match action)",
+    )
+    ai_normalized_enabled = fields.Boolean(string="AI Normalizer Active", compute="_compute_ai_config", store=False)
+    ai_vision_enabled = fields.Boolean(string="Vision Active", compute="_compute_ai_config", store=False)
+    ai_openai_key_set = fields.Boolean(string="OpenAI Key Set", compute="_compute_ai_config", store=False)
 
     # ══════════════════════════════════════════════════════════════════════════
     # COMPUTE
@@ -160,14 +200,15 @@ class PlasticosAdminKpi(models.Model):
                     (NOW() + INTERVAL '3 days')::date AS in_3_days
             """)
             row = cr.dictfetchone()
-            mtd = row['mtd_start']
-            ytd = row['ytd_start']
-            wtd = row['wtd_start']
-            today = row['today']
-            in_3d = row['in_3_days']
+            mtd = row["mtd_start"]
+            ytd = row["ytd_start"]
+            wtd = row["wtd_start"]
+            today = row["today"]
+            in_3d = row["in_3_days"]
 
             # ── INTAKES ───────────────────────────────────────────────────────
-            cr.execute("""
+            cr.execute(
+                """
                 SELECT
                     COUNT(*) FILTER (WHERE status='draft')                AS draft,
                     COUNT(*) FILTER (WHERE status='matched')              AS matched,
@@ -181,23 +222,26 @@ class PlasticosAdminKpi(models.Model):
                     AVG(EXTRACT(EPOCH FROM NOW()-create_date)/86400)
                         FILTER (WHERE status NOT IN ('won','lost','expired','draft')) AS avg_age
                 FROM plasticos_intake
-            """, (mtd, mtd))
+            """,
+                (mtd, mtd),
+            )
             r = cr.dictfetchone()
-            rec.intake_draft        = r['draft']       or 0
-            rec.intake_matched      = r['matched']     or 0
-            rec.intake_offer_sent   = r['offer_sent']  or 0
-            rec.intake_processing   = r['processing']  or 0
-            rec.intake_won_mtd      = r['won_mtd']     or 0
-            rec.intake_lost_mtd     = r['lost_mtd']    or 0
-            rec.intake_total_open   = r['total_open']  or 0
-            rec.avg_intake_age_days = round(r['avg_age'] or 0, 1)
+            rec.intake_draft = r["draft"] or 0
+            rec.intake_matched = r["matched"] or 0
+            rec.intake_offer_sent = r["offer_sent"] or 0
+            rec.intake_processing = r["processing"] or 0
+            rec.intake_won_mtd = r["won_mtd"] or 0
+            rec.intake_lost_mtd = r["lost_mtd"] or 0
+            rec.intake_total_open = r["total_open"] or 0
+            rec.avg_intake_age_days = round(r["avg_age"] or 0, 1)
 
-            won  = rec.intake_won_mtd
+            won = rec.intake_won_mtd
             lost = rec.intake_lost_mtd
             rec.intake_win_rate_mtd = round(won / (won + lost) * 100, 1) if (won + lost) else 0.0
 
             # ── OFFERS ────────────────────────────────────────────────────────
-            cr.execute("""
+            cr.execute(
+                """
                 SELECT
                     COUNT(*) FILTER (WHERE state='draft')                 AS draft,
                     COUNT(*) FILTER (WHERE state='sent')                  AS sent,
@@ -212,22 +256,25 @@ class PlasticosAdminKpi(models.Model):
                                      AND valid_until IS NOT NULL
                                      AND valid_until <= %s)               AS expiring_soon
                 FROM plasticos_offer
-            """, (mtd, mtd, mtd, in_3d))
+            """,
+                (mtd, mtd, mtd, in_3d),
+            )
             r = cr.dictfetchone()
-            rec.offer_draft         = r['draft']         or 0
-            rec.offer_sent          = r['sent']          or 0
-            rec.offer_responded     = r['responded']     or 0
-            rec.offer_accepted_mtd  = r['accepted_mtd']  or 0
-            rec.offer_rejected_mtd  = r['rejected_mtd']  or 0
-            rec.offer_expired_mtd   = r['expired_mtd']   or 0
-            rec.offer_expiring_soon = r['expiring_soon'] or 0
+            rec.offer_draft = r["draft"] or 0
+            rec.offer_sent = r["sent"] or 0
+            rec.offer_responded = r["responded"] or 0
+            rec.offer_accepted_mtd = r["accepted_mtd"] or 0
+            rec.offer_rejected_mtd = r["rejected_mtd"] or 0
+            rec.offer_expired_mtd = r["expired_mtd"] or 0
+            rec.offer_expiring_soon = r["expiring_soon"] or 0
 
-            acc  = rec.offer_accepted_mtd
-            rej  = rec.offer_rejected_mtd
+            acc = rec.offer_accepted_mtd
+            rej = rec.offer_rejected_mtd
             rec.offer_accept_rate_mtd = round(acc / (acc + rej) * 100, 1) if (acc + rej) else 0.0
 
             # ── TRANSACTIONS ──────────────────────────────────────────────────
-            cr.execute("""
+            cr.execute(
+                """
                 SELECT
                     COUNT(*) FILTER (WHERE state NOT IN ('closed','cancelled'))         AS tx_open,
                     COUNT(*) FILTER (WHERE state IN ('dispatched','in_progress','in_transit')) AS in_motion,
@@ -250,20 +297,23 @@ class PlasticosAdminKpi(models.Model):
                     SUM(revenue_total) FILTER (WHERE state NOT IN ('closed','cancelled')
                                               AND revenue_total > 0)                   AS pipeline_val
                 FROM plasticos_transaction
-            """, (mtd,))
+            """,
+                (mtd,),
+            )
             r = cr.dictfetchone()
-            rec.tx_open                 = r['tx_open']        or 0
-            rec.tx_in_motion            = r['in_motion']      or 0
-            rec.tx_delivered_uninvoiced = r['delivered_uninv']or 0
-            rec.tx_missing_docs         = r['missing_docs']   or 0
-            rec.tx_negative_margin      = r['neg_margin']     or 0
-            rec.tx_sup_not_ready        = r['sup_not_ready']  or 0
-            rec.tx_stalled_followup     = r['stalled_fu']     or 0
-            rec.tx_closed_mtd           = r['closed_mtd']     or 0
-            rec.pipeline_value_open     = r['pipeline_val']   or 0.0
+            rec.tx_open = r["tx_open"] or 0
+            rec.tx_in_motion = r["in_motion"] or 0
+            rec.tx_delivered_uninvoiced = r["delivered_uninv"] or 0
+            rec.tx_missing_docs = r["missing_docs"] or 0
+            rec.tx_negative_margin = r["neg_margin"] or 0
+            rec.tx_sup_not_ready = r["sup_not_ready"] or 0
+            rec.tx_stalled_followup = r["stalled_fu"] or 0
+            rec.tx_closed_mtd = r["closed_mtd"] or 0
+            rec.pipeline_value_open = r["pipeline_val"] or 0.0
 
             # ── FINANCIALS ────────────────────────────────────────────────────
-            cr.execute("""
+            cr.execute(
+                """
                 SELECT
                     SUM(revenue_total)   FILTER (WHERE write_date >= %s)  AS rev_mtd,
                     SUM(revenue_total)   FILTER (WHERE write_date >= %s)  AS rev_ytd,
@@ -277,25 +327,28 @@ class PlasticosAdminKpi(models.Model):
                                      AND commission_locked=FALSE)         AS comm_unlocked
                 FROM plasticos_transaction
                 WHERE state='closed'
-            """, (mtd, ytd, mtd, ytd, mtd, ytd, mtd, ytd))
+            """,
+                (mtd, ytd, mtd, ytd, mtd, ytd, mtd, ytd),
+            )
             r = cr.dictfetchone()
-            rec.revenue_mtd         = r['rev_mtd']       or 0.0
-            rec.revenue_ytd         = r['rev_ytd']       or 0.0
-            rec.gm_mtd              = r['gm_mtd']        or 0.0
-            rec.gm_ytd              = r['gm_ytd']        or 0.0
-            rec.net_margin_mtd      = r['nm_mtd']        or 0.0
-            rec.net_margin_ytd      = r['nm_ytd']        or 0.0
-            rec.commission_mtd      = r['comm_mtd']      or 0.0
-            rec.commission_ytd      = r['comm_ytd']      or 0.0
-            rec.commission_unlocked = r['comm_unlocked'] or 0
+            rec.revenue_mtd = r["rev_mtd"] or 0.0
+            rec.revenue_ytd = r["rev_ytd"] or 0.0
+            rec.gm_mtd = r["gm_mtd"] or 0.0
+            rec.gm_ytd = r["gm_ytd"] or 0.0
+            rec.net_margin_mtd = r["nm_mtd"] or 0.0
+            rec.net_margin_ytd = r["nm_ytd"] or 0.0
+            rec.commission_mtd = r["comm_mtd"] or 0.0
+            rec.commission_ytd = r["comm_ytd"] or 0.0
+            rec.commission_unlocked = r["comm_unlocked"] or 0
 
             rev_mtd = rec.revenue_mtd
             rev_ytd = rec.revenue_ytd
-            rec.gm_pct_mtd  = round(rec.gm_mtd / rev_mtd * 100, 1)  if rev_mtd  else 0.0
-            rec.gm_pct_ytd  = round(rec.gm_ytd / rev_ytd * 100, 1)  if rev_ytd  else 0.0
+            rec.gm_pct_mtd = round(rec.gm_mtd / rev_mtd * 100, 1) if rev_mtd else 0.0
+            rec.gm_pct_ytd = round(rec.gm_ytd / rev_ytd * 100, 1) if rev_ytd else 0.0
 
             # ── WEB LEADS ─────────────────────────────────────────────────────
-            cr.execute("""
+            cr.execute(
+                """
                 SELECT
                     COUNT(*) FILTER (WHERE create_date::date = %s)        AS today,
                     COUNT(*) FILTER (WHERE create_date >= %s)             AS wtd,
@@ -306,20 +359,23 @@ class PlasticosAdminKpi(models.Model):
                                      AND create_date >= %s)               AS cold_mtd,
                     COUNT(*) FILTER (WHERE state='error')                 AS err_open
                 FROM plasticos_web_lead
-            """, (today, wtd, mtd, mtd, mtd))
+            """,
+                (today, wtd, mtd, mtd, mtd),
+            )
             r = cr.dictfetchone()
-            rec.lead_received_today = r['today']   or 0
-            rec.lead_received_wtd   = r['wtd']     or 0
-            rec.lead_received_mtd   = r['mtd']     or 0
-            rec.lead_hot_mtd        = r['hot_mtd'] or 0
-            rec.lead_cold_mtd       = r['cold_mtd']or 0
-            rec.lead_error_open     = r['err_open']or 0
+            rec.lead_received_today = r["today"] or 0
+            rec.lead_received_wtd = r["wtd"] or 0
+            rec.lead_received_mtd = r["mtd"] or 0
+            rec.lead_hot_mtd = r["hot_mtd"] or 0
+            rec.lead_cold_mtd = r["cold_mtd"] or 0
+            rec.lead_error_open = r["err_open"] or 0
 
             total_leads = rec.lead_hot_mtd + rec.lead_cold_mtd
             rec.lead_hot_rate_mtd = round(rec.lead_hot_mtd / total_leads * 100, 1) if total_leads else 0.0
 
             # ── AI STATS ──────────────────────────────────────────────────────
-            cr.execute("""
+            cr.execute(
+                """
                 SELECT
                     COUNT(*) FILTER (WHERE ai_normalized IS NOT NULL
                                      AND create_date >= %s)               AS normalized_mtd,
@@ -333,34 +389,42 @@ class PlasticosAdminKpi(models.Model):
                     COUNT(*) FILTER (WHERE state='error'
                                      AND create_date >= %s)               AS err_mtd
                 FROM plasticos_web_lead
-            """, (mtd, mtd, mtd, mtd, mtd))
+            """,
+                (mtd, mtd, mtd, mtd, mtd),
+            )
             r = cr.dictfetchone()
-            rec.ai_leads_normalized_mtd = r['normalized_mtd'] or 0
-            rec.ai_leads_vision_mtd     = r['vision_mtd']     or 0
-            rec.ai_hot_auto_mtd         = r['hot_auto_mtd']   or 0
-            rec.ai_cold_auto_mtd        = r['cold_auto_mtd']  or 0
-            rec.ai_error_mtd            = r['err_mtd']        or 0
+            rec.ai_leads_normalized_mtd = r["normalized_mtd"] or 0
+            rec.ai_leads_vision_mtd = r["vision_mtd"] or 0
+            rec.ai_hot_auto_mtd = r["hot_auto_mtd"] or 0
+            rec.ai_cold_auto_mtd = r["cold_auto_mtd"] or 0
+            rec.ai_error_mtd = r["err_mtd"] or 0
 
-            hot  = rec.ai_hot_auto_mtd
+            hot = rec.ai_hot_auto_mtd
             cold = rec.ai_cold_auto_mtd
             rec.ai_hot_rate_mtd = round(hot / (hot + cold) * 100, 1) if (hot + cold) else 0.0
 
             # Auto-intakes: HOT leads that created intakes MTD
-            cr.execute("""
+            cr.execute(
+                """
                 SELECT COUNT(*) FROM plasticos_intake i
                 WHERE i.source_lead_id IS NOT NULL
                 AND i.create_date >= %s
-            """, (mtd,))
-            rec.ai_intakes_auto_created = (cr.fetchone()[0] or 0)
+            """,
+                (mtd,),
+            )
+            rec.ai_intakes_auto_created = cr.fetchone()[0] or 0
 
             # Manual overrides: COLD leads forced to HOT
-            cr.execute("""
+            cr.execute(
+                """
                 SELECT COUNT(*) FROM plasticos_web_lead
                 WHERE decision='hot'
                 AND triage_log ILIKE '%%Manual override%%'
                 AND create_date >= %s
-            """, (mtd,))
-            rec.ai_manual_override_mtd = (cr.fetchone()[0] or 0)
+            """,
+                (mtd,),
+            )
+            rec.ai_manual_override_mtd = cr.fetchone()[0] or 0
 
             # Pending review: HOT intakes from web leads with no partner
             cr.execute("""
@@ -369,7 +433,7 @@ class PlasticosAdminKpi(models.Model):
                 AND partner_id IS NULL
                 AND status NOT IN ('won','lost','expired')
             """)
-            rec.ai_pending_review = (cr.fetchone()[0] or 0)
+            rec.ai_pending_review = cr.fetchone()[0] or 0
 
             rec.last_refresh = fields.Datetime.now()
 
@@ -379,18 +443,18 @@ class PlasticosAdminKpi(models.Model):
             config_model = "plasticos.web.lead.config"
             if config_model not in self.env:
                 rec.ai_normalized_enabled = False
-                rec.ai_vision_enabled     = False
-                rec.ai_openai_key_set     = False
+                rec.ai_vision_enabled = False
+                rec.ai_openai_key_set = False
                 continue
             try:
                 config = self.env[config_model].sudo().get_config()
                 rec.ai_normalized_enabled = bool(getattr(config, "ai_enabled", False))
-                rec.ai_vision_enabled     = bool(getattr(config, "vision_enabled", False))
-                rec.ai_openai_key_set     = bool(getattr(config, "openai_api_key", ""))
+                rec.ai_vision_enabled = bool(getattr(config, "vision_enabled", False))
+                rec.ai_openai_key_set = bool(getattr(config, "openai_api_key", ""))
             except Exception:
                 rec.ai_normalized_enabled = False
-                rec.ai_vision_enabled     = False
-                rec.ai_openai_key_set     = False
+                rec.ai_vision_enabled = False
+                rec.ai_openai_key_set = False
 
     # ── Singleton helper ──────────────────────────────────────────────────────
 
@@ -539,6 +603,7 @@ class PlasticosAdminKpi(models.Model):
 # REP PERFORMANCE — SQL VIEW (one row per rep × period)
 # ─────────────────────────────────────────────────────────────────────────────
 
+
 class PlasticosRepPerformance(models.Model):
     """Rep performance SQL VIEW: one row per salesperson per period.
 
@@ -553,25 +618,25 @@ class PlasticosRepPerformance(models.Model):
     _rec_name = "rep_name"
     _order = "period_sort asc, revenue_closed desc"
 
-    rep_name        = fields.Char(   string="Rep",             readonly=True)
-    salesperson_id  = fields.Many2one("res.users",             readonly=True)
-    period          = fields.Char(   string="Period",          readonly=True)
-    period_sort     = fields.Integer(string="_psort",          readonly=True)
+    rep_name = fields.Char(string="Rep", readonly=True)
+    salesperson_id = fields.Many2one("res.users", readonly=True)
+    period = fields.Char(string="Period", readonly=True)
+    period_sort = fields.Integer(string="_psort", readonly=True)
 
-    deals_closed    = fields.Integer(string="Closed",          readonly=True)
-    revenue_closed  = fields.Float(  string="Revenue",         readonly=True, digits=(16,2))
-    gm_closed       = fields.Float(  string="GM $",            readonly=True, digits=(16,2))
-    gm_pct          = fields.Float(  string="GM %",            readonly=True, digits=(5,1))
-    net_margin      = fields.Float(  string="Net $",           readonly=True, digits=(16,2))
-    commission      = fields.Float(  string="Commission",      readonly=True, digits=(16,2))
+    deals_closed = fields.Integer(string="Closed", readonly=True)
+    revenue_closed = fields.Float(string="Revenue", readonly=True, digits=(16, 2))
+    gm_closed = fields.Float(string="GM $", readonly=True, digits=(16, 2))
+    gm_pct = fields.Float(string="GM %", readonly=True, digits=(5, 1))
+    net_margin = fields.Float(string="Net $", readonly=True, digits=(16, 2))
+    commission = fields.Float(string="Commission", readonly=True, digits=(16, 2))
 
-    deals_open      = fields.Integer(string="Open Deals",      readonly=True)
-    pipeline_val    = fields.Float(  string="Pipeline",        readonly=True, digits=(16,2))
-    intakes_created = fields.Integer(string="Intakes",         readonly=True)
-    offers_sent     = fields.Integer(string="Offers Sent",     readonly=True)
-    offers_accepted = fields.Integer(string="Acc'd",           readonly=True)
-    offer_acc_rate  = fields.Float(  string="Acc Rate %",      readonly=True, digits=(5,1))
-    avg_gm_pct      = fields.Float(  string="Avg GM %",        readonly=True, digits=(5,1))
+    deals_open = fields.Integer(string="Open Deals", readonly=True)
+    pipeline_val = fields.Float(string="Pipeline", readonly=True, digits=(16, 2))
+    intakes_created = fields.Integer(string="Intakes", readonly=True)
+    offers_sent = fields.Integer(string="Offers Sent", readonly=True)
+    offers_accepted = fields.Integer(string="Acc'd", readonly=True)
+    offer_acc_rate = fields.Float(string="Acc Rate %", readonly=True, digits=(5, 1))
+    avg_gm_pct = fields.Float(string="Avg GM %", readonly=True, digits=(5, 1))
 
     def init(self):
         self.env.cr.execute("DROP VIEW IF EXISTS plasticos_rep_performance")

--- a/plasticos_commission/models/commission_payout.py
+++ b/plasticos_commission/models/commission_payout.py
@@ -26,42 +26,72 @@ class PlasticosCommissionPayout(models.Model):
 
     # ── Rep + Period ────────────────────────────────────────────────────────
     sales_rep_id = fields.Many2one(
-        "res.users", string="Sales Rep", required=True, tracking=True, index=True,
+        "res.users",
+        string="Sales Rep",
+        required=True,
+        tracking=True,
+        index=True,
         domain="[('share', '=', False)]",
     )
     commission_rule_id = fields.Many2one(
-        "plasticos.commission.rule", string="Commission Rule", tracking=True,
+        "plasticos.commission.rule",
+        string="Commission Rule",
+        tracking=True,
         help="Primary rule used for this period. Informational only.",
     )
     period_start = fields.Date(required=True, tracking=True)
-    period_end   = fields.Date(required=True, tracking=True)
+    period_end = fields.Date(required=True, tracking=True)
 
     # ── Amounts ─────────────────────────────────────────────────────────────
-    transaction_count   = fields.Integer(string="# Transactions", compute="_compute_totals", store=True)
-    gross_margin_total  = fields.Float(string="Total Gross Margin", compute="_compute_totals", store=True, digits="Product Price")
-    commission_due      = fields.Float(string="Commission Due", compute="_compute_totals", store=True, digits="Product Price",
-                                       help="Sum of commission_locked_amount from linked closed transactions.")
-    commission_paid     = fields.Float(string="Commission Paid", digits="Product Price", tracking=True,
-                                       help="Actual amount disbursed. Defaults to commission_due on mark_paid.")
-    commission_balance  = fields.Float(string="Balance Due", compute="_compute_balance", store=True, digits="Product Price")
-    currency_id         = fields.Many2one("res.currency", default=lambda self: self.env.company.currency_id, readonly=True)
+    transaction_count = fields.Integer(string="# Transactions", compute="_compute_totals", store=True)
+    gross_margin_total = fields.Float(
+        string="Total Gross Margin", compute="_compute_totals", store=True, digits="Product Price"
+    )
+    commission_due = fields.Float(
+        string="Commission Due",
+        compute="_compute_totals",
+        store=True,
+        digits="Product Price",
+        help="Sum of commission_locked_amount from linked closed transactions.",
+    )
+    commission_paid = fields.Float(
+        string="Commission Paid",
+        digits="Product Price",
+        tracking=True,
+        help="Actual amount disbursed. Defaults to commission_due on mark_paid.",
+    )
+    commission_balance = fields.Float(
+        string="Balance Due", compute="_compute_balance", store=True, digits="Product Price"
+    )
+    currency_id = fields.Many2one("res.currency", default=lambda self: self.env.company.currency_id, readonly=True)
 
     # ── Linked Transactions ──────────────────────────────────────────────────
     transaction_ids = fields.Many2many(
-        "plasticos.transaction", "commission_payout_tx_rel", "payout_id", "transaction_id",
+        "plasticos.transaction",
+        "commission_payout_tx_rel",
+        "payout_id",
+        "transaction_id",
         string="Transactions",
         domain="[('state', '=', 'closed'), ('commission_locked', '=', True)]",
     )
 
     # ── Payment Info ─────────────────────────────────────────────────────────
     state = fields.Selection(
-        [("draft", "Draft"), ("confirmed", "Confirmed — Awaiting Payment"),
-         ("paid", "Paid"), ("cancelled", "Cancelled")],
-        default="draft", required=True, tracking=True, index=True,
+        [
+            ("draft", "Draft"),
+            ("confirmed", "Confirmed — Awaiting Payment"),
+            ("paid", "Paid"),
+            ("cancelled", "Cancelled"),
+        ],
+        default="draft",
+        required=True,
+        tracking=True,
+        index=True,
     )
-    payment_date      = fields.Date(tracking=True)
-    payment_reference = fields.Char(string="Payment Reference", tracking=True,
-                                    help="Check number, wire reference, or payroll batch ID.")
+    payment_date = fields.Date(tracking=True)
+    payment_reference = fields.Char(
+        string="Payment Reference", tracking=True, help="Check number, wire reference, or payroll batch ID."
+    )
     notes = fields.Text()
 
     # ── Constraints ──────────────────────────────────────────────────────────
@@ -76,9 +106,9 @@ class PlasticosCommissionPayout(models.Model):
     def _compute_totals(self):
         for rec in self:
             txs = rec.transaction_ids
-            rec.transaction_count  = len(txs)
+            rec.transaction_count = len(txs)
             rec.gross_margin_total = sum(txs.mapped("gross_margin"))
-            rec.commission_due     = sum(txs.mapped("commission_locked_amount"))
+            rec.commission_due = sum(txs.mapped("commission_locked_amount"))
 
     @api.depends("commission_due", "commission_paid")
     def _compute_balance(self):
@@ -103,8 +133,10 @@ class PlasticosCommissionPayout(models.Model):
                 raise UserError("Cannot confirm a payout with no transactions linked.")
             rec.state = "confirmed"
             rec.message_post(
-                body=(f"Payout confirmed: {rec.transaction_count} transaction(s), "
-                      f"${rec.commission_due:,.2f} due to {rec.sales_rep_id.name}."),
+                body=(
+                    f"Payout confirmed: {rec.transaction_count} transaction(s), "
+                    f"${rec.commission_due:,.2f} due to {rec.sales_rep_id.name}."
+                ),
                 message_type="notification",
             )
 
@@ -118,8 +150,10 @@ class PlasticosCommissionPayout(models.Model):
             rec.commission_paid = rec.commission_due
             rec.state = "paid"
             rec.message_post(
-                body=(f"Commission paid: ${rec.commission_paid:,.2f} on {rec.payment_date} "
-                      f"(ref: {rec.payment_reference or 'N/A'})."),
+                body=(
+                    f"Commission paid: ${rec.commission_paid:,.2f} on {rec.payment_date} "
+                    f"(ref: {rec.payment_reference or 'N/A'})."
+                ),
                 message_type="notification",
             )
 
@@ -143,23 +177,25 @@ class PlasticosCommissionPayout(models.Model):
         Safe to call from cron or UI wizard.
         Returns new payout record, or False if no qualifying transactions found.
         """
-        already_paid_tx_ids = self.search(
-            [("state", "in", ["confirmed", "paid"])]
-        ).mapped("transaction_ids").ids
+        already_paid_tx_ids = self.search([("state", "in", ["confirmed", "paid"])]).mapped("transaction_ids").ids
 
-        txs = self.env["plasticos.transaction"].search([
-            ("user_id", "=", sales_rep_id),
-            ("state", "=", "closed"),
-            ("commission_locked", "=", True),
-            ("commission_locked_amount", ">", 0),
-            ("id", "not in", already_paid_tx_ids),
-        ])
+        txs = self.env["plasticos.transaction"].search(
+            [
+                ("user_id", "=", sales_rep_id),
+                ("state", "=", "closed"),
+                ("commission_locked", "=", True),
+                ("commission_locked_amount", ">", 0),
+                ("id", "not in", already_paid_tx_ids),
+            ]
+        )
         if not txs:
             return False
 
-        return self.create({
-            "sales_rep_id": sales_rep_id,
-            "period_start": period_start,
-            "period_end":   period_end,
-            "transaction_ids": [(6, 0, txs.ids)],
-        })
+        return self.create(
+            {
+                "sales_rep_id": sales_rep_id,
+                "period_start": period_start,
+                "period_end": period_end,
+                "transaction_ids": [(6, 0, txs.ids)],
+            }
+        )

--- a/plasticos_commission/models/commission_service.py
+++ b/plasticos_commission/models/commission_service.py
@@ -45,7 +45,10 @@ class PlasticosCommissionService(models.AbstractModel):
             amount = gross_margin * override
             _logger.debug(
                 "Commission override on %s: %.4f × %.2f = %.2f",
-                record.name, override, gross_margin, amount,
+                record.name,
+                override,
+                gross_margin,
+                amount,
             )
             return round(amount, 2)
 
@@ -71,26 +74,29 @@ class PlasticosCommissionService(models.AbstractModel):
                 )
                 _logger.debug(
                     "Commission rule '%s' on %s: %.2f",
-                    rule.name, record.name, amount,
+                    rule.name,
+                    record.name,
+                    amount,
                 )
                 return round(max(amount, 0.0), 2)
             else:
                 _logger.debug(
                     "Commission rule '%s' not applicable for %s — falling through",
-                    rule.name, record.name,
+                    rule.name,
+                    record.name,
                 )
 
         # 4. ICP default rate fallback
         try:
             icp = record.env["ir.config_parameter"].sudo()
-            default_rate = float(
-                icp.get_param("plasticos.commission.default_rate", "0.0")
-            )
+            default_rate = float(icp.get_param("plasticos.commission.default_rate", "0.0"))
             if default_rate > 0:
                 amount = gross_margin * default_rate
                 _logger.debug(
                     "Commission ICP default rate %.4f on %s: %.2f",
-                    default_rate, record.name, amount,
+                    default_rate,
+                    record.name,
+                    amount,
                 )
                 return round(amount, 2)
         except Exception:

--- a/plasticos_commission/models/sales_dashboard.py
+++ b/plasticos_commission/models/sales_dashboard.py
@@ -25,91 +25,121 @@ class PlasticosSalesDashboard(models.Model):
     _order = "transaction_state desc, write_date desc"
 
     # ── Identity ──────────────────────────────────────────────────────────────
-    transaction_id  = fields.Many2one(PLASTICOS_TRANSACTION, readonly=True)
+    transaction_id = fields.Many2one(PLASTICOS_TRANSACTION, readonly=True)
     transaction_ref = fields.Char(string="Deal #", readonly=True)
-    user_id         = fields.Many2one("res.users", string="Rep", readonly=True)
+    user_id = fields.Many2one("res.users", string="Rep", readonly=True)
 
     # ── Deal Basics ───────────────────────────────────────────────────────────
     supplier_id = fields.Many2one("res.partner", string="Supplier", readonly=True)
-    buyer_id    = fields.Many2one("res.partner", string="Buyer", readonly=True)
-    product_id  = fields.Many2one("product.product", string="Material", readonly=True)
-    quantity    = fields.Float(string="Quantity", readonly=True)
-    uom_id      = fields.Many2one("uom.uom", string="UOM", readonly=True)
+    buyer_id = fields.Many2one("res.partner", string="Buyer", readonly=True)
+    product_id = fields.Many2one("product.product", string="Material", readonly=True)
+    quantity = fields.Float(string="Quantity", readonly=True)
+    uom_id = fields.Many2one("uom.uom", string="UOM", readonly=True)
 
     # ── Financials ────────────────────────────────────────────────────────────
-    unit_price            = fields.Float(string="Sell $/unit",    digits="Product Price", readonly=True)
-    revenue_total         = fields.Float(string="Sell Total",     digits="Product Price", readonly=True)
-    purchase_cost_total   = fields.Float(string="Buy Total",      digits="Product Price", readonly=True)
-    freight_cost_total    = fields.Float(string="Freight",        digits="Product Price", readonly=True)
-    gross_margin          = fields.Float(string="Gross Margin",   digits="Product Price", readonly=True)
-    currency_id           = fields.Many2one("res.currency", readonly=True)
+    unit_price = fields.Float(string="Sell $/unit", digits="Product Price", readonly=True)
+    revenue_total = fields.Float(string="Sell Total", digits="Product Price", readonly=True)
+    purchase_cost_total = fields.Float(string="Buy Total", digits="Product Price", readonly=True)
+    freight_cost_total = fields.Float(string="Freight", digits="Product Price", readonly=True)
+    gross_margin = fields.Float(string="Gross Margin", digits="Product Price", readonly=True)
+    currency_id = fields.Many2one("res.currency", readonly=True)
 
     # ── Weight ────────────────────────────────────────────────────────────────
-    final_weight               = fields.Float(string="Net Weight (lbs)", readonly=True)
-    weight_source              = fields.Selection(
-        [("scale", "Scale Ticket"), ("buyer", "Buyer Report"),
-         ("supplier", "Supplier Weight"), ("none", "No Weight")],
-        string="Weight Source", readonly=True,
+    final_weight = fields.Float(string="Net Weight (lbs)", readonly=True)
+    weight_source = fields.Selection(
+        [("scale", "Scale Ticket"), ("buyer", "Buyer Report"), ("supplier", "Supplier Weight"), ("none", "No Weight")],
+        string="Weight Source",
+        readonly=True,
     )
     weight_discrepancy_flagged = fields.Boolean(string="Discrepancy", readonly=True)
-    weight_discrepancy_pct     = fields.Float(string="Discrepancy %", readonly=True)
+    weight_discrepancy_pct = fields.Float(string="Discrepancy %", readonly=True)
 
     # ── Logistics ─────────────────────────────────────────────────────────────
     transaction_state = fields.Selection(
-        [("draft", "Draft"), ("active", "Active"),
-         ("pending_supplier", "Pending Supplier"), ("supplier_not_ready", "Supplier Not Ready"),
-         ("supplier_ready", "Supplier Ready"), ("do_created", "DO Created"),
-         ("dispatched", "Dispatched"), ("in_progress", "In Progress"),
-         ("in_transit", "In Transit"), ("delivered", "Delivered"),
-         ("invoiced", "Invoiced"), ("closed", "Closed"), ("cancelled", "Cancelled")],
-        string="Deal Status", readonly=True,
+        [
+            ("draft", "Draft"),
+            ("active", "Active"),
+            ("pending_supplier", "Pending Supplier"),
+            ("supplier_not_ready", "Supplier Not Ready"),
+            ("supplier_ready", "Supplier Ready"),
+            ("do_created", "DO Created"),
+            ("dispatched", "Dispatched"),
+            ("in_progress", "In Progress"),
+            ("in_transit", "In Transit"),
+            ("delivered", "Delivered"),
+            ("invoiced", "Invoiced"),
+            ("closed", "Closed"),
+            ("cancelled", "Cancelled"),
+        ],
+        string="Deal Status",
+        readonly=True,
     )
     load_state = fields.Selection(
-        [("draft", "Draft"), ("awaiting_ready", "Awaiting Ready"),
-         ("ready_confirmed", "Ready Confirmed"), ("rate_confirmed", "Rate Confirmed"),
-         ("scheduled", "Scheduled"), ("dispatched", "Dispatched"),
-         ("picked_up", "Picked Up"), ("delivered", "Delivered"),
-         ("closed", "Closed"), ("exception", "Exception")],
-        string="Load Status", readonly=True,
+        [
+            ("draft", "Draft"),
+            ("awaiting_ready", "Awaiting Ready"),
+            ("ready_confirmed", "Ready Confirmed"),
+            ("rate_confirmed", "Rate Confirmed"),
+            ("scheduled", "Scheduled"),
+            ("dispatched", "Dispatched"),
+            ("picked_up", "Picked Up"),
+            ("delivered", "Delivered"),
+            ("closed", "Closed"),
+            ("exception", "Exception"),
+        ],
+        string="Load Status",
+        readonly=True,
     )
-    load_id           = fields.Many2one("plasticos.load", readonly=True)
-    pickup_datetime   = fields.Datetime(string="Pickup", readonly=True)
+    load_id = fields.Many2one("plasticos.load", readonly=True)
+    pickup_datetime = fields.Datetime(string="Pickup", readonly=True)
     delivery_datetime = fields.Datetime(string="Est. Delivery", readonly=True)
-    delivered_at      = fields.Datetime(string="Delivered At", readonly=True)
-    carrier_name      = fields.Char(string="Carrier", readonly=True)
-    trailer_number    = fields.Char(string="Trailer #", readonly=True)
-    delivery_term     = fields.Selection(
+    delivered_at = fields.Datetime(string="Delivered At", readonly=True)
+    carrier_name = fields.Char(string="Carrier", readonly=True)
+    trailer_number = fields.Char(string="Trailer #", readonly=True)
+    delivery_term = fields.Selection(
         [("fcfs", "FCFS"), ("appointment", "Appointment")],
-        string="Delivery Term", readonly=True,
+        string="Delivery Term",
+        readonly=True,
     )
 
     # ── Document Checklist (computed, not in SQL view) ────────────────────────
     doc_bol = fields.Selection(
         [("ok", "✓"), ("pending", "Pending Review"), ("missing", "Missing")],
-        string="BOL", compute="_compute_doc_checklist", readonly=True,
+        string="BOL",
+        compute="_compute_doc_checklist",
+        readonly=True,
     )
     doc_scale_ticket = fields.Selection(
         [("ok", "✓"), ("pending", "Pending Review"), ("missing", "Missing")],
-        string="Scale Ticket", compute="_compute_doc_checklist", readonly=True,
+        string="Scale Ticket",
+        compute="_compute_doc_checklist",
+        readonly=True,
     )
     doc_invoice = fields.Selection(
         [("ok", "✓"), ("pending", "Pending Review"), ("missing", "Missing")],
-        string="Invoice", compute="_compute_doc_checklist", readonly=True,
+        string="Invoice",
+        compute="_compute_doc_checklist",
+        readonly=True,
     )
     doc_customer_order = fields.Selection(
         [("ok", "✓"), ("pending", "Pending Review"), ("missing", "Missing")],
-        string="Customer Order", compute="_compute_doc_checklist", readonly=True,
+        string="Customer Order",
+        compute="_compute_doc_checklist",
+        readonly=True,
     )
     docs_all_clear = fields.Boolean(
-        string="Docs Clear", compute="_compute_doc_checklist", readonly=True,
+        string="Docs Clear",
+        compute="_compute_doc_checklist",
+        readonly=True,
     )
 
     # ── Commission ────────────────────────────────────────────────────────────
-    commission_amount        = fields.Float(string="Est. Commission",  digits="Product Price", readonly=True)
+    commission_amount = fields.Float(string="Est. Commission", digits="Product Price", readonly=True)
     commission_locked_amount = fields.Float(string="Final Commission", digits="Product Price", readonly=True)
-    commission_payout_state  = fields.Selection(
+    commission_payout_state = fields.Selection(
         [("unpaid", "Unpaid"), ("confirmed", "Awaiting Payment"), ("paid", "Paid")],
-        string="Pay Status", readonly=True,
+        string="Pay Status",
+        readonly=True,
     )
 
     write_date = fields.Datetime(string="Last Updated", readonly=True)
@@ -194,10 +224,16 @@ class PlasticosSalesDashboard(models.Model):
                 rec.docs_all_clear = False
             return
 
-        docs = self.env[active_model].sudo().search([
-            ("transaction_id", "in", tx_ids),
-            ("doc_type", "in", list(DOC_TYPES.keys())),
-        ])
+        docs = (
+            self.env[active_model]
+            .sudo()
+            .search(
+                [
+                    ("transaction_id", "in", tx_ids),
+                    ("doc_type", "in", list(DOC_TYPES.keys())),
+                ]
+            )
+        )
 
         lookup = {}
         for doc in docs:
@@ -276,9 +312,11 @@ class PlasticosSalesDashboard(models.Model):
             return {
                 "type": "ir.actions.client",
                 "tag": "display_notification",
-                "params": {"title": "No Load Yet",
-                           "message": "A load has not been created for this transaction yet.",
-                           "type": "warning"},
+                "params": {
+                    "title": "No Load Yet",
+                    "message": "A load has not been created for this transaction yet.",
+                    "type": "warning",
+                },
             }
         return {
             "type": "ir.actions.act_window",
@@ -292,16 +330,25 @@ class PlasticosSalesDashboard(models.Model):
     def action_view_payout(self):
         """Commission payout batch detail — shown when pay status is not Unpaid."""
         self.ensure_one()
-        payout_ids = self.env["plasticos.commission.payout"].sudo().search([
-            ("transaction_ids", "in", [self.transaction_id.id]),
-        ]).ids
+        payout_ids = (
+            self.env["plasticos.commission.payout"]
+            .sudo()
+            .search(
+                [
+                    ("transaction_ids", "in", [self.transaction_id.id]),
+                ]
+            )
+            .ids
+        )
         if not payout_ids:
             return {
                 "type": "ir.actions.client",
                 "tag": "display_notification",
-                "params": {"title": "No Payout Record",
-                           "message": "No commission payout has been created yet for this deal.",
-                           "type": "info"},
+                "params": {
+                    "title": "No Payout Record",
+                    "message": "No commission payout has been created yet for this deal.",
+                    "type": "info",
+                },
             }
         return {
             "type": "ir.actions.act_window",

--- a/plasticos_facility_profile/models/res_partner.py
+++ b/plasticos_facility_profile/models/res_partner.py
@@ -23,9 +23,7 @@ class ResPartner(models.Model):
             partner.is_company = partner.company_type == "company"
 
     # ── Facility Profile link ─────────────────────────────────────────
-    facility_profile_ids = fields.One2many(
-        "plasticos.facility.profile", "partner_id", string="Facility Capabilities"
-    )
+    facility_profile_ids = fields.One2many("plasticos.facility.profile", "partner_id", string="Facility Capabilities")
     facility_profile_count = fields.Integer(
         string="Capabilities",
         compute="_compute_facility_profile_count",
@@ -251,7 +249,5 @@ class ResPartner(models.Model):
         if "parent_id" in vals and not vals.get("parent_id"):
             for rec in self:
                 if rec.facility_profile_ids:
-                    raise ValidationError(
-                        "Cannot convert facility to parent while capability profile exists."
-                    )
+                    raise ValidationError("Cannot convert facility to parent while capability profile exists.")
         return super().write(vals)

--- a/plasticos_partner_import/models/partner_import_service.py
+++ b/plasticos_partner_import/models/partner_import_service.py
@@ -99,10 +99,16 @@ VS_COMPANY_TYPE_MAP = {
     "unknown": "other",
 }
 
-_SUPPLIER_ONLY_ROLES = frozenset({
-    "recycler", "commercial_recycler", "mrf", "transfer_station",
-    "distribution_center", "grower_farm",
-})
+_SUPPLIER_ONLY_ROLES = frozenset(
+    {
+        "recycler",
+        "commercial_recycler",
+        "mrf",
+        "transfer_station",
+        "distribution_center",
+        "grower_farm",
+    }
+)
 _BUYER_ONLY_ROLES = frozenset({"manufacturer", "compounder"})
 _ROLE_ORIGIN_SECTOR_DEFAULTS = {
     "grower_farm": "agriculture",
@@ -130,13 +136,15 @@ class PlasticosPartnerImportService(models.AbstractModel):
 
         model = env[model_name]
         rec = model.create(values)
-        self.env["ir.model.data"].create({
-            "name": external_id.split(".")[-1],
-            "module": external_id.split(".")[0],
-            "model": model_name,
-            "res_id": rec.id,
-            "noupdate": True,
-        })
+        self.env["ir.model.data"].create(
+            {
+                "name": external_id.split(".")[-1],
+                "module": external_id.split(".")[0],
+                "model": model_name,
+                "res_id": rec.id,
+                "noupdate": True,
+            }
+        )
         _logger.debug("Created %s via %s (id=%d)", model_name, external_id, rec.id)
         return rec
 
@@ -190,10 +198,7 @@ class PlasticosPartnerImportService(models.AbstractModel):
     def _apply_vanillasoft_lead_source(self, partner):
         if partner.lead_source_id:
             return
-        vs_source = self.env.ref(
-            "plasticos_facility_profile.utm_source_vanillasoft",
-            raise_if_not_found=False
-        )
+        vs_source = self.env.ref("plasticos_facility_profile.utm_source_vanillasoft", raise_if_not_found=False)
         if vs_source:
             partner.lead_source_id = vs_source.id
 
@@ -219,9 +224,7 @@ class PlasticosPartnerImportService(models.AbstractModel):
         if not country_name:
             return False
         country = self.env["res.country"].search(
-            ["|",
-             ("name", "ilike", country_name.strip()),
-             ("code", "=", country_name.strip().upper()[:2])],
+            ["|", ("name", "ilike", country_name.strip()), ("code", "=", country_name.strip().upper()[:2])],
             limit=1,
         )
         return country.id if country else False
@@ -477,8 +480,7 @@ class PlasticosPartnerImportService(models.AbstractModel):
         contact_email = self._normalize_email(row.get("Email", ""), contact_name)
         if contact_name and contact_name not in ("Primary", "United States"):
             contact = self._create_facility_contact(
-                facility, parent, contact_name, contact_phone,
-                contact_email, facility_type, contacts_created
+                facility, parent, contact_name, contact_phone, contact_email, facility_type, contacts_created
             )
         return facility, contact
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ exclude = [
     ".venv",
     "venv",
     "*.egg-info",
+    "current work - ib",
 ]
 
 [tool.ruff.lint]


### PR DESCRIPTION
## Summary

**Makefile** (new at repo root):
- `make lint` / `make format` / `make format-fix` — ruff with consistent excludes
- `make check` — pre-commit gate (lint + format)
- `make audit-quick` — fast pre-PR: lint, format, xml, odoo19 patterns, wiring, deps, cron
- `make audit` — full suite (audit-quick + semgrep + all ci/ scripts)
- `make up/down/restart/logs/shell` — docker compose shortcuts
- `make update m=plasticos_commission` — `-u` module shortcut
- `make rebuild` — drop + full rebuild no demo
- `make test` / `make test-module m=<mod>` — test runner
- `make pr-check` — full PR gate (should run before every PR open)

**pyproject.toml**: add `current work - ib` to ruff exclude list so gitignored drafts don't fail lint

**ruff format**: auto-applied to 6 files (admin_dashboard, commission models, res_partner, partner_import_service) that were formatted slightly differently from the project standard