### PR TITLE
fix(plasticos_commission): break circular dependency with plasticos_transaction

### DIFF
--- a/plasticos_commission/__manifest__.py
+++ b/plasticos_commission/__manifest__.py
@@ -20,6 +20,7 @@
         "data/commission_payout_sequence.xml",
         "views/commission_payout_views.xml",
         "views/sales_dashboard_views.xml",
+        "views/transaction_commission_views.xml",
     ],
     "installable": True,
     "application": False,

--- a/plasticos_commission/models/__init__.py
+++ b/plasticos_commission/models/__init__.py
@@ -2,3 +2,4 @@ from . import commission_rule
 from . import commission_service
 from . import commission_payout
 from . import sales_dashboard
+from . import transaction_commission

--- a/plasticos_commission/models/transaction_commission.py
+++ b/plasticos_commission/models/transaction_commission.py
@@ -1,0 +1,94 @@
+"""Commission extension for plasticos.transaction.
+
+Adds commission fields and overrides to the transaction model.
+This extension pattern avoids the circular dependency:
+  plasticos_transaction → plasticos_commission → plasticos_transaction (WRONG)
+  plasticos_commission _inherits_ plasticos_transaction (CORRECT — one direction only)
+"""
+
+from odoo import api, fields, models
+from odoo.exceptions import UserError, ValidationError
+
+
+class PlasticosTransactionCommission(models.Model):
+    _inherit = "plasticos.transaction"
+
+    # ── Commission Fields ─────────────────────────────────────────────────────
+    commission_rule_id = fields.Many2one(
+        "plasticos.commission.rule",
+        string="Commission Rule",
+        tracking=True,
+    )
+    commission_locked = fields.Boolean(
+        string="Commission Locked",
+        default=False,
+        copy=False,
+        tracking=True,
+        help="When True, commission_amount is frozen at commission_locked_amount.",
+    )
+    commission_locked_amount = fields.Float(
+        string="Locked Commission",
+        copy=False,
+        help="The commission amount captured at close time.",
+    )
+    commission_override_pct = fields.Float(
+        string="Commission Override %",
+        help="Admin override: fraction 0.0–1.0. Leave 0 to use rule. Only managers can edit.",
+        groups="plasticos_transaction.group_plasticos_manager",
+    )
+
+    # ── Commission Compute ────────────────────────────────────────────────────
+
+    @api.depends(
+        "gross_margin",
+        "commission_rule_id",
+        "commission_override_pct",
+        "state",
+        "commission_locked",
+        "commission_locked_amount",
+    )
+    def _compute_commission(self):
+        """Override base stub — compute actual commission via service."""
+        service = self.env["plasticos.commission.service"]
+        for rec in self:
+            if rec.commission_locked:
+                rec.commission_amount = rec.commission_locked_amount or 0.0
+                continue
+            rec.commission_amount = service.compute_commission(rec)
+
+    @api.depends("gross_margin", "commission_amount")
+    def _compute_net_margin(self):
+        """Override base — net margin = gross margin - commission."""
+        for rec in self:
+            rec.net_margin = rec.gross_margin - (rec.commission_amount or 0.0)
+
+    # ── Commission Constraints ────────────────────────────────────────────────
+
+    @api.constrains("commission_override_pct")
+    def _check_override_pct_range(self):
+        """Override base stub — validate commission override is a fraction 0.0–1.0."""
+        for rec in self:
+            if rec.commission_override_pct and not (0.0 <= rec.commission_override_pct <= 1.0):
+                raise ValidationError(
+                    "Commission override percentage must be between 0.0 and 1.0 (e.g., 0.15 for 15%)."
+                )
+
+    # ── Write Guards ──────────────────────────────────────────────────────────
+
+    def _validate_write_immutability(self, rec, vals):
+        """Override to add commission immutability guards."""
+        super()._validate_write_immutability(rec, vals)
+        if rec.state == "closed" and "commission_rule_id" in vals:
+            raise UserError("Closed transactions are immutable.")
+        if rec.commission_locked and "commission_rule_id" in vals:
+            raise UserError("Commission cannot be modified after lock.")
+
+    # ── Close Override ────────────────────────────────────────────────────────
+
+    def _apply_close(self, rec):
+        """Override to lock commission at close time, then write state."""
+        service = self.env["plasticos.commission.service"]
+        amount = service.compute_commission(rec)
+        rec.commission_locked_amount = amount
+        rec.commission_locked = True
+        super()._apply_close(rec)

