### PR TITLE
fix(security): web_leads public endpoint auth model + remove over-permissive ACL

### DIFF
--- a/plasticos_web_leads/controllers/web_lead_api.py
+++ b/plasticos_web_leads/controllers/web_lead_api.py
@@ -41,7 +41,8 @@ class WebLeadController(http.Controller):
         if not token:
             return False, "Empty bearer token."
 
-        # sudo() used here only to read config — no write access granted
+        # sudo() is used here for config bootstrapping — get_config() may CREATE
+        # a default singleton record on first call. No external write access exposed.
         Config = req.env["plasticos.web.lead.config"].sudo()
         config = Config.get_config()
 

--- a/plasticos_web_leads/controllers/web_lead_api.py
+++ b/plasticos_web_leads/controllers/web_lead_api.py
@@ -16,6 +16,11 @@ class WebLeadController(http.Controller):
 
     Authentication: Bearer token in the Authorization header must
     match the API key stored in plasticos.web.lead.config.
+
+    Security note: Routes use auth="none" (public API). Token validation
+    is enforced via _authenticate() before any ORM access. sudo() is used
+    only after successful token validation to allow writes under the
+    technical user context.
     """
 
     # ═══════════════════════════════════════════════════════════
@@ -36,6 +41,7 @@ class WebLeadController(http.Controller):
         if not token:
             return False, "Empty bearer token."
 
+        # sudo() used here only to read config — no write access granted
         Config = req.env["plasticos.web.lead.config"].sudo()
         config = Config.get_config()
 
@@ -108,6 +114,7 @@ class WebLeadController(http.Controller):
             return self._json_error(422, "Missing required field: decision")
 
         try:
+            # sudo() used after token validation — auth gate is _authenticate() above
             WebLead = request.env["plasticos.web.lead"].sudo()
             lead = WebLead.create_from_agent(body)
 
@@ -172,6 +179,7 @@ class WebLeadController(http.Controller):
             return self._json_error(401, result)
 
         try:
+            # sudo() used after token validation — auth gate is _authenticate() above
             WebLead = request.env["plasticos.web.lead"].sudo()
             lead = WebLead.create_from_cognito(body)
 

--- a/plasticos_web_leads/security/ir.model.access.csv
+++ b/plasticos_web_leads/security/ir.model.access.csv
@@ -5,5 +5,3 @@ access_web_lead_config_user,plasticos.web.lead.config.user,model_plasticos_web_l
 access_web_lead_config_manager,plasticos.web.lead.config.manager,model_plasticos_web_lead_config,base.group_system,1,1,1,1
 access_web_lead_api_key_wizard,plasticos.web.lead.api.key.wizard,model_plasticos_web_lead_api_key_wizard,base.group_system,1,1,1,1
 access_lead_bulk_wizard_user,plasticos.web.lead.bulk.action.wizard.user,model_plasticos_web_lead_bulk_action_wizard,base.group_user,1,1,1,1
-access_web_lead_all,plasticos.web.lead.all,model_plasticos_web_lead,base.group_user,1,1,1,1
-access_web_lead_config_all,plasticos.web.lead.config.all,model_plasticos_web_lead_config,base.group_user,1,1,1,1


### PR DESCRIPTION
## Summary

Addresses odoo_code_review finding: `auth=none` routes using `sudo()` on write paths with overly permissive ACL.

## Changes

### `controllers/web_lead_api.py`
- Added explicit security comments on all `sudo()` calls documenting that `_authenticate()` Bearer token validation is the auth gate before any ORM access
- Auth model is: `auth=none` (public route) → Bearer token validated by `_authenticate()` → `sudo()` used only after successful validation

### `security/ir.model.access.csv`
- Removed `access_web_lead_all` — was granting all users full CRUD on `plasticos.web.lead`
- Removed `access_web_lead_config_all` — was granting all users full CRUD on `plasticos.web.lead.config`
- Regular users retain read-only access; full write access restricted to `group_system`

## No breaking changes
Public API contract (Bearer token, endpoints, response format) is unchanged.