--- a/plasticos_commission/views/transaction_commission_views.xml
+++ b/plasticos_commission/views/transaction_commission_views.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <!-- ═══════════════════════════════════════════════════════════════════
+         Commission tab — injected into plasticos.transaction form view.
+         Defined here (not in plasticos_transaction) to break the circular
+         dependency: transaction no longer depends on commission module.
+         ═══════════════════════════════════════════════════════════════════ -->
+
+    <record id="view_transaction_form_commission" model="ir.ui.view">
+        <field name="name">plasticos.transaction.form.commission</field>
+        <field name="model">plasticos.transaction</field>
+        <field name="inherit_id" ref="plasticos_transaction.view_transaction_form"/>
+        <field name="priority">10</field>
+        <field name="arch" type="xml">
+            <!-- Insert Commission tab before the Compliance tab -->
+            <xpath expr="//page[@string='Compliance']" position="before">
+                <page string="Commission">
+                    <group>
+                        <field name="commission_rule_id"/>
+                        <field name="commission_amount"/>
+                        <field name="commission_locked"/>
+                        <field name="commission_locked_amount" invisible="not commission_locked"/>
+                    </group>
+                </page>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/plasticos_transaction/__manifest__.py
+++ b/plasticos_transaction/__manifest__.py
@@ -20,7 +20,6 @@
         "plasticos_product",
         "plasticos_offer",
         # "plasticos_matching",  # Disabled - external microservice
-        "plasticos_commission",
     ],
     "data": [
         "security/security_hardening.xml",

--- a/plasticos_transaction/models/audit_cron.py
+++ b/plasticos_transaction/models/audit_cron.py
@@ -21,13 +21,19 @@ class PlasticosAuditCron(models.Model):
             return
 
         try:
-            violations = tx_model.search(
-                [
+            # commission_locked is defined by plasticos_commission extension;
+            # only filter on it when the field exists
+            domain = [("state", "=", "closed"), ("gross_margin", "<", 0)]
+            commission_field_exists = "commission_locked" in tx_model._fields
+            if commission_field_exists:
+                domain = [
                     ("state", "=", "closed"),
                     "|",
                     ("gross_margin", "<", 0),
                     ("commission_locked", "=", False),
-                ],
+                ]
+            violations = tx_model.search(
+                domain,
                 order="write_date ASC, id ASC",
                 limit=500,
             )

--- a/plasticos_transaction/models/transaction.py
+++ b/plasticos_transaction/models/transaction.py
@@ -392,14 +392,15 @@ class PlasticosTransaction(models.Model):
         help="Gross margin - commission (company profit).",
     )
 
-    commission_rule_id = fields.Many2one("plasticos.commission.rule")
-    commission_amount = fields.Float(compute="_compute_commission", store=True)
-    commission_locked = fields.Boolean(default=False, copy=False)
-    commission_locked_amount = fields.Float(copy=False)
-    commission_override_pct = fields.Float(
-        string="Commission Override %",
-        help="Admin override: fraction 0.0–1.0. Leave 0 to use rule. Only managers can edit.",
-        groups="plasticos_transaction.group_plasticos_manager",
+    # Commission fields (commission_rule_id, commission_locked, commission_locked_amount,
+    # commission_override_pct) are defined by plasticos_commission via _inherit extension
+    # (transaction_commission.py) to avoid circular dependency.
+    # commission_amount is kept here as a stub so _compute_net_margin works without
+    # requiring the commission module.
+    commission_amount = fields.Float(
+        compute="_compute_commission",
+        store=True,
+        help="Computed by plasticos_commission extension. Zero when commission not installed.",
     )
 
     compliance_status = fields.Selection(
@@ -484,12 +485,7 @@ class PlasticosTransaction(models.Model):
 
     @api.constrains("commission_override_pct")
     def _check_override_pct_range(self):
-        """Validate commission override is a fraction 0.0–1.0."""
-        for rec in self:
-            if rec.commission_override_pct and not (0.0 <= rec.commission_override_pct <= 1.0):
-                raise ValidationError(
-                    "Commission override percentage must be between 0.0 and 1.0 (e.g., 0.15 for 15%)."
-                )
+        """Stub — overridden by plasticos_commission.transaction_commission."""
 
     # ── Default Delivery Term Helper ─────────────────────────
     def _get_default_delivery_term(self):
@@ -760,7 +756,7 @@ class PlasticosTransaction(models.Model):
 
     @api.depends("gross_margin", "commission_amount")
     def _compute_net_margin(self):
-        """Net margin = gross margin - commission."""
+        """Net margin = gross margin - commission. Overridden by plasticos_commission."""
         for rec in self:
             rec.net_margin = rec.gross_margin - (rec.commission_amount or 0.0)
 
@@ -776,25 +772,13 @@ class PlasticosTransaction(models.Model):
             rec.freight_chargebacks = 0.0
             rec.lightweight_penalties = 0.0
 
-    @api.depends(
-        "gross_margin",
-        "commission_rule_id",
-        "commission_override_pct",
-        "state",
-        "commission_locked",
-        "commission_locked_amount",
-    )
+    @api.depends()
     def _compute_commission(self):
-        if "plasticos.commission.service" not in self.env:
-            for rec in self:
-                rec.commission_amount = rec.commission_locked_amount or 0.0
-            return
-        service = self.env["plasticos.commission.service"]
+        """Stub — overridden by plasticos_commission.transaction_commission.
+        Falls back to zero when commission module is not installed.
+        """
         for rec in self:
-            if rec.commission_locked:
-                rec.commission_amount = rec.commission_locked_amount or 0.0
-                continue
-            rec.commission_amount = service.compute_commission(rec)
+            rec.commission_amount = 0.0
 
     @api.depends("create_date")
     def _compute_compliance(self):
@@ -893,7 +877,10 @@ class PlasticosTransaction(models.Model):
                 raise UserError("State can only be changed via action methods.")
 
     def _validate_write_immutability(self, rec, vals):
-        """Guard immutable fields: name, closed-state fields, commission lock, invoice reassignment."""
+        """Guard immutable fields: name, closed-state fields, invoice reassignment.
+        Commission-specific guards (commission_rule_id, commission_locked) are
+        enforced by plasticos_commission.transaction_commission.
+        """
         if "name" in vals:
             raise UserError("Transaction reference cannot be modified.")
         if rec.state == "closed":
@@ -903,12 +890,9 @@ class PlasticosTransaction(models.Model):
                 "customer_invoice_id",
                 "vendor_bill_ids",
                 "freight_bill_ids",
-                "commission_rule_id",
             }
             if protected.intersection(vals.keys()):
                 raise UserError("Closed transactions are immutable.")
-        if rec.commission_locked and "commission_rule_id" in vals:
-            raise UserError("Commission cannot be modified after lock.")
         if rec.customer_invoice_id and "customer_invoice_id" in vals:
             if vals["customer_invoice_id"] != rec.customer_invoice_id.id:
                 raise UserError("Customer invoice cannot be reassigned once set.")
@@ -951,15 +935,10 @@ class PlasticosTransaction(models.Model):
 
     def action_close(self):
         service_docs = self.env["plasticos.compliance.service"] if "plasticos.compliance.service" in self.env else None
-        service_commission = (
-            self.env["plasticos.commission.service"] if "plasticos.commission.service" in self.env else None
-        )
 
         for rec in self:
-            # Validate preconditions FIRST (includes auth check), before acquiring lock
             self._validate_close_preconditions(rec, service_docs)
 
-            # Now acquire advisory lock for the actual close operation
             self.env.cr.execute(
                 "SELECT pg_try_advisory_lock(hashtext(%s))",
                 [f"plasticos_transaction.close_{rec.id}"],
@@ -968,7 +947,7 @@ class PlasticosTransaction(models.Model):
             if not locked:
                 raise UserError(f"Transaction {rec.name} is already being closed by another process.")
             try:
-                self._apply_close(rec, service_commission)
+                self._apply_close(rec)
             finally:
                 self.env.cr.execute(
                     "SELECT pg_advisory_unlock(hashtext(%s))",
@@ -998,16 +977,9 @@ class PlasticosTransaction(models.Model):
         if rec.gross_margin < 0:
             raise UserError("Cannot close transaction with negative gross margin.")
 
-    def _apply_close(self, rec, service_commission):
-        """Compute commission and write the closed state onto the transaction record."""
-        amount = service_commission.compute_commission(rec) if service_commission else 0.0
-        rec.write(
-            {
-                "commission_locked_amount": amount,
-                "commission_locked": True,
-                "state": "closed",
-            }
-        )
+    def _apply_close(self, rec):
+        """Write closed state. Commission locking is applied by plasticos_commission extension."""
+        rec.with_context(bypass_state_guard=True).write({"state": "closed"})
 
     # ═════════════════════════════════════════════════════════
     # State Transition Action Methods (for crons/system processes)

--- a/plasticos_transaction/views/transaction_views.xml
+++ b/plasticos_transaction/views/transaction_views.xml
@@ -186,14 +186,7 @@
                                 </group>
                             </group>
                         </page>
-                        <page string="Commission">
-                            <group>
-                                <field name="commission_rule_id"/>
-                                <field name="commission_amount"/>
-                                <field name="commission_locked"/>
-                                <field name="commission_locked_amount" invisible="not commission_locked"/>
-                            </group>
-                        </page>
+                        <!-- Commission tab rendered by plasticos_commission/views/transaction_commission_views.xml -->
                         <page string="Compliance">
                             <group>
                                 <field name="compliance_status"/>


### PR DESCRIPTION
## Problem

`plasticos_transaction` → depends on `plasticos_commission` → depends on `plasticos_transaction` — circular dependency that fails `ci/check_circular_deps.py`.

## Fix

Moved commission fields and methods OUT of `transaction.py` INTO a new `_inherit` extension (`transaction_commission.py`) in `plasticos_commission`. Same pattern used by `plasticos_claims` and `plasticos_documents` bridges.

**Dependency after fix:** `plasticos_commission` → `plasticos_transaction` (one direction only ✅)

## Changes

- `plasticos_transaction/__manifest__.py`: remove `plasticos_commission` from depends
- `plasticos_transaction/models/transaction.py`: keep `commission_amount` stub (so `net_margin` always computes), stubs for `_compute_commission` / `_check_override_pct_range`, simplified `_apply_close` uses `bypass_state_guard`
- `plasticos_transaction/models/audit_cron.py`: guard `commission_locked` domain behind field-exists check
- `plasticos_transaction/views/transaction_views.xml`: remove Commission tab (replaced by inherit view below)
- `plasticos_commission/models/transaction_commission.py` (NEW): `_inherit = 'plasticos.transaction'` with all 5 commission fields, real `_compute_commission`, `_compute_net_margin` override, `_validate_write_immutability` override, `_apply_close` override
- `plasticos_commission/views/transaction_commission_views.xml` (NEW): injects Commission tab into transaction form

## Verified

`ci/check_circular_deps.py` → ✅ No circular dependencies found