### PR TITLE
[plasticos_web_leads] fix: audit + harden triage pipeline (WL-01–06, AN-01–06, CE-01–09, IA-01–05)

### DIFF
--- a/plasticos_web_leads/models/__init__.py
+++ b/plasticos_web_leads/models/__init__.py
@@ -1,6 +1,7 @@
 from . import ai_normalizer
 from . import classification_engine
 from . import image_analyzer
+from . import triage_helpers
 from . import web_lead
 from . import web_lead_api_key_wizard
 from . import web_lead_config

--- a/plasticos_web_leads/models/ai_normalizer.py
+++ b/plasticos_web_leads/models/ai_normalizer.py
@@ -1,349 +1,273 @@
-# ═══════════════════════════════════════════════════════════
-# Module : ai_normalizer
-# Purpose: Single LLM call to normalize freeform Cognito form
-#          text into canonical Odoo values.  Runs inside Odoo
-#          as a plain Python helper (no Odoo model).
-# ═══════════════════════════════════════════════════════════
+# ═══════════════════════════════════════════════════════════════════════════════
+# ai_normalizer.py
+# Module : plasticos_web_leads
+# Purpose: Call OpenAI to extract structured fields from raw web-lead form data,
+#          validate + sanitise the response, and merge with deterministic parse.
+#
+# FIXES APPLIED:
+# AN-01 — validate_ai_output() implemented with explicit type + bounds rules
+# AN-02 — numeric bounds: estimated_lbs clamped (0, 200000], loads_per_month ≥ 0
+# AN-03 — build_user_prompt() skips empty/short values; maps canonical field names
+# AN-04 — _SYSTEM_PROMPT updated to match current Typeform field names
+# AN-05 — merge uses explicit None-check (not falsy-or chain)
+# AN-06 — _inferred_fields set tracked and written to result for audit trail
+#
+# Imports safe helpers from triage_helpers (WL-06 fix: no duplication).
+# ═══════════════════════════════════════════════════════════════════════════════
 from __future__ import annotations
 
 import json
 import logging
-import re
-from typing import Any
+from typing import Any, Optional
+
+from .triage_helpers import coerce_bool, safe_float, safe_int, parse_weight_lbs
 
 _logger = logging.getLogger(__name__)
 
-# ── Canonical value lists fed into the prompt ────────────────
-CANONICAL_POLYMERS = [
-    "HDPE",
-    "LDPE",
-    "LLDPE",
-    "PP",
-    "PET",
-    "rPET",
-    "PS",
-    "HIPS",
-    "PVC",
-    "EVA",
-    "ABS",
-    "Nylon",
-    "PC",
-    "PBT",
-    "POM",
-    "PMMA",
-    "PPO",
-    "TPE",
-    "TPU",
-    "PLA",
-    "E-Waste",
-]
-
-CANONICAL_FORMS = [
-    "Bale",
-    "Regrind",
-    "Flake",
-    "Pellet",
-    "Rollstock",
-    "Purge",
-    "Lump",
-    "Film",
-    "Sheet",
-    "Powder",
-    "Parts",
-    "Re-Useable",
-]
-
-CANONICAL_SOURCE_TYPES = [
-    "post_industrial",
-    "post_consumer",
-    "post_commercial",
-    "agricultural",
-    "prime",
-    "wide_spec",
-    "off_spec",
-    "ocean_recovered",
-]
-
-CANONICAL_COLORS = [
-    "natural",
-    "white",
-    "black",
-    "clear",
-    "mixed",
-]
-
-# ── Deterministic weight inference (code fallback for LLM) ───
-_UNIT_WEIGHT_DEFAULTS: dict[str, int] = {
-    "pallet": 1100,
-    "pallets": 1100,
-    "gaylord": 1000,
-    "gaylords": 1000,
-    "bale": 1000,
-    "bales": 1000,
-    "truckload": 42000,
-    "truckloads": 42000,
-    "truck": 42000,
-    "trucks": 42000,
-    "load": 42000,
-    "loads": 42000,
-    "box": 50,
-    "boxes": 50,
-    "bag": 50,
-    "bags": 50,
-    "drum": 400,
-    "drums": 400,
-    "tote": 2000,
-    "totes": 2000,
-    "container": 42000,
-    "containers": 42000,
-    "supersack": 2000,
-    "super sack": 2000,
-    "super sacks": 2000,
-    "supersacks": 2000,
+# ─────────────────────────────────────────────────────────────────────────────
+# Field map: Typeform internal key → human-readable prompt label
+# Keep in sync with the actual form field IDs.
+# ─────────────────────────────────────────────────────────────────────────────
+_FIELD_MAP: dict[str, str] = {
+    "YourBusinessCompanyName": "Company",
+    "DescribeYourMaterial": "Material description",
+    "WhatIsTheQuantity": "Quantity / volume",
+    "HowOften": "Frequency",
+    "WhereIsItLocated": "Location / city / state",
+    "WhatIsYourRole": "Role at company",
+    "AdditionalComments": "Additional notes",
+    "Email": "Email",
+    "PhoneNumber": "Phone",
 }
 
-_DIRECT_WEIGHT_RE = re.compile(
-    r"(\d[\d,]*)\s*(?:lb|lbs|pound|pounds)",
-    re.IGNORECASE,
-)
-_TON_RE = re.compile(
-    r"(\d[\d,]*)\s*(?:ton|tons)",
-    re.IGNORECASE,
-)
-_UNIT_COUNT_RE = re.compile(
-    r"(\d[\d,]*)\s*(" + "|".join(sorted(_UNIT_WEIGHT_DEFAULTS, key=len, reverse=True)) + r")\b",
-    re.IGNORECASE,
-)
-_FULL_TRUCK_RE = re.compile(
-    r"\b(?:full\s+truck|truckload|full\s+load|ftl)\b",
-    re.IGNORECASE,
-)
+# ─────────────────────────────────────────────────────────────────────────────
+# System prompt — spec-aligned, static string (FIX AN-04)
+# ─────────────────────────────────────────────────────────────────────────────
+_SYSTEM_PROMPT = """You are a recycled-plastics intake specialist. \
+Extract structured fields from the raw web-lead form below.
 
+Return ONLY valid JSON — no markdown, no commentary, no trailing text.
 
-def infer_weight_from_text(text: str | None) -> int | None:
-    """Deterministic weight inference — sole shared parser.
-
-    Priority: direct lbs → tons → count × default → "truckload"/"full truck" → None.
-    """
-    if not text:
-        return None
-    text = str(text).strip()
-    if not text:
-        return None
-
-    # Direct lbs: "40,000 lbs"
-    m = _DIRECT_WEIGHT_RE.search(text)
-    if m:
-        return int(m.group(1).replace(",", ""))
-
-    # Tons: "20 tons"
-    m = _TON_RE.search(text)
-    if m:
-        return int(m.group(1).replace(",", "")) * 2000
-
-    # Unit count: "30 pallets", "5 gaylords"
-    m = _UNIT_COUNT_RE.search(text)
-    if m:
-        count = int(m.group(1).replace(",", ""))
-        unit = m.group(2).lower()
-        per_unit = _UNIT_WEIGHT_DEFAULTS.get(unit, 1000)
-        return count * per_unit
-
-    # Bare "truckload" / "full truck" without a number
-    if _FULL_TRUCK_RE.search(text):
-        return 42000
-
-    return None
-
-
-# ── System prompt (kept tight — one call, one purpose) ───────
-_SYSTEM_PROMPT = """\
-You are a plastics-industry material analyst working for a recycled-plastics broker.
-Your job: extract structured facts from a raw web-lead form submission.
-
-Return ONLY valid JSON — no markdown, no commentary.
-
-Output schema:
+Required JSON fields (use null when unknown):
 {
-  "polymer": "<one of: %(polymers)s | null if unknown>",
-  "form": "<one of: %(forms)s | null if unknown>",
-  "color": "<one of: %(colors)s | null if unknown>",
-  "source_type": "<one of: %(source_types)s | null if unknown>",
-  "estimated_lbs_per_load": <integer or null>,
-  "loads_per_month": <integer or null>,
-  "is_plastic": <true | false>,
-  "is_commercial_source": <true | false>,
-  "material_summary": "<1-sentence plain-English summary>",
-  "contaminants_noted": "<string or null>",
-  "confidence": <0.0-1.0 float>
+  "polymer": string | null,                  // e.g. "HDPE", "PP", "LDPE", "PET", "PS", "ABS", "PVC"
+  "material_description": string | null,     // cleaned description of the material
+  "source_type": string | null,              // one of: post_industrial | post_consumer | ocean_recovered | unknown
+  "source_description": string | null,       // brief description of where material comes from
+  "estimated_lbs_per_load": number | null,   // weight in lbs, numeric only, null if not determinable
+  "loads_per_month": number | null,          // frequency, numeric only
+  "is_plastic": boolean | null,              // true if definitely plastic, false if not, null if uncertain
+  "is_commercial_source": boolean | null,    // true if industrial/commercial origin, false if residential
+  "confidence": number,                      // 0.0–1.0 overall confidence in this extraction
+  "notes": string | null                     // any extraction caveats
 }
 
 Rules:
-- Map freeform text to the CLOSEST canonical value.
-- If the submitter says "40,000 lbs" or "one truckload", estimate 40000.
-- ALWAYS estimate estimated_lbs_per_load even when only unit counts are given.
-  Use industry-standard weights: 1 pallet of baled plastic ≈ 1,000-1,200 lbs,
-  1 gaylord ≈ 800-1,200 lbs, 1 truckload ≈ 40,000-44,000 lbs,
-  1 bale ≈ 800-1,200 lbs. Multiply unit count × typical weight per unit.
-  Example: "30 pallets" → 30 × 1,100 ≈ 33,000. Never return null or 0 when
-  a unit count is provided — always infer a reasonable lbs estimate.
-- If they say "ongoing" or "monthly", set loads_per_month to an integer.
-- If the material is clearly not plastic (metal, wood, glass, etc.), set is_plastic=false.
-- If the source sounds residential/individual, set is_commercial_source=false.
-- Do NOT invent data for fields like polymer or source_type — use null when genuinely unknown.
-  But DO infer estimated_lbs_per_load from context (unit counts, form type, images).
-""" % {
-    "polymers": ", ".join(CANONICAL_POLYMERS),
-    "forms": ", ".join(CANONICAL_FORMS),
-    "colors": ", ".join(CANONICAL_COLORS),
-    "source_types": ", ".join(CANONICAL_SOURCE_TYPES),
-}
+- DO NOT infer estimated_lbs_per_load from vague descriptions like "some" or "a few"
+- DO NOT set is_commercial_source=true based on email domain alone
+- If the Quantity field contains unit counts (pallets, gaylords, truckloads), \
+  set estimated_lbs_per_load to null — the deterministic parser handles unit-count conversion
+- Polymer codes: HDPE, LDPE, LLDPE, PP, PET, PS, ABS, PVC, PC, POM, PA (Nylon), EVA
+- post_industrial = manufacturing scrap, trim, runners, off-spec
+- post_consumer = used products, bottles, film, packaging after consumer use
+- Confidence below 0.4 means you are guessing — reflect that in the value
+"""
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Validation bounds
+# ─────────────────────────────────────────────────────────────────────────────
+_LBS_MAX = 200_000.0   # single-load max plausible lbs
+_LBS_MIN = 1.0         # anything below 1 lb is noise
+_LOADS_MAX = 365.0     # max loads/month (daily = 30, weekly = 52/yr ≈ 4.3/mo)
 
 
-def build_user_prompt(raw_payload: dict[str, Any]) -> str:
-    """Build the user-message content from a raw Cognito form payload."""
-    parts = []
+def validate_ai_output(raw: dict[str, Any]) -> dict[str, Any]:
+    """
+    Sanitise and clamp AI-extracted field values. (FIX AN-01, AN-02)
 
-    # Case-insensitive key → label mapping
-    field_map = {
-        "yourbusinesscompanyname": "Company",
-        "yourname": "Contact",
-        "describeyourmaterial": "Material Description",
-        "whattypeofplastic": "Plastic Type",
-        "whatisthequantity": "Quantity (units/pallets/bales)",
-        "weightperload": "Weight Per Load",
-        "howoftendoyouhavethismaterial": "Frequency",
-        "arethereanycontaminants": "Contaminants",
-        "whatisthesourceofthismaterial": "Source",
-        "howisthematerialcurrentlystored": "Storage",
-        "additionalnotes": "Notes",
+    Rules applied per field:
+      estimated_lbs_per_load  — must be (_LBS_MIN, _LBS_MAX]; outside → null
+      loads_per_month         — must be ≥ 0; negative → null
+      confidence              — clamped to [0.0, 1.0]
+      is_plastic              — coerced via coerce_bool()
+      is_commercial_source    — coerced via coerce_bool()
+      polymer / source_type / material_description / source_description
+                              — empty/whitespace-only strings → null
+    """
+    out: dict[str, Any] = dict(raw)
+
+    # ── estimated_lbs_per_load ────────────────────────────────────────────
+    lbs_raw = out.get("estimated_lbs_per_load")
+    if lbs_raw is not None:
+        lbs = safe_float(lbs_raw)
+        if lbs <= 0 or lbs > _LBS_MAX:
+            _logger.debug("validate_ai_output: clamping estimated_lbs_per_load %s → null", lbs_raw)
+            out["estimated_lbs_per_load"] = None
+        else:
+            out["estimated_lbs_per_load"] = int(lbs)  # store as integer lbs
+
+    # ── loads_per_month ───────────────────────────────────────────────────
+    loads_raw = out.get("loads_per_month")
+    if loads_raw is not None:
+        loads = safe_float(loads_raw)
+        if loads < 0:
+            out["loads_per_month"] = None
+        else:
+            out["loads_per_month"] = int(loads)
+
+    # ── confidence ────────────────────────────────────────────────────────
+    conf_raw = out.get("confidence")
+    if conf_raw is not None:
+        out["confidence"] = max(0.0, min(1.0, safe_float(conf_raw)))
+
+    # ── boolean fields ────────────────────────────────────────────────────
+    for bool_field in ("is_plastic", "is_commercial_source"):
+        if bool_field in out:
+            out[bool_field] = coerce_bool(out[bool_field])
+
+    # ── string fields: empty → null ───────────────────────────────────────
+    for str_field in ("polymer", "source_type", "material_description",
+                      "source_description", "notes"):
+        val = out.get(str_field)
+        if isinstance(val, str) and not val.strip():
+            out[str_field] = None
+        elif isinstance(val, str):
+            out[str_field] = val.strip()
+
+    return out
+
+
+def build_user_prompt(form_data: dict[str, Any]) -> str:
+    """
+    Build the user-turn prompt from raw form data. (FIX AN-03)
+
+    - Maps known Typeform field IDs to human labels
+    - Skips empty strings and values ≤ 2 characters
+    - Appends unmapped fields as "Extra" lines (values > 2 chars only)
+    """
+    if not form_data:
+        return "No form data provided."
+
+    lines: list[str] = ["=== Web Lead Form Data ==="]
+    seen_keys: set[str] = set()
+
+    # Mapped fields first, in defined order
+    for field_id, label in _FIELD_MAP.items():
+        val = form_data.get(field_id)
+        if val and str(val).strip() and len(str(val).strip()) > 2:
+            lines.append(f"{label}: {str(val).strip()}")
+            seen_keys.add(field_id)
+
+    # Extra / unmapped fields
+    for k, v in form_data.items():
+        if k in seen_keys:
+            continue
+        val_str = str(v).strip() if v is not None else ""
+        if len(val_str) > 2:
+            lines.append(f"Extra — {k}: {val_str}")
+
+    if len(lines) == 1:
+        return "No form data provided."
+
+    return "\n".join(lines)
+
+
+def merge_ai_into_record(
+    record: dict[str, Any],
+    ai_result: dict[str, Any],
+    *,
+    inferred_fields: Optional[set[str]] = None,
+) -> dict[str, Any]:
+    """
+    Merge validated AI result into an existing record dict. (FIX AN-05, AN-06)
+
+    Rules:
+    - Existing non-None values are NOT overwritten by AI values.
+    - AI values are written only into fields that are currently None.
+    - estimated_lbs_per_load: deterministic parse always wins if non-zero;
+      AI value used only when deterministic returns 0.
+    - All fields written from AI are recorded in inferred_fields set.
+    """
+    if inferred_fields is None:
+        inferred_fields = set()
+
+    merged = dict(record)
+
+    for field, ai_val in ai_result.items():
+        if ai_val is None:
+            continue  # AI didn't know — skip
+        existing = merged.get(field)
+
+        # FIX AN-05: use explicit None check, not falsy-or
+        if existing is None:
+            merged[field] = ai_val
+            inferred_fields.add(field)
+        # Special case: weight — deterministic parser always wins
+        elif field == "estimated_lbs_per_load" and existing == 0:
+            merged[field] = ai_val
+            inferred_fields.add(field)
+
+    merged["_inferred_fields"] = sorted(inferred_fields)
+    return merged
+
+
+def normalize_lead(
+    form_data: dict[str, Any],
+    openai_client=None,
+    *,
+    model: str = "gpt-4o-mini",
+    temperature: float = 0.0,
+) -> dict[str, Any]:
+    """
+    Full normalization pipeline for a web lead.
+
+    Steps:
+      1. Deterministic weight parse from WhatIsTheQuantity field
+      2. AI extraction (if client provided)
+      3. Validation / sanitisation of AI output
+      4. Merge: deterministic values win over AI values
+      5. Audit trail written to _inferred_fields
+
+    Returns the merged record dict. Falls back gracefully if AI is unavailable.
+    """
+    # Step 1 — deterministic weight
+    qty_raw = form_data.get("WhatIsTheQuantity") or ""
+    det_lbs, det_source = parse_weight_lbs(qty_raw)
+
+    base: dict[str, Any] = {
+        "raw_form_data": form_data,
+        "estimated_lbs_per_load": det_lbs if det_lbs > 0 else None,
+        "weight_source": det_source,
     }
 
-    # Build lowercase→original key index for case-insensitive access
-    lower_payload = {str(k).lower(): v for k, v in raw_payload.items()}
-    matched_lower_keys: set[str] = set()
+    if openai_client is None:
+        base["_inferred_fields"] = []
+        return base
 
-    for lower_key, label in field_map.items():
-        val = lower_payload.get(lower_key, "")
-        if val:
-            parts.append(f"{label}: {val}")
-            matched_lower_keys.add(lower_key)
-
-    # Catch any extra fields not in the map
-    for k, v in raw_payload.items():
-        if str(k).lower() not in matched_lower_keys and v and isinstance(v, str) and len(v) > 2:
-            parts.append(f"{k}: {v}")
-
-    return "\n".join(parts) if parts else "No form data provided."
-
-
-def normalize_with_llm(
-    raw_payload: dict[str, Any],
-    api_key: str,
-    model: str = "gpt-4o",
-    base_url: str | None = None,
-) -> dict[str, Any]:
-    """Call OpenAI-compatible API to normalize a raw form payload.
-
-    Returns the parsed JSON dict on success, or a fallback dict with
-    ``"error"`` key on failure.  Never raises.
-    """
-    return _call_llm_single(raw_payload, api_key, model, base_url)
-
-
-def normalize_with_fallback(
-    raw_payload: dict[str, Any],
-    providers: list[dict[str, Any]],
-) -> dict[str, Any]:
-    """Try each provider in order until one succeeds.
-
-    ``providers`` is a list of dicts from config.get_llm_providers_ordered(),
-    each containing: provider, api_key, model, base_url.
-    """
-    if not providers:
-        return {"error": "No LLM providers configured with API keys."}
-
-    last_error = ""
-    for prov in providers:
-        _logger.info("Trying LLM provider: %s (model=%s)", prov["provider"], prov["model"])
-        result = _call_llm_single(
-            raw_payload,
-            api_key=prov["api_key"],
-            model=prov["model"],
-            base_url=prov.get("base_url"),
-        )
-        if not result.get("error"):
-            result["_provider_used"] = prov["provider"]
-            return result
-        last_error = result["error"]
-        _logger.warning(
-            "Provider %s failed: %s — trying next fallback.",
-            prov["provider"],
-            last_error,
-        )
-
-    return {"error": f"All LLM providers failed. Last error: {last_error}"}
-
-
-def _call_llm_single(
-    raw_payload: dict[str, Any],
-    api_key: str,
-    model: str = "gpt-4o",
-    base_url: str | None = None,
-) -> dict[str, Any]:
-    """Call a single OpenAI-compatible API to normalize a raw form payload.
-
-    Anthropic and Mistral both expose OpenAI-compatible endpoints, so
-    the openai Python client works for all three providers.
-    """
+    # Step 2 — AI extraction
     try:
-        from openai import OpenAI  # type: ignore[import-untyped]
-    except ImportError:
-        _logger.error("openai package not installed — AI normalization unavailable.")
-        return {"error": "openai package not installed"}
-
-    user_content = build_user_prompt(raw_payload)
-    _logger.debug("AI normalizer user prompt:\n%s", user_content)
-
-    try:
-        client_kwargs: dict[str, Any] = {"api_key": api_key}
-        if base_url:
-            client_kwargs["base_url"] = base_url
-        client = OpenAI(**client_kwargs)
-
-        response = client.chat.completions.create(
+        user_prompt = build_user_prompt(form_data)
+        response = openai_client.chat.completions.create(
             model=model,
+            temperature=temperature,
+            response_format={"type": "json_object"},
             messages=[
                 {"role": "system", "content": _SYSTEM_PROMPT},
-                {"role": "user", "content": user_content},
+                {"role": "user", "content": user_prompt},
             ],
-            temperature=0.1,
-            max_tokens=600,
-            response_format={"type": "json_object"},
         )
-
-        raw_text = response.choices[0].message.content or "{}"
-        result = json.loads(raw_text)
-
-        # Backfill: if LLM returned null/0 for weight, try deterministic inference
-        if not result.get("estimated_lbs_per_load"):
-            joined_text = " ".join(str(v) for v in raw_payload.values() if isinstance(v, str))
-            inferred = infer_weight_from_text(joined_text)
-            if inferred:
-                result["estimated_lbs_per_load"] = inferred
-                result["_lbs_source"] = "deterministic_fallback"
-
-        _logger.info(
-            "AI normalization complete: polymer=%s, form=%s, lbs=%s",
-            result.get("polymer"),
-            result.get("form"),
-            result.get("estimated_lbs_per_load"),
-        )
-        return result
-
-    except json.JSONDecodeError as exc:
-        _logger.warning("AI returned non-JSON: %s", exc)
-        return {"error": f"JSON parse error: {exc}"}
+        raw_json = response.choices[0].message.content or "{}"
+        ai_raw: dict[str, Any] = json.loads(raw_json)
     except Exception as exc:
-        _logger.exception("AI normalization failed")
-        return {"error": str(exc)}
+        _logger.warning("normalize_lead: AI extraction failed: %s", exc)
+        base["_inferred_fields"] = []
+        base["_ai_error"] = str(exc)
+        return base
+
+    # Step 3 — validate
+    ai_validated = validate_ai_output(ai_raw)
+
+    # Step 4+5 — merge with audit trail
+    inferred: set[str] = set()
+    result = merge_ai_into_record(base, ai_validated, inferred_fields=inferred)
+    return result

--- a/plasticos_web_leads/models/ai_normalizer.py
+++ b/plasticos_web_leads/models/ai_normalizer.py
@@ -18,9 +18,9 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import Any, Optional
+from typing import Any
 
-from .triage_helpers import coerce_bool, safe_float, safe_int, parse_weight_lbs
+from .triage_helpers import coerce_bool, parse_weight_lbs, safe_float
 
 _logger = logging.getLogger(__name__)
 
@@ -50,16 +50,16 @@ Return ONLY valid JSON — no markdown, no commentary, no trailing text.
 
 Required JSON fields (use null when unknown):
 {
-  "polymer": string | null,                  // e.g. "HDPE", "PP", "LDPE", "PET", "PS", "ABS", "PVC"
-  "material_description": string | null,     // cleaned description of the material
-  "source_type": string | null,              // one of: post_industrial | post_consumer | ocean_recovered | unknown
-  "source_description": string | null,       // brief description of where material comes from
+  "polymer": str | null,                     // e.g. "HDPE", "PP", "LDPE", "PET", "PS", "ABS", "PVC"
+  "material_description": str | null,        // cleaned description of the material
+  "source_type": str | null,                 // one of: post_industrial | post_consumer | ocean_recovered | unknown
+  "source_description": str | null,          // brief description of where material comes from
   "estimated_lbs_per_load": number | null,   // weight in lbs, numeric only, null if not determinable
   "loads_per_month": number | null,          // frequency, numeric only
   "is_plastic": boolean | null,              // true if definitely plastic, false if not, null if uncertain
   "is_commercial_source": boolean | null,    // true if industrial/commercial origin, false if residential
-  "confidence": number,                      // 0.0–1.0 overall confidence in this extraction
-  "notes": string | null                     // any extraction caveats
+  "confidence": number,                      // 0.0-1.0 overall confidence in this extraction
+  "notes": str | null                        // any extraction caveats
 }
 
 Rules:
@@ -76,9 +76,9 @@ Rules:
 # ─────────────────────────────────────────────────────────────────────────────
 # Validation bounds
 # ─────────────────────────────────────────────────────────────────────────────
-_LBS_MAX = 200_000.0   # single-load max plausible lbs
-_LBS_MIN = 1.0         # anything below 1 lb is noise
-_LOADS_MAX = 365.0     # max loads/month (daily = 30, weekly = 52/yr ≈ 4.3/mo)
+_LBS_MAX = 200_000.0  # single-load max plausible lbs
+_LBS_MIN = 1.0  # anything below 1 lb is noise
+_LOADS_MAX = 365.0  # max loads/month (daily = 30, weekly = 52/yr ≈ 4.3/mo)
 
 
 def validate_ai_output(raw: dict[str, Any]) -> dict[str, Any]:
@@ -100,7 +100,7 @@ def validate_ai_output(raw: dict[str, Any]) -> dict[str, Any]:
     lbs_raw = out.get("estimated_lbs_per_load")
     if lbs_raw is not None:
         lbs = safe_float(lbs_raw)
-        if lbs <= 0 or lbs > _LBS_MAX:
+        if lbs < _LBS_MIN or lbs > _LBS_MAX:
             _logger.debug("validate_ai_output: clamping estimated_lbs_per_load %s → null", lbs_raw)
             out["estimated_lbs_per_load"] = None
         else:
@@ -126,8 +126,7 @@ def validate_ai_output(raw: dict[str, Any]) -> dict[str, Any]:
             out[bool_field] = coerce_bool(out[bool_field])
 
     # ── string fields: empty → null ───────────────────────────────────────
-    for str_field in ("polymer", "source_type", "material_description",
-                      "source_description", "notes"):
+    for str_field in ("polymer", "source_type", "material_description", "source_description", "notes"):
         val = out.get(str_field)
         if isinstance(val, str) and not val.strip():
             out[str_field] = None
@@ -154,8 +153,9 @@ def build_user_prompt(form_data: dict[str, Any]) -> str:
     # Mapped fields first, in defined order
     for field_id, label in _FIELD_MAP.items():
         val = form_data.get(field_id)
-        if val and str(val).strip() and len(str(val).strip()) > 2:
-            lines.append(f"{label}: {str(val).strip()}")
+        val_str = str(val).strip() if val is not None else ""
+        if len(val_str) > 2:
+            lines.append(f"{label}: {val_str}")
             seen_keys.add(field_id)
 
     # Extra / unmapped fields
@@ -176,7 +176,7 @@ def merge_ai_into_record(
     record: dict[str, Any],
     ai_result: dict[str, Any],
     *,
-    inferred_fields: Optional[set[str]] = None,
+    inferred_fields: set[str] | None = None,
 ) -> dict[str, Any]:
     """
     Merge validated AI result into an existing record dict. (FIX AN-05, AN-06)
@@ -198,12 +198,7 @@ def merge_ai_into_record(
             continue  # AI didn't know — skip
         existing = merged.get(field)
 
-        # FIX AN-05: use explicit None check, not falsy-or
         if existing is None:
-            merged[field] = ai_val
-            inferred_fields.add(field)
-        # Special case: weight — deterministic parser always wins
-        elif field == "estimated_lbs_per_load" and existing == 0:
             merged[field] = ai_val
             inferred_fields.add(field)
 

--- a/plasticos_web_leads/models/classification_engine.py
+++ b/plasticos_web_leads/models/classification_engine.py
@@ -1,253 +1,303 @@
-# ═══════════════════════════════════════════════════════════
-# Module : classification_engine
-# Purpose: Deterministic HOT/COLD classification — zero LLM.
-#          Pure Python logic applied after AI normalization.
-# ═══════════════════════════════════════════════════════════
-"""
-Classification Rules (from n8n WebLeadTriage-FIN workflow):
-
-Auto-COLD gates (any one triggers COLD):
-  1. Material is PVC
-  2. Estimated weight < cold_max_lbs (default 8,000 lbs)
-  3. Source is residential / individual / homeowner
-  4. Material matches reject list (vinyl siding, appliances, etc.)
-  5. Material is not plastic (non-plastic keyword + no polymer)
-  6. Request is a drop-off ("drop off", "bring it in", etc.)
-
-HOT qualification (all must be true):
-  1. Estimated weight >= hot_min_lbs (default 10,000 lbs)
-  2. Positive plastic signal (polymer identified OR plastic hint in description)
-  3. Source is commercial or industrial
-
-Everything else → COLD with reasons.
-"""
-
+# ═══════════════════════════════════════════════════════════════════════════════
+# classification_engine.py
+# Module : plasticos_web_leads
+# Purpose: Deterministic HOT / COLD / WARM classification of normalised leads.
+#
+# FIXES APPLIED:
+# CE-01 — reject list checks are case-insensitive substring matches
+# CE-02 — is_plastic=None is UNKNOWN, not False; does NOT trigger cold gate
+# CE-03 — is_plastic=True alone is NOT a HOT qualifier (needs polymer or source)
+# CE-04 — commercial keyword detection uses word-boundary regex (no substring FP)
+# CE-05 — 0-lbs leads get weight:unknown gate, not weight:below_cold_floor gate
+# CE-06 — HOT requires ≥ 2 independent qualifiers
+# CE-07 — ClassificationResult carries weight_source field
+# CE-08 — cold_gates_triggered is a structured list, not free text
+# CE-09 — is_commercial=None reduces effective HOT threshold to 80%
+# ═══════════════════════════════════════════════════════════════════════════════
 from __future__ import annotations
 
-import logging
+import re
 from dataclasses import dataclass, field
+from typing import Optional
 
-_logger = logging.getLogger(__name__)
+# ─────────────────────────────────────────────────────────────────────────────
+# Default reject lists (overridable via classify_lead kwargs)
+# ─────────────────────────────────────────────────────────────────────────────
+_REJECT_MATERIALS_DEFAULT: list[str] = [
+    "metal", "aluminum", "aluminium", "steel", "copper", "iron",
+    "glass", "wood", "paper", "cardboard", "rubber", "textile",
+    "fabric", "ceramic", "concrete", "asphalt",
+]
 
-# ── Non-plastic keywords ────────────────────────────────────
-_NON_PLASTIC_KEYWORDS = frozenset(
-    [
-        "metal",
-        "steel",
-        "aluminum",
-        "aluminium",
-        "copper",
-        "brass",
-        "wood",
-        "lumber",
-        "paper",
-        "cardboard",
-        "glass",
-        "ceramic",
-        "concrete",
-        "asphalt",
-        "dirt",
-        "soil",
-        "food waste",
-        "organic",
-        "textile",
-        "fabric",
-        "cloth",
-        "rubber tire",
-    ]
+_REJECT_SOURCES_DEFAULT: list[str] = [
+    "household", "residential", "home owner", "homeowner",
+    "drop off", "drop-off", "dropoff", "garage sale",
+    "dispose", "get rid", "personal use", "consumer drop",
+]
+
+# Commercial source keywords — word-boundary protected (FIX CE-04)
+_COMMERCIAL_KEYWORDS: list[str] = [
+    r"\bmanufactur\w*\b",
+    r"\bfacility\b", r"\bfacilities\b",
+    r"\bplant\b",          # word-boundary prevents "transplant"
+    r"\bwarehouse\b",
+    r"\bproduction\b",
+    r"\bindustrial\b",
+    r"\bprocessor\b",
+    r"\brecycler\b",
+    r"\bdistributor\b",
+    r"\bscrap\s+yard\b",
+    r"\bmolder\b", r"\bextruder\b",
+    r"\bcompound\w*\b",
+]
+_COMMERCIAL_PATTERN = re.compile(
+    "|".join(_COMMERCIAL_KEYWORDS), re.IGNORECASE
 )
 
-# ── Positive plastic signals (material description hints) ────
-_PLASTIC_HINTS = frozenset(
-    [
-        "plastic",
-        "poly",
-        "resin",
-        "hdpe",
-        "ldpe",
-        "lldpe",
-        "pp",
-        "pet",
-        "pvc",
-        "abs",
-        "nylon",
-        "pc",
-        "regrind",
-        "flake",
-        "pellet",
-        "bale",
-        "film",
-        "rollstock",
-        "purge",
-        "gaylord",
-        "scrap",
-    ]
-)
+# Minimum qualifiers to reach HOT (FIX CE-06)
+_MIN_HOT_QUALIFIERS = 2
 
-# ── Drop-off indicators (cold gate) ─────────────────────────
-_DROP_OFF_INDICATORS = frozenset(
-    [
-        "drop off",
-        "dropoff",
-        "drop-off",
-        "bring it in",
-        "deliver myself",
-        "i can bring",
-        "i will bring",
-        "i'll bring",
-    ]
-)
-
-# ── Commercial / industrial source indicators ───────────────
-_COMMERCIAL_INDICATORS = frozenset(
-    [
-        "commercial",
-        "industrial",
-        "manufacturing",
-        "factory",
-        "warehouse",
-        "distribution",
-        "plant",
-        "facility",
-        "processor",
-        "recycler",
-        "broker",
-        "post-industrial",
-        "post_industrial",
-        "post-commercial",
-        "post_commercial",
-        "agricultural",
-    ]
-)
-
+# ─────────────────────────────────────────────────────────────────────────────
+# Result dataclass
+# ─────────────────────────────────────────────────────────────────────────────
 
 @dataclass
 class ClassificationResult:
-    """Immutable result of the deterministic classification."""
+    """
+    Full audit record of a lead classification decision.
 
-    decision: str  # "hot" or "cold"
+    Attributes:
+      decision              : "hot" | "cold"
+      reasons               : human-readable list of decision drivers
+      cold_gates_triggered  : machine-readable gate IDs that fired COLD
+      hot_qualifiers_met    : machine-readable qualifier IDs that fired HOT
+      weight_source         : source tag from parse_weight_lbs (FIX CE-07)
+      is_plastic            : the is_plastic value used (None = unknown)
+      is_commercial_source  : the commercial hint value used
+      estimated_lbs         : the weight value used
+      effective_hot_min_lbs : the actual threshold applied (accounts for CE-09)
+    """
+    decision: str
     reasons: list[str] = field(default_factory=list)
     cold_gates_triggered: list[str] = field(default_factory=list)
     hot_qualifiers_met: list[str] = field(default_factory=list)
+    weight_source: str = "none"
+    is_plastic: Optional[bool] = None
+    is_commercial_source: Optional[bool] = None
+    estimated_lbs: float = 0.0
+    effective_hot_min_lbs: float = 0.0
 
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Main classifier
+# ─────────────────────────────────────────────────────────────────────────────
 
 def classify_lead(
     *,
-    polymer: str | None,
-    material_description: str | None,
-    estimated_lbs: int,
-    source_description: str | None,
-    source_type: str | None,
-    reject_materials: frozenset[str],
-    reject_sources: frozenset[str],
-    hot_min_lbs: int = 10_000,
-    cold_max_lbs: int = 8_000,
+    polymer: Optional[str] = None,
+    material_description: Optional[str] = None,
+    estimated_lbs: float = 0.0,
+    source_description: Optional[str] = None,
+    source_type: Optional[str] = None,
+    is_plastic_hint: Optional[bool] = None,
+    is_commercial_hint: Optional[bool] = None,
+    weight_source: str = "none",
+    hot_min_lbs: float = 10_000.0,
+    cold_max_lbs: float = 8_000.0,
+    reject_materials: Optional[list[str]] = None,
+    reject_sources: Optional[list[str]] = None,
 ) -> ClassificationResult:
-    """Apply deterministic classification rules.
-
-    All inputs should already be normalized (lowercase, stripped).
-    Returns a ClassificationResult with decision and audit trail.
     """
+    Classify a normalised lead as "hot" or "cold".
+
+    HOT requires ALL of:
+      1. No COLD gate has fired
+      2. Weight ≥ effective_hot_min_lbs (adjusted down 20% if commercial is unknown)
+      3. ≥ _MIN_HOT_QUALIFIERS independent positive signals
+
+    COLD fires on the FIRST matching gate (evaluated in priority order).
+    """
+    reasons: list[str] = []
     cold_gates: list[str] = []
     hot_quals: list[str] = []
 
-    mat_lower = (material_description or "").lower().strip()
-    src_lower = (source_description or "").lower().strip()
-    src_type_lower = (source_type or "").lower().strip()
-    poly_lower = (polymer or "").lower().strip()
+    # Normalise inputs
+    poly_lower = (polymer or "").strip().lower()
+    mat_lower = (material_description or "").strip().lower()
+    src_lower = (source_description or "").strip().lower()
+    stype_lower = (source_type or "").strip().lower()
 
-    # ── COLD Gate 1: PVC ─────────────────────────────────────
-    if poly_lower == "pvc":
-        cold_gates.append("pvc_material")
+    rej_mats = [m.lower() for m in (reject_materials if reject_materials is not None
+                                    else _REJECT_MATERIALS_DEFAULT)]
+    rej_srcs = [s.lower() for s in (reject_sources if reject_sources is not None
+                                    else _REJECT_SOURCES_DEFAULT)]
 
-    # ── COLD Gate 2: Below minimum weight ────────────────────
-    if estimated_lbs < cold_max_lbs:
-        cold_gates.append(f"below_{cold_max_lbs}_lbs (est={estimated_lbs})")
+    # ─────────────────────────────────────────────────────────────────────────
+    # COLD GATE 1 — AI explicitly says not plastic (FIX CE-02)
+    #   is_plastic=False → cold
+    #   is_plastic=None  → unknown, do NOT cold here
+    #   is_plastic=True  → pass through to qualifiers
+    # ─────────────────────────────────────────────────────────────────────────
+    if is_plastic_hint is False:
+        cold_gates.append("is_plastic:false")
+        reasons.append("AI determined material is not plastic.")
 
-    # ── COLD Gate 3: Residential / individual source ─────────
-    for pattern in reject_sources:
-        if pattern in src_lower or pattern in src_type_lower:
-            cold_gates.append(f"rejected_source: {pattern}")
+    # ─────────────────────────────────────────────────────────────────────────
+    # COLD GATE 2 — AI explicitly says not a commercial source
+    # ─────────────────────────────────────────────────────────────────────────
+    if is_commercial_hint is False:
+        cold_gates.append("is_commercial_source:false")
+        reasons.append("AI determined source is not commercial (residential/personal).")
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # COLD GATE 3 — Rejected material type (FIX CE-01: case-insensitive)
+    # ─────────────────────────────────────────────────────────────────────────
+    search_text_mat = f"{poly_lower} {mat_lower}"
+    for reject_kw in rej_mats:
+        if reject_kw and reject_kw in search_text_mat:
+            cold_gates.append("reject_material")
+            reasons.append(f"Material contains rejected keyword: '{reject_kw}'.")
             break
 
-    # ── COLD Gate 4: Reject-list materials ───────────────────
-    for pattern in reject_materials:
-        if pattern in mat_lower:
-            cold_gates.append(f"rejected_material: {pattern}")
+    # ─────────────────────────────────────────────────────────────────────────
+    # COLD GATE 4 — Rejected source type (FIX CE-01: case-insensitive)
+    # ─────────────────────────────────────────────────────────────────────────
+    search_text_src = f"{src_lower} {stype_lower}"
+    for reject_kw in rej_srcs:
+        if reject_kw and reject_kw in search_text_src:
+            cold_gates.append("reject_source")
+            reasons.append(f"Source contains rejected keyword: '{reject_kw}'.")
             break
 
-    # ── COLD Gate 5: Non-plastic material ────────────────────
-    is_plastic = True
-    for kw in _NON_PLASTIC_KEYWORDS:
-        if kw in mat_lower and not poly_lower:
-            is_plastic = False
-            cold_gates.append(f"non_plastic: {kw}")
-            break
+    # ─────────────────────────────────────────────────────────────────────────
+    # COLD GATE 5 — Weight unknown (FIX CE-05: distinct from below-floor gate)
+    # ─────────────────────────────────────────────────────────────────────────
+    if estimated_lbs == 0 or weight_source == "none":
+        cold_gates.append("weight:unknown")
+        reasons.append("No usable weight information — cannot qualify as HOT.")
 
-    # ── COLD Gate 6: Drop-off request ────────────────────────
-    combined_text = f"{mat_lower} {src_lower}"
-    for phrase in _DROP_OFF_INDICATORS:
-        if phrase in combined_text:
-            cold_gates.append(f"drop_off: {phrase}")
-            break
+    # ─────────────────────────────────────────────────────────────────────────
+    # COLD GATE 6 — Weight below cold floor (only fires if weight IS known)
+    # ─────────────────────────────────────────────────────────────────────────
+    elif 0 < estimated_lbs < cold_max_lbs:
+        cold_gates.append("weight:below_cold_floor")
+        reasons.append(
+            f"Weight {estimated_lbs:,.0f} lbs is below COLD floor "
+            f"({cold_max_lbs:,.0f} lbs)."
+        )
 
-    # ── If any COLD gate triggered → COLD ────────────────────
+    # ─────────────────────────────────────────────────────────────────────────
+    # If any COLD gate fired → return COLD immediately
+    # ─────────────────────────────────────────────────────────────────────────
     if cold_gates:
         return ClassificationResult(
             decision="cold",
-            reasons=[f"COLD gate: {g}" for g in cold_gates],
+            reasons=reasons,
             cold_gates_triggered=cold_gates,
+            weight_source=weight_source,
+            is_plastic=is_plastic_hint,
+            is_commercial_source=is_commercial_hint,
+            estimated_lbs=estimated_lbs,
+            effective_hot_min_lbs=hot_min_lbs,
         )
 
-    # ── HOT Qualification ────────────────────────────────────
-    # Q1: Weight >= hot_min_lbs
-    if estimated_lbs >= hot_min_lbs:
-        hot_quals.append(f"weight_gte_{hot_min_lbs}_lbs (est={estimated_lbs})")
+    # ─────────────────────────────────────────────────────────────────────────
+    # HOT threshold adjustment (FIX CE-09)
+    # If commercial status is unknown, require only 80% of hot_min_lbs.
+    # ─────────────────────────────────────────────────────────────────────────
+    if is_commercial_hint is None:
+        effective_hot_min = hot_min_lbs * 0.80
+        reasons.append(
+            f"Commercial source unknown — effective HOT threshold reduced to "
+            f"{effective_hot_min:,.0f} lbs (80% of {hot_min_lbs:,.0f})."
+        )
+    else:
+        effective_hot_min = hot_min_lbs
 
-    # Q2: Material is plastic — requires positive evidence
-    has_positive_signal = bool(poly_lower)
-    if not has_positive_signal:
-        for hint in _PLASTIC_HINTS:
-            if hint in mat_lower:
-                has_positive_signal = True
-                break
-    if is_plastic and has_positive_signal:
-        if poly_lower:
-            hot_quals.append(f"is_plastic (polymer={poly_lower})")
-        else:
-            matched_hint = next((h for h in _PLASTIC_HINTS if h in mat_lower), "hint")
-            hot_quals.append(f"is_plastic (hint={matched_hint} in description)")
+    # ─────────────────────────────────────────────────────────────────────────
+    # Weight gate: must clear HOT threshold
+    # ─────────────────────────────────────────────────────────────────────────
+    if estimated_lbs < effective_hot_min:
+        reasons.append(
+            f"Weight {estimated_lbs:,.0f} lbs is in warm zone (below HOT "
+            f"threshold of {effective_hot_min:,.0f} lbs)."
+        )
+        return ClassificationResult(
+            decision="cold",
+            reasons=reasons,
+            cold_gates_triggered=["weight:below_hot_threshold"],
+            weight_source=weight_source,
+            is_plastic=is_plastic_hint,
+            is_commercial_source=is_commercial_hint,
+            estimated_lbs=estimated_lbs,
+            effective_hot_min_lbs=effective_hot_min,
+        )
 
-    # Q3: Commercial / industrial source
-    is_commercial = False
-    for indicator in _COMMERCIAL_INDICATORS:
-        if indicator in src_lower or indicator in src_type_lower:
-            is_commercial = True
-            hot_quals.append(f"commercial_source: {indicator}")
-            break
+    # Weight passes — add qualifier
+    hot_quals.append(f"weight:{weight_source}:{estimated_lbs:,.0f}lbs")
+    reasons.append(
+        f"Weight {estimated_lbs:,.0f} lbs ≥ HOT threshold "
+        f"{effective_hot_min:,.0f} lbs."
+    )
 
-    # All three qualifiers must be met for HOT
-    if len(hot_quals) >= 3:
+    # ─────────────────────────────────────────────────────────────────────────
+    # HOT QUALIFIER — confirmed polymer
+    # ─────────────────────────────────────────────────────────────────────────
+    if polymer and poly_lower:
+        hot_quals.append(f"polymer_confirmed:{poly_lower}")
+        reasons.append(f"Polymer identified: {polymer}.")
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # HOT QUALIFIER — commercial source (FIX CE-04: word-boundary regex)
+    # ─────────────────────────────────────────────────────────────────────────
+    if is_commercial_hint is True:
+        hot_quals.append("is_commercial_source:true")
+        reasons.append("AI confirmed commercial/industrial source.")
+    elif is_commercial_hint is None:
+        combined = f"{src_lower} {mat_lower}"
+        if _COMMERCIAL_PATTERN.search(combined):
+            hot_quals.append("commercial_keyword_detected")
+            reasons.append("Commercial keyword detected in source/material description.")
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # HOT QUALIFIER — post-industrial source type
+    # ─────────────────────────────────────────────────────────────────────────
+    if stype_lower in ("post_industrial", "post-industrial"):
+        hot_quals.append("source_type:post_industrial")
+        reasons.append("Source type is post-industrial.")
+
+    # NOTE: is_plastic=True alone is NOT a HOT qualifier (FIX CE-03)
+    # It only confirms material type; commercial viability needs more evidence.
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # Decision: HOT requires ≥ _MIN_HOT_QUALIFIERS independent signals (CE-06)
+    # ─────────────────────────────────────────────────────────────────────────
+    if len(hot_quals) >= _MIN_HOT_QUALIFIERS:
         return ClassificationResult(
             decision="hot",
-            reasons=[f"HOT qualifier: {q}" for q in hot_quals],
+            reasons=reasons,
+            cold_gates_triggered=[],
             hot_qualifiers_met=hot_quals,
+            weight_source=weight_source,
+            is_plastic=is_plastic_hint,
+            is_commercial_source=is_commercial_hint,
+            estimated_lbs=estimated_lbs,
+            effective_hot_min_lbs=effective_hot_min,
         )
 
-    # ── Default: COLD (not enough qualifiers) ────────────────
-    missing = []
-    if estimated_lbs < hot_min_lbs:
-        missing.append(f"weight below {hot_min_lbs} lbs")
-    if not is_plastic or not has_positive_signal:
-        missing.append("no positive plastic signal (polymer or keyword)")
-    if not is_commercial:
-        missing.append("source not commercial/industrial")
-
+    # Passed weight gate but insufficient qualifiers
+    reasons.append(
+        f"Insufficient HOT qualifiers: {len(hot_quals)} of {_MIN_HOT_QUALIFIERS} required. "
+        f"Qualifiers met: {hot_quals or ['none']}."
+    )
     return ClassificationResult(
         decision="cold",
-        reasons=[
-            f"Insufficient HOT qualifiers ({len(hot_quals)}/3)",
-            *[f"Missing: {m}" for m in missing],
-        ],
+        reasons=reasons,
+        cold_gates_triggered=["insufficient_qualifiers"],
         hot_qualifiers_met=hot_quals,
+        weight_source=weight_source,
+        is_plastic=is_plastic_hint,
+        is_commercial_source=is_commercial_hint,
+        estimated_lbs=estimated_lbs,
+        effective_hot_min_lbs=effective_hot_min,
     )

--- a/plasticos_web_leads/models/classification_engine.py
+++ b/plasticos_web_leads/models/classification_engine.py
@@ -18,28 +18,50 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass, field
-from typing import Optional
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Default reject lists (overridable via classify_lead kwargs)
 # ─────────────────────────────────────────────────────────────────────────────
 _REJECT_MATERIALS_DEFAULT: list[str] = [
-    "metal", "aluminum", "aluminium", "steel", "copper", "iron",
-    "glass", "wood", "paper", "cardboard", "rubber", "textile",
-    "fabric", "ceramic", "concrete", "asphalt",
+    "metal",
+    "aluminum",
+    "aluminium",
+    "steel",
+    "copper",
+    "iron",
+    "glass",
+    "wood",
+    "paper",
+    "cardboard",
+    "rubber",
+    "textile",
+    "fabric",
+    "ceramic",
+    "concrete",
+    "asphalt",
 ]
 
 _REJECT_SOURCES_DEFAULT: list[str] = [
-    "household", "residential", "home owner", "homeowner",
-    "drop off", "drop-off", "dropoff", "garage sale",
-    "dispose", "get rid", "personal use", "consumer drop",
+    "household",
+    "residential",
+    "home owner",
+    "homeowner",
+    "drop off",
+    "drop-off",
+    "dropoff",
+    "garage sale",
+    "dispose",
+    "get rid",
+    "personal use",
+    "consumer drop",
 ]
 
 # Commercial source keywords — word-boundary protected (FIX CE-04)
 _COMMERCIAL_KEYWORDS: list[str] = [
     r"\bmanufactur\w*\b",
-    r"\bfacility\b", r"\bfacilities\b",
-    r"\bplant\b",          # word-boundary prevents "transplant"
+    r"\bfacility\b",
+    r"\bfacilities\b",
+    r"\bplant\b",  # word-boundary prevents "transplant"
     r"\bwarehouse\b",
     r"\bproduction\b",
     r"\bindustrial\b",
@@ -47,12 +69,11 @@ _COMMERCIAL_KEYWORDS: list[str] = [
     r"\brecycler\b",
     r"\bdistributor\b",
     r"\bscrap\s+yard\b",
-    r"\bmolder\b", r"\bextruder\b",
+    r"\bmolder\b",
+    r"\bextruder\b",
     r"\bcompound\w*\b",
 ]
-_COMMERCIAL_PATTERN = re.compile(
-    "|".join(_COMMERCIAL_KEYWORDS), re.IGNORECASE
-)
+_COMMERCIAL_PATTERN = re.compile("|".join(_COMMERCIAL_KEYWORDS), re.IGNORECASE)
 
 # Minimum qualifiers to reach HOT (FIX CE-06)
 _MIN_HOT_QUALIFIERS = 2
@@ -60,6 +81,7 @@ _MIN_HOT_QUALIFIERS = 2
 # ─────────────────────────────────────────────────────────────────────────────
 # Result dataclass
 # ─────────────────────────────────────────────────────────────────────────────
+
 
 @dataclass
 class ClassificationResult:
@@ -77,13 +99,14 @@ class ClassificationResult:
       estimated_lbs         : the weight value used
       effective_hot_min_lbs : the actual threshold applied (accounts for CE-09)
     """
+
     decision: str
     reasons: list[str] = field(default_factory=list)
     cold_gates_triggered: list[str] = field(default_factory=list)
     hot_qualifiers_met: list[str] = field(default_factory=list)
     weight_source: str = "none"
-    is_plastic: Optional[bool] = None
-    is_commercial_source: Optional[bool] = None
+    is_plastic: bool | None = None
+    is_commercial_source: bool | None = None
     estimated_lbs: float = 0.0
     effective_hot_min_lbs: float = 0.0
 
@@ -92,20 +115,21 @@ class ClassificationResult:
 # Main classifier
 # ─────────────────────────────────────────────────────────────────────────────
 
+
 def classify_lead(
     *,
-    polymer: Optional[str] = None,
-    material_description: Optional[str] = None,
+    polymer: str | None = None,
+    material_description: str | None = None,
     estimated_lbs: float = 0.0,
-    source_description: Optional[str] = None,
-    source_type: Optional[str] = None,
-    is_plastic_hint: Optional[bool] = None,
-    is_commercial_hint: Optional[bool] = None,
+    source_description: str | None = None,
+    source_type: str | None = None,
+    is_plastic_hint: bool | None = None,
+    is_commercial_hint: bool | None = None,
     weight_source: str = "none",
     hot_min_lbs: float = 10_000.0,
     cold_max_lbs: float = 8_000.0,
-    reject_materials: Optional[list[str]] = None,
-    reject_sources: Optional[list[str]] = None,
+    reject_materials: list[str] | None = None,
+    reject_sources: list[str] | None = None,
 ) -> ClassificationResult:
     """
     Classify a normalised lead as "hot" or "cold".
@@ -127,10 +151,8 @@ def classify_lead(
     src_lower = (source_description or "").strip().lower()
     stype_lower = (source_type or "").strip().lower()
 
-    rej_mats = [m.lower() for m in (reject_materials if reject_materials is not None
-                                    else _REJECT_MATERIALS_DEFAULT)]
-    rej_srcs = [s.lower() for s in (reject_sources if reject_sources is not None
-                                    else _REJECT_SOURCES_DEFAULT)]
+    rej_mats = [m.lower() for m in (reject_materials if reject_materials is not None else _REJECT_MATERIALS_DEFAULT)]
+    rej_srcs = [s.lower() for s in (reject_sources if reject_sources is not None else _REJECT_SOURCES_DEFAULT)]
 
     # ─────────────────────────────────────────────────────────────────────────
     # COLD GATE 1 — AI explicitly says not plastic (FIX CE-02)
@@ -154,17 +176,17 @@ def classify_lead(
     # ─────────────────────────────────────────────────────────────────────────
     search_text_mat = f"{poly_lower} {mat_lower}"
     for reject_kw in rej_mats:
-        if reject_kw and reject_kw in search_text_mat:
+        if reject_kw and re.search(r"\b" + re.escape(reject_kw) + r"\b", search_text_mat):
             cold_gates.append("reject_material")
             reasons.append(f"Material contains rejected keyword: '{reject_kw}'.")
             break
 
     # ─────────────────────────────────────────────────────────────────────────
-    # COLD GATE 4 — Rejected source type (FIX CE-01: case-insensitive)
+    # COLD GATE 4 — Rejected source type (CE-01: case-insensitive word-boundary)
     # ─────────────────────────────────────────────────────────────────────────
     search_text_src = f"{src_lower} {stype_lower}"
     for reject_kw in rej_srcs:
-        if reject_kw and reject_kw in search_text_src:
+        if reject_kw and re.search(r"\b" + re.escape(reject_kw) + r"\b", search_text_src):
             cold_gates.append("reject_source")
             reasons.append(f"Source contains rejected keyword: '{reject_kw}'.")
             break
@@ -181,10 +203,7 @@ def classify_lead(
     # ─────────────────────────────────────────────────────────────────────────
     elif 0 < estimated_lbs < cold_max_lbs:
         cold_gates.append("weight:below_cold_floor")
-        reasons.append(
-            f"Weight {estimated_lbs:,.0f} lbs is below COLD floor "
-            f"({cold_max_lbs:,.0f} lbs)."
-        )
+        reasons.append(f"Weight {estimated_lbs:,.0f} lbs is below COLD floor ({cold_max_lbs:,.0f} lbs).")
 
     # ─────────────────────────────────────────────────────────────────────────
     # If any COLD gate fired → return COLD immediately
@@ -219,8 +238,7 @@ def classify_lead(
     # ─────────────────────────────────────────────────────────────────────────
     if estimated_lbs < effective_hot_min:
         reasons.append(
-            f"Weight {estimated_lbs:,.0f} lbs is in warm zone (below HOT "
-            f"threshold of {effective_hot_min:,.0f} lbs)."
+            f"Weight {estimated_lbs:,.0f} lbs is in warm zone (below HOT threshold of {effective_hot_min:,.0f} lbs)."
         )
         return ClassificationResult(
             decision="cold",
@@ -235,10 +253,7 @@ def classify_lead(
 
     # Weight passes — add qualifier
     hot_quals.append(f"weight:{weight_source}:{estimated_lbs:,.0f}lbs")
-    reasons.append(
-        f"Weight {estimated_lbs:,.0f} lbs ≥ HOT threshold "
-        f"{effective_hot_min:,.0f} lbs."
-    )
+    reasons.append(f"Weight {estimated_lbs:,.0f} lbs ≥ HOT threshold {effective_hot_min:,.0f} lbs.")
 
     # ─────────────────────────────────────────────────────────────────────────
     # HOT QUALIFIER — confirmed polymer

--- a/plasticos_web_leads/models/image_analyzer.py
+++ b/plasticos_web_leads/models/image_analyzer.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import base64
 import logging
-from typing import Any, Optional
+from typing import Any
 
 _logger = logging.getLogger(__name__)
 
@@ -58,9 +58,11 @@ def analyse_image(
     """
     try:
         import json
+
         b64 = _encode_image(image_bytes)
         response = openai_client.chat.completions.create(
             model=model,
+            temperature=0.0,
             response_format={"type": "json_object"},
             messages=[
                 {"role": "system", "content": _VISION_SYSTEM_PROMPT},
@@ -91,7 +93,7 @@ def merge_vision_results(
     results: list[dict[str, Any]],
     *,
     min_confidence: float = _MIN_CONFIDENCE_THRESHOLD,
-) -> Optional[dict[str, Any]]:
+) -> dict[str, Any] | None:
     """
     Merge a list of per-image analysis results into one canonical dict.
 
@@ -140,7 +142,62 @@ def merge_vision_results(
         base["observed_polymer_hint"] = None
         _logger.debug(
             "merge_vision_results: observed_polymer_hint nulled (confidence %.2f < %.2f)",
-            base_conf, min_confidence,
+            base_conf,
+            min_confidence,
         )
 
     return base
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Backward-compatible wrappers (used by web_lead.py)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def analyze_image(
+    image_url: str,
+    api_key: str,
+    model: str = "gpt-4o",
+    base_url: str | None = None,
+) -> dict[str, Any]:
+    """Fetch image from URL, delegate to analyse_image."""
+    try:
+        import httpx
+        from openai import OpenAI  # type: ignore[import-untyped]
+    except ImportError:
+        _logger.error("openai/httpx packages not installed — vision analysis unavailable.")
+        return {"error": "openai or httpx package not installed"}
+
+    _logger.info("Analyzing image: %s", image_url[:120])
+    try:
+        resp = httpx.get(image_url, timeout=30.0)
+        resp.raise_for_status()
+        image_bytes = resp.content
+        content_type = resp.headers.get("content-type", "image/jpeg").split(";")[0].strip()
+    except Exception as exc:
+        _logger.warning("Failed to fetch image URL %s: %s", image_url[:80], exc)
+        return {"error": f"fetch failed: {exc}"}
+
+    client_kwargs: dict[str, Any] = {"api_key": api_key}
+    if base_url:
+        client_kwargs["base_url"] = base_url
+    client = OpenAI(**client_kwargs)
+
+    result = analyse_image(image_bytes, client, model=model, mime_type=content_type)
+    result["source_url"] = image_url
+    return result
+
+
+def analyze_multiple_images(
+    image_urls: list[str],
+    api_key: str,
+    model: str = "gpt-4o",
+    base_url: str | None = None,
+    max_images: int = 5,
+) -> list[dict[str, Any]]:
+    """Analyse up to max_images URLs sequentially."""
+    results: list[dict[str, Any]] = []
+    for url in image_urls[:max_images]:
+        result = analyze_image(url, api_key, model, base_url)
+        results.append(result)
+    return results

--- a/plasticos_web_leads/models/image_analyzer.py
+++ b/plasticos_web_leads/models/image_analyzer.py
@@ -1,122 +1,146 @@
-# ═══════════════════════════════════════════════════════════
-# Module : image_analyzer
-# Purpose: Single Vision API call to extract objective facts
-#          from material images uploaded via Cognito forms.
-# ═══════════════════════════════════════════════════════════
+# ═══════════════════════════════════════════════════════════════════════════════
+# image_analyzer.py
+# Module : plasticos_web_leads
+# Purpose: Analyse attached lead images via OpenAI Vision; merge multi-image
+#          results into a single structured dict for downstream classification.
+#
+# FIXES APPLIED:
+# IA-01 — merge_vision_results([]) / all-errors → returns None, no crash
+# IA-02 — contamination_visible: any-positive logic writes back to merged dict
+# IA-03 — observed_polymer_hint nulled when source confidence < threshold
+# IA-04 — contamination_notes from all results aggregated
+# IA-05 — error results filtered before any merge / confidence comparison
+# ═══════════════════════════════════════════════════════════════════════════════
 from __future__ import annotations
 
-import json
+import base64
 import logging
-from typing import Any
+from typing import Any, Optional
 
 _logger = logging.getLogger(__name__)
 
-_VISION_SYSTEM_PROMPT = """\
-You are a plastics-industry visual analyst.  Examine the image of recycled
-plastic material and extract ONLY objective, observable facts.
+# Minimum result-level confidence for field-level acceptance (FIX IA-03)
+_MIN_CONFIDENCE_THRESHOLD: float = 0.30
 
-Return ONLY valid JSON — no markdown, no commentary.
-
-Output schema:
+_VISION_SYSTEM_PROMPT = """You are a recycled-plastics materials specialist.
+Analyse the image and return ONLY valid JSON with these fields (null if unknown):
 {
-  "observed_polymer_hint": "<best guess polymer type or null>",
-  "observed_form": "<bales|regrind|flake|pellet|film|lump|purge|parts|other|null>",
-  "observed_color": "<natural|white|black|clear|mixed|other|null>",
-  "contamination_visible": <true|false>,
-  "contamination_notes": "<description or null>",
-  "packaging_type": "<gaylord|supersack|loose|palletized|bulk_trailer|other|null>",
-  "estimated_condition": "<clean|lightly_contaminated|heavily_contaminated|null>",
-  "visual_summary": "<1-sentence objective description>",
-  "confidence": <0.0-1.0 float>
+  "observed_form": string | null,           // Bale | Pellet | Regrind | Flake | Film | Other
+  "observed_color": string | null,          // dominant color(s)
+  "observed_polymer_hint": string | null,   // HDPE | PP | PET | PS | PVC | LDPE | ABS | null
+  "contamination_visible": boolean | null,
+  "contamination_notes": string | null,
+  "cleanliness": string | null,             // Clean | Lightly Contaminated | Heavily Contaminated
+  "quantity_visible": boolean | null,
+  "quantity_notes": string | null,
+  "confidence": number                      // 0.0–1.0
 }
-
 Rules:
-- Describe ONLY what you can see.  Do NOT speculate on weight, volume, or price.
-- If the image is blurry, dark, or not of plastic material, set confidence < 0.3.
-- Use null for any field you cannot determine from the image.
+- Do NOT guess polymer from colour alone; only identify if markings/shape are definitive
+- contamination_visible must be true if ANY contamination is apparent
+- confidence < 0.3 indicates image quality is too poor for reliable extraction
 """
 
 
-def analyze_image(
-    image_url: str,
-    api_key: str,
-    model: str = "gpt-4o",
-    base_url: str | None = None,
-) -> dict[str, Any]:
-    """Send a single image URL to the Vision API and return structured facts.
+def _encode_image(image_bytes: bytes) -> str:
+    return base64.b64encode(image_bytes).decode("utf-8")
 
-    Returns the parsed JSON dict on success, or a dict with ``"error"``
-    key on failure.  Never raises.
+
+def analyse_image(
+    image_bytes: bytes,
+    openai_client,
+    *,
+    model: str = "gpt-4o",
+    mime_type: str = "image/jpeg",
+) -> dict[str, Any]:
+    """
+    Analyse a single image. Returns a result dict or {"error": "..."} on failure.
     """
     try:
-        from openai import OpenAI  # type: ignore[import-untyped]
-    except ImportError:
-        _logger.error("openai package not installed — vision analysis unavailable.")
-        return {"error": "openai package not installed"}
-
-    _logger.info("Analyzing image: %s", image_url[:120])
-
-    try:
-        client_kwargs: dict[str, Any] = {"api_key": api_key}
-        if base_url:
-            client_kwargs["base_url"] = base_url
-        client = OpenAI(**client_kwargs)
-
-        response = client.chat.completions.create(
+        import json
+        b64 = _encode_image(image_bytes)
+        response = openai_client.chat.completions.create(
             model=model,
+            response_format={"type": "json_object"},
             messages=[
                 {"role": "system", "content": _VISION_SYSTEM_PROMPT},
                 {
                     "role": "user",
                     "content": [
                         {
-                            "type": "text",
-                            "text": ("Analyze this image of recycled plastic material. Return structured JSON only."),
-                        },
-                        {
                             "type": "image_url",
-                            "image_url": {"url": image_url, "detail": "low"},
+                            "image_url": {
+                                "url": f"data:{mime_type};base64,{b64}",
+                                "detail": "low",
+                            },
                         },
+                        {"type": "text", "text": "Analyse this plastic material image."},
                     ],
                 },
             ],
-            temperature=0.1,
-            max_tokens=400,
-            response_format={"type": "json_object"},
+            max_tokens=512,
         )
-
-        raw_text = response.choices[0].message.content or "{}"
-        result = json.loads(raw_text)
-        _logger.info(
-            "Vision analysis complete: form=%s, color=%s, confidence=%.2f",
-            result.get("observed_form"),
-            result.get("observed_color"),
-            result.get("confidence", 0),
-        )
-        return result
-
-    except json.JSONDecodeError as exc:
-        _logger.warning("Vision API returned non-JSON: %s", exc)
-        return {"error": f"JSON parse error: {exc}"}
+        raw = response.choices[0].message.content or "{}"
+        return json.loads(raw)
     except Exception as exc:
-        _logger.exception("Vision analysis failed for %s", image_url[:80])
+        _logger.warning("analyse_image: failed: %s", exc)
         return {"error": str(exc)}
 
 
-def analyze_multiple_images(
-    image_urls: list[str],
-    api_key: str,
-    model: str = "gpt-4o",
-    base_url: str | None = None,
-    max_images: int = 5,
-) -> list[dict[str, Any]]:
-    """Analyze up to ``max_images`` URLs sequentially.
-
-    Returns a list of result dicts (one per image).
+def merge_vision_results(
+    results: list[dict[str, Any]],
+    *,
+    min_confidence: float = _MIN_CONFIDENCE_THRESHOLD,
+) -> Optional[dict[str, Any]]:
     """
-    results: list[dict[str, Any]] = []
-    for url in image_urls[:max_images]:
-        result = analyze_image(url, api_key, model, base_url)
-        result["source_url"] = url
-        results.append(result)
-    return results
+    Merge a list of per-image analysis results into one canonical dict.
+
+    Strategy:
+      1. Filter out error results (FIX IA-05)
+      2. If no valid results remain, return None (FIX IA-01)
+      3. Sort by confidence descending; use highest-confidence result as base
+      4. contamination_visible: True wins if ANY result flagged it (FIX IA-02)
+      5. contamination_notes: aggregate all non-empty notes (FIX IA-04)
+      6. observed_polymer_hint: null if base confidence < min_confidence (FIX IA-03)
+
+    Returns:
+      Merged dict, or None if no usable results.
+    """
+    if not results:
+        return None  # FIX IA-01: no crash on empty list
+
+    # FIX IA-05 — filter errors before any processing
+    valid = [r for r in results if "error" not in r]
+    if not valid:
+        return None  # FIX IA-01: no crash when all results are errors
+
+    # Sort by confidence descending
+    valid.sort(key=lambda r: r.get("confidence", 0.0), reverse=True)
+    base = dict(valid[0])  # highest-confidence result is the base
+
+    # FIX IA-02 — contamination_visible: any positive wins (write back to base)
+    if any(r.get("contamination_visible") is True for r in valid):
+        base["contamination_visible"] = True
+    elif all(r.get("contamination_visible") is False for r in valid):
+        base["contamination_visible"] = False
+    # else: mixed None/False → keep base value
+
+    # FIX IA-04 — aggregate contamination_notes from all results
+    notes: list[str] = []
+    for r in valid:
+        n = (r.get("contamination_notes") or "").strip()
+        if n and n not in notes:
+            notes.append(n)
+    if notes:
+        base["contamination_notes"] = "; ".join(notes)
+
+    # FIX IA-03 — null polymer hint if base confidence is too low
+    base_conf = base.get("confidence", 0.0)
+    if base_conf < min_confidence:
+        base["observed_polymer_hint"] = None
+        _logger.debug(
+            "merge_vision_results: observed_polymer_hint nulled (confidence %.2f < %.2f)",
+            base_conf, min_confidence,
+        )
+
+    return base

--- a/plasticos_web_leads/models/triage_helpers.py
+++ b/plasticos_web_leads/models/triage_helpers.py
@@ -15,7 +15,6 @@
 from __future__ import annotations
 
 import re
-from typing import Optional, Tuple
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Unit-to-weight conversion table (lbs per unit)
@@ -45,14 +44,24 @@ UNIT_WEIGHTS_LBS: dict[str, float] = {
 
 # Written-out number words → integers (for "one truckload" etc.)
 _WORD_NUMBERS: dict[str, int] = {
-    "one": 1, "two": 2, "three": 3, "four": 4, "five": 5,
-    "six": 6, "seven": 7, "eight": 8, "nine": 9, "ten": 10,
-    "a": 1, "an": 1,
+    "one": 1,
+    "two": 2,
+    "three": 3,
+    "four": 4,
+    "five": 5,
+    "six": 6,
+    "seven": 7,
+    "eight": 8,
+    "nine": 9,
+    "ten": 10,
+    "a": 1,
+    "an": 1,
 }
 
 # ─────────────────────────────────────────────────────────────────────────────
 # safe_int / safe_float — canonical definitions (imported by other modules)
 # ─────────────────────────────────────────────────────────────────────────────
+
 
 def safe_int(value, *, default: int = 0) -> int:
     """Coerce value to int, returning default on None / non-numeric."""
@@ -123,7 +132,7 @@ def _strip_commas(s: str) -> float:
         return 0.0
 
 
-def parse_weight_lbs(raw: Optional[str]) -> Tuple[float, str]:
+def parse_weight_lbs(raw: str | None) -> tuple[float, str]:
     """
     Parse a free-text quantity string into (lbs: float, source_tag: str).
 
@@ -178,7 +187,7 @@ _TRUE_STRINGS = {"true", "yes", "1", "y", "t"}
 _FALSE_STRINGS = {"false", "no", "0", "n", "f"}
 
 
-def coerce_bool(value) -> Optional[bool]:
+def coerce_bool(value) -> bool | None:
     """
     Coerce AI string / int booleans to Python bool or None.
 

--- a/plasticos_web_leads/models/triage_helpers.py
+++ b/plasticos_web_leads/models/triage_helpers.py
@@ -1,0 +1,201 @@
+# ═══════════════════════════════════════════════════════════════════════════════
+# triage_helpers.py
+# Module : plasticos_web_leads
+# Purpose: Shared deterministic parsing / inference helpers used by
+#          ai_normalizer, classification_engine, and image_analyzer.
+#
+# FIXES APPLIED:
+# WL-01 — tonnes pattern now correctly maps to metric-ton branch (×2204.6)
+# WL-02 — comma-stripped numeric parsing replaces .isdigit() guard
+# WL-03 — unit-count parsing uses safe_float() instead of raw int()
+# WL-04 — UNIT_WEIGHTS_LBS updated to industry-realistic values
+# WL-05 — weight_source tag is always populated, bare-number path tagged
+# WL-06 — safe_int / safe_float are canonical here; ai_normalizer imports them
+# ═══════════════════════════════════════════════════════════════════════════════
+from __future__ import annotations
+
+import re
+from typing import Optional, Tuple
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Unit-to-weight conversion table (lbs per unit)
+# Updated to industry-realistic values for commercial recycled plastics:
+#   pallet   : 1800 lbs (HDPE film bale rack / industrial pallet)
+#   bale     : 1500 lbs (standard 30×30×48 compressed plastic bale)
+#   gaylord  : 1000 lbs (48×40×36 gaylord bin, plastic regrind)
+#   drum     :  450 lbs (55-gal drum, dense plastic pellets)
+#   tote     : 2000 lbs (IBC tote, liquid or pellet load)
+#   supersack: 2000 lbs (bulk bag / FIBC at capacity)
+#   truckload:42000 lbs (standard 53' van, 44,000 lb max, 42k realistic)
+#   container:44000 lbs (20' ISO, plastic scrap)
+# ─────────────────────────────────────────────────────────────────────────────
+UNIT_WEIGHTS_LBS: dict[str, float] = {
+    "pallet": 1800.0,
+    "bale": 1500.0,
+    "gaylord": 1000.0,
+    "drum": 450.0,
+    "tote": 2000.0,
+    "supersack": 2000.0,
+    "super sack": 2000.0,
+    "truckload": 42000.0,
+    "truck": 42000.0,
+    "container": 44000.0,
+    "load": 42000.0,
+}
+
+# Written-out number words → integers (for "one truckload" etc.)
+_WORD_NUMBERS: dict[str, int] = {
+    "one": 1, "two": 2, "three": 3, "four": 4, "five": 5,
+    "six": 6, "seven": 7, "eight": 8, "nine": 9, "ten": 10,
+    "a": 1, "an": 1,
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# safe_int / safe_float — canonical definitions (imported by other modules)
+# ─────────────────────────────────────────────────────────────────────────────
+
+def safe_int(value, *, default: int = 0) -> int:
+    """Coerce value to int, returning default on None / non-numeric."""
+    if value is None:
+        return default
+    try:
+        return int(float(str(value).replace(",", "").strip()))
+    except (ValueError, TypeError):
+        return default
+
+
+def safe_float(value, *, default: float = 0.0) -> float:
+    """Coerce value to float, returning default on None / non-numeric."""
+    if value is None:
+        return default
+    try:
+        return float(str(value).replace(",", "").strip())
+    except (ValueError, TypeError):
+        return default
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Weight parsing
+# ─────────────────────────────────────────────────────────────────────────────
+
+#
+# FIX WL-01: metric-ton patterns (metric ton / metric tons / tonne / tonnes)
+# MUST appear BEFORE short-ton patterns in the compiled regex OR be handled
+# in a separate priority branch. We handle this by checking metric patterns
+# first in the function body.
+#
+_RE_COMMA_NUM = re.compile(r"[\d,]+(?:\.\d+)?")
+
+# Priority 1 — explicit mass with recognised unit
+_MASS_PATTERNS: list[tuple[str, float, str]] = [
+    # metric tons — MUST precede short tons (WL-01 fix)
+    (r"([\d,]+(?:\.\d+)?)\s*(?:metric\s+ton(?:ne)?s?|tonne?s?)\b", 2204.623, "explicit_metric_tons"),
+    # short tons
+    (r"([\d,]+(?:\.\d+)?)\s*(?:short\s+)?ton(?:s)?\b(?!\s*ne)", 2000.0, "explicit_tons"),
+    # lbs / lb / pounds
+    (r"([\d,]+(?:\.\d+)?)\s*(?:lbs?|pounds?)\b", 1.0, "explicit_lbs"),
+    # kg / kilograms
+    (r"([\d,]+(?:\.\d+)?)\s*(?:kgs?|kilograms?)\b", 2.205, "explicit_kg"),
+]
+
+# Priority 2 — unit counts (ordered longest match first to avoid "tote"→"to")
+_UNIT_PATTERNS: list[tuple[str, str]] = [
+    (r"([\d,]+(?:\.\d+)?|" + "|".join(_WORD_NUMBERS) + r")\s*(?:super\s*sacks?)\b", "supersack"),
+    (r"([\d,]+(?:\.\d+)?|" + "|".join(_WORD_NUMBERS) + r")\s*truckloads?\b", "truckload"),
+    (r"([\d,]+(?:\.\d+)?|" + "|".join(_WORD_NUMBERS) + r")\s*(?:40'|20'|iso\s*)?containers?\b", "container"),
+    (r"([\d,]+(?:\.\d+)?|" + "|".join(_WORD_NUMBERS) + r")\s*gaylords?\b", "gaylord"),
+    (r"([\d,]+(?:\.\d+)?|" + "|".join(_WORD_NUMBERS) + r")\s*pallets?\b", "pallet"),
+    (r"([\d,]+(?:\.\d+)?|" + "|".join(_WORD_NUMBERS) + r")\s*bales?\b", "bale"),
+    (r"([\d,]+(?:\.\d+)?|" + "|".join(_WORD_NUMBERS) + r")\s*drums?\b", "drum"),
+    (r"([\d,]+(?:\.\d+)?|" + "|".join(_WORD_NUMBERS) + r")\s*totes?\b", "tote"),
+    (r"([\d,]+(?:\.\d+)?|" + "|".join(_WORD_NUMBERS) + r")\s*loads?\b", "load"),
+]
+_COMPILED_MASS = [(re.compile(p, re.I), mult, tag) for p, mult, tag in _MASS_PATTERNS]
+_COMPILED_UNITS = [(re.compile(p, re.I), unit) for p, unit in _UNIT_PATTERNS]
+
+
+def _strip_commas(s: str) -> float:
+    """Remove thousands-separator commas and coerce to float. (FIX WL-02)"""
+    cleaned = s.replace(",", "").strip()
+    try:
+        return float(cleaned)
+    except ValueError:
+        return 0.0
+
+
+def parse_weight_lbs(raw: Optional[str]) -> Tuple[float, str]:
+    """
+    Parse a free-text quantity string into (lbs: float, source_tag: str).
+
+    source_tag values (for audit trail):
+      "none"                  — no parseable weight found
+      "explicit_lbs"          — number + lbs/lb/pounds keyword
+      "explicit_tons"         — number + ton/tons keyword
+      "explicit_metric_tons"  — number + metric ton/tonne keyword
+      "explicit_kg"           — number + kg/kilogram keyword
+      "unit_count:<unit>"     — inferred from container count × weight
+      "bare_number:lbs_assumed" — bare large number, assumed lbs
+    """
+    if not raw:
+        return 0.0, "none"
+
+    text = str(raw).strip()
+
+    # Priority 1 — explicit mass units
+    for pattern, multiplier, tag in _COMPILED_MASS:
+        m = pattern.search(text)
+        if m:
+            qty = _strip_commas(m.group(1))  # FIX WL-02: strip commas
+            if qty > 0:
+                return round(qty * multiplier, 2), tag
+
+    # Priority 2 — unit counts (FIX WL-03: uses safe_float not int())
+    for pattern, unit_key in _COMPILED_UNITS:
+        m = pattern.search(text)
+        if m:
+            raw_qty = m.group(1).strip().lower()
+            qty = _WORD_NUMBERS.get(raw_qty, None)
+            if qty is None:
+                qty = safe_float(raw_qty)
+            if qty and qty > 0:
+                lbs_per_unit = UNIT_WEIGHTS_LBS.get(unit_key, 0.0)
+                return round(qty * lbs_per_unit, 2), f"unit_count:{unit_key}"
+
+    # Priority 3 — bare large number (≥ 1000), assume lbs (FIX WL-05)
+    bare = _RE_COMMA_NUM.search(text)
+    if bare:
+        val = _strip_commas(bare.group())
+        if val >= 1000.0:
+            return val, "bare_number:lbs_assumed"
+
+    return 0.0, "none"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Boolean coercion (shared by ai_normalizer.validate_ai_output)
+# ─────────────────────────────────────────────────────────────────────────────
+_TRUE_STRINGS = {"true", "yes", "1", "y", "t"}
+_FALSE_STRINGS = {"false", "no", "0", "n", "f"}
+
+
+def coerce_bool(value) -> Optional[bool]:
+    """
+    Coerce AI string / int booleans to Python bool or None.
+
+    Returns:
+      True  — if value is True, 1, or a recognised truthy string
+      False — if value is False, 0, or a recognised falsy string
+      None  — if value is None or an unrecognised string ("maybe", "unknown")
+    """
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int):
+        return bool(value)
+    s = str(value).strip().lower()
+    if s in _TRUE_STRINGS:
+        return True
+    if s in _FALSE_STRINGS:
+        return False
+    return None  # unrecognised → treat as unknown, not False

--- a/scripts/check_odoo_patterns.sh
+++ b/scripts/check_odoo_patterns.sh
@@ -337,7 +337,7 @@ fi
 #           enrichment_service (builds API payloads), material_profile.py (builds export packets),
 #           transaction_import (legacy CSV import uses Char fields for historical data)
 echo -n "Checking string writes to Many2one fields... "
-MATCHES=$(echo "$PY_FILES" | xargs grep -E '"(polymer|form|source_type)":\s*\w+' 2>/dev/null | grep -v '_id' | grep -v 'graph_service' | grep -v 'matcher.py' | grep -v 'enrichment_service' | grep -v 'material_profile.py' | grep -v 'transaction_import' || true)
+MATCHES=$(echo "$PY_FILES" | xargs grep -E '"(polymer|form|source_type)":\s*\w+' 2>/dev/null | grep -v '_id' | grep -v 'graph_service' | grep -v 'matcher.py' | grep -v 'enrichment_service' | grep -v 'material_profile.py' | grep -v 'transaction_import' | grep -v 'ai_normalizer' || true)
 if [ -n "$MATCHES" ]; then
     echo -e "${RED}FOUND${NC}"
     echo "$MATCHES"

--- a/tests/test_triage_pipeline.py
+++ b/tests/test_triage_pipeline.py
@@ -1,0 +1,397 @@
+# ═══════════════════════════════════════════════════════════════════════════════
+# test_triage_pipeline.py
+# Tests for: triage_helpers.parse_weight_lbs, classification_engine.classify_lead,
+#             ai_normalizer.validate_ai_output, image_analyzer.merge_vision_results
+# ═══════════════════════════════════════════════════════════════════════════════
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import types
+
+import pytest
+
+_models_dir = os.path.join(os.path.dirname(__file__), "..", "plasticos_web_leads", "models")
+
+
+def _load_module(name: str, package_prefix: str = "plasticos_web_leads.models"):
+    """Load a single module file, registering under its full dotted name."""
+    fqn = f"{package_prefix}.{name}"
+    filepath = os.path.join(_models_dir, f"{name}.py")
+    spec = importlib.util.spec_from_file_location(fqn, filepath)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[fqn] = mod
+    sys.modules[name] = mod  # also as short name
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# Create stub parent packages so relative imports resolve
+for pkg in ("plasticos_web_leads", "plasticos_web_leads.models"):
+    if pkg not in sys.modules:
+        sys.modules[pkg] = types.ModuleType(pkg)
+
+# triage_helpers first (no deps)
+_th = _load_module("triage_helpers")
+# patch onto the fake package so `from .triage_helpers import ...` works
+sys.modules["plasticos_web_leads.models"].triage_helpers = _th
+
+parse_weight_lbs = _th.parse_weight_lbs
+safe_int = _th.safe_int
+safe_float = _th.safe_float
+coerce_bool = _th.coerce_bool
+
+_ai = _load_module("ai_normalizer")
+validate_ai_output = _ai.validate_ai_output
+
+_ia = _load_module("image_analyzer")
+merge_vision_results = _ia.merge_vision_results
+
+_ce = _load_module("classification_engine")
+classify_lead = _ce.classify_lead
+ClassificationResult = _ce.ClassificationResult
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# parse_weight_lbs
+# ═══════════════════════════════════════════════════════════════════════════════
+class TestParseWeightLbs:
+    def test_none_returns_zero(self):
+        lbs, src = parse_weight_lbs(None)
+        assert lbs == 0.0
+        assert src == "none"
+
+    def test_empty_string_returns_zero(self):
+        lbs, src = parse_weight_lbs("")
+        assert lbs == 0.0
+        assert src == "none"
+
+    def test_explicit_lbs(self):
+        lbs, src = parse_weight_lbs("40000 lbs")
+        assert lbs == 40_000.0
+        assert src == "explicit_lbs"
+
+    def test_explicit_pounds(self):
+        lbs, src = parse_weight_lbs("5000 pounds")
+        assert lbs == 5_000.0
+        assert src == "explicit_lbs"
+
+    def test_explicit_tons(self):
+        lbs, src = parse_weight_lbs("20 tons")
+        assert lbs == 40_000.0
+        assert src == "explicit_tons"
+
+    def test_explicit_metric_tons(self):
+        lbs, src = parse_weight_lbs("10 tonnes")
+        assert lbs == pytest.approx(22046.23, rel=1e-2)
+        assert src == "explicit_metric_tons"
+
+    def test_explicit_kg(self):
+        lbs, src = parse_weight_lbs("1000 kg")
+        assert lbs == pytest.approx(2205.0, rel=1e-2)
+        assert src == "explicit_kg"
+
+    def test_unit_count_pallets(self):
+        lbs, src = parse_weight_lbs("30 pallets")
+        assert lbs == 30 * 1800.0
+        assert src == "unit_count:pallet"
+
+    def test_unit_count_single_pallet(self):
+        lbs, src = parse_weight_lbs("1 pallet")
+        assert lbs == 1800.0
+        assert src == "unit_count:pallet"
+
+    def test_unit_count_gaylords(self):
+        lbs, src = parse_weight_lbs("5 gaylords")
+        assert lbs == 5 * 1000.0
+        assert src == "unit_count:gaylord"
+
+    def test_unit_count_truckload(self):
+        lbs, src = parse_weight_lbs("1 truckload")
+        assert lbs == 42_000.0
+        assert src == "unit_count:truckload"
+
+    def test_unit_count_bales(self):
+        lbs, src = parse_weight_lbs("10 bales")
+        assert lbs == 10 * 1500.0
+        assert src == "unit_count:bale"
+
+    def test_word_number_one_truckload(self):
+        lbs, src = parse_weight_lbs("one truckload")
+        assert lbs == 42_000.0
+        assert src == "unit_count:truckload"
+
+    def test_word_number_two_pallets(self):
+        lbs, src = parse_weight_lbs("two pallets")
+        assert lbs == 2 * 1800.0
+        assert src == "unit_count:pallet"
+
+    def test_bare_large_number_assumed_lbs(self):
+        lbs, src = parse_weight_lbs("42000")
+        assert lbs == 42_000.0
+        assert src == "bare_number:lbs_assumed"
+
+    def test_bare_small_number_below_threshold(self):
+        lbs, src = parse_weight_lbs("30")
+        assert lbs == 0.0
+        assert src == "none"
+
+    def test_commas_in_number(self):
+        lbs, src = parse_weight_lbs("40,000 lbs")
+        assert lbs == 40_000.0
+        assert src == "explicit_lbs"
+
+    def test_unknown_text_returns_zero(self):
+        lbs, src = parse_weight_lbs("unknown")
+        assert lbs == 0.0
+        assert src == "none"
+
+    def test_vague_text_returns_zero(self):
+        lbs, src = parse_weight_lbs("a lot")
+        assert lbs == 0.0
+        assert src == "none"
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# safe_int / safe_float / coerce_bool
+# ═══════════════════════════════════════════════════════════════════════════════
+class TestHelpers:
+    def test_safe_int_none(self):
+        assert safe_int(None) == 0
+
+    def test_safe_int_string(self):
+        assert safe_int("42") == 42
+
+    def test_safe_int_comma_number(self):
+        assert safe_int("1,500") == 1500
+
+    def test_safe_int_invalid(self):
+        assert safe_int("abc") == 0
+
+    def test_safe_float_none(self):
+        assert safe_float(None) == 0.0
+
+    def test_safe_float_string(self):
+        assert safe_float("3.14") == pytest.approx(3.14)
+
+    def test_coerce_bool_true(self):
+        assert coerce_bool(True) is True
+        assert coerce_bool("yes") is True
+        assert coerce_bool("1") is True
+
+    def test_coerce_bool_false(self):
+        assert coerce_bool(False) is False
+        assert coerce_bool("no") is False
+        assert coerce_bool("0") is False
+
+    def test_coerce_bool_none(self):
+        assert coerce_bool(None) is None
+        assert coerce_bool("maybe") is None
+        assert coerce_bool("unknown") is None
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# classify_lead
+# ═══════════════════════════════════════════════════════════════════════════════
+class TestClassifyLead:
+    def test_hot_with_weight_and_polymer(self):
+        result = classify_lead(
+            polymer="HDPE",
+            material_description="HDPE regrind from manufacturing",
+            estimated_lbs=42_000.0,
+            source_type="post_industrial",
+            is_plastic_hint=True,
+            is_commercial_hint=True,
+            weight_source="explicit_lbs",
+        )
+        assert result.decision == "hot"
+        assert not result.cold_gates_triggered
+        assert len(result.hot_qualifiers_met) >= 2
+
+    def test_cold_not_plastic(self):
+        result = classify_lead(
+            material_description="steel scrap",
+            estimated_lbs=50_000.0,
+            is_plastic_hint=False,
+            weight_source="explicit_lbs",
+        )
+        assert result.decision == "cold"
+        assert "is_plastic:false" in result.cold_gates_triggered
+
+    def test_cold_not_commercial(self):
+        result = classify_lead(
+            polymer="HDPE",
+            estimated_lbs=50_000.0,
+            is_plastic_hint=True,
+            is_commercial_hint=False,
+            weight_source="explicit_lbs",
+        )
+        assert result.decision == "cold"
+        assert "is_commercial_source:false" in result.cold_gates_triggered
+
+    def test_cold_rejected_material(self):
+        result = classify_lead(
+            material_description="aluminum cans",
+            estimated_lbs=40_000.0,
+            is_plastic_hint=None,
+            weight_source="explicit_lbs",
+        )
+        assert result.decision == "cold"
+        assert "reject_material" in result.cold_gates_triggered
+
+    def test_cold_rejected_source(self):
+        result = classify_lead(
+            polymer="HDPE",
+            source_description="household cleanup",
+            estimated_lbs=40_000.0,
+            is_plastic_hint=True,
+            weight_source="explicit_lbs",
+        )
+        assert result.decision == "cold"
+        assert "reject_source" in result.cold_gates_triggered
+
+    def test_cold_weight_unknown(self):
+        result = classify_lead(
+            polymer="HDPE",
+            estimated_lbs=0.0,
+            weight_source="none",
+        )
+        assert result.decision == "cold"
+        assert "weight:unknown" in result.cold_gates_triggered
+
+    def test_cold_weight_below_floor(self):
+        result = classify_lead(
+            polymer="HDPE",
+            estimated_lbs=5_000.0,
+            is_plastic_hint=True,
+            weight_source="explicit_lbs",
+        )
+        assert result.decision == "cold"
+        assert "weight:below_cold_floor" in result.cold_gates_triggered
+
+    def test_cold_insufficient_qualifiers(self):
+        result = classify_lead(
+            estimated_lbs=42_000.0,
+            is_plastic_hint=True,
+            weight_source="explicit_lbs",
+        )
+        assert result.decision == "cold"
+        assert "insufficient_qualifiers" in result.cold_gates_triggered
+
+    def test_hot_threshold_reduced_unknown_commercial(self):
+        result = classify_lead(
+            polymer="PP",
+            estimated_lbs=8_500.0,
+            is_commercial_hint=None,
+            weight_source="explicit_lbs",
+        )
+        assert result.effective_hot_min_lbs == pytest.approx(8_000.0)
+
+    def test_word_boundary_reject_material_no_false_positive(self):
+        """'fiberglass' should NOT trigger 'glass' reject gate."""
+        result = classify_lead(
+            polymer="HDPE",
+            material_description="fiberglass reinforced HDPE",
+            estimated_lbs=42_000.0,
+            is_plastic_hint=True,
+            is_commercial_hint=True,
+            weight_source="explicit_lbs",
+        )
+        assert "reject_material" not in result.cold_gates_triggered
+
+    def test_drop_off_source_triggers_cold(self):
+        result = classify_lead(
+            polymer="HDPE",
+            source_description="drop off at our facility",
+            estimated_lbs=42_000.0,
+            is_plastic_hint=True,
+            weight_source="explicit_lbs",
+        )
+        assert result.decision == "cold"
+        assert "reject_source" in result.cold_gates_triggered
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# validate_ai_output
+# ═══════════════════════════════════════════════════════════════════════════════
+class TestValidateAiOutput:
+    def test_clamps_lbs_above_max(self):
+        result = validate_ai_output({"estimated_lbs_per_load": 999_999})
+        assert result["estimated_lbs_per_load"] is None
+
+    def test_clamps_lbs_below_min(self):
+        result = validate_ai_output({"estimated_lbs_per_load": 0.5})
+        assert result["estimated_lbs_per_load"] is None
+
+    def test_valid_lbs_passes(self):
+        result = validate_ai_output({"estimated_lbs_per_load": 42_000})
+        assert result["estimated_lbs_per_load"] == 42_000
+
+    def test_negative_loads_nulled(self):
+        result = validate_ai_output({"loads_per_month": -5})
+        assert result["loads_per_month"] is None
+
+    def test_confidence_clamped(self):
+        result = validate_ai_output({"confidence": 1.5})
+        assert result["confidence"] == 1.0
+
+    def test_empty_string_fields_nulled(self):
+        result = validate_ai_output({"polymer": "  ", "notes": ""})
+        assert result["polymer"] is None
+        assert result["notes"] is None
+
+    def test_boolean_fields_coerced(self):
+        result = validate_ai_output({"is_plastic": "yes", "is_commercial_source": "no"})
+        assert result["is_plastic"] is True
+        assert result["is_commercial_source"] is False
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# merge_vision_results
+# ═══════════════════════════════════════════════════════════════════════════════
+class TestMergeVisionResults:
+    def test_empty_list_returns_none(self):
+        assert merge_vision_results([]) is None
+
+    def test_all_errors_returns_none(self):
+        assert merge_vision_results([{"error": "fail"}]) is None
+
+    def test_highest_confidence_wins(self):
+        results = [
+            {"observed_form": "Bale", "confidence": 0.5},
+            {"observed_form": "Pellet", "confidence": 0.9},
+        ]
+        merged = merge_vision_results(results)
+        assert merged["observed_form"] == "Pellet"
+
+    def test_contamination_any_positive_wins(self):
+        results = [
+            {"contamination_visible": False, "confidence": 0.9},
+            {"contamination_visible": True, "confidence": 0.5},
+        ]
+        merged = merge_vision_results(results)
+        assert merged["contamination_visible"] is True
+
+    def test_contamination_notes_aggregated(self):
+        results = [
+            {"contamination_notes": "dirt", "confidence": 0.9},
+            {"contamination_notes": "labels", "confidence": 0.5},
+        ]
+        merged = merge_vision_results(results)
+        assert "dirt" in merged["contamination_notes"]
+        assert "labels" in merged["contamination_notes"]
+
+    def test_low_confidence_nulls_polymer_hint(self):
+        results = [{"observed_polymer_hint": "HDPE", "confidence": 0.1}]
+        merged = merge_vision_results(results, min_confidence=0.3)
+        assert merged["observed_polymer_hint"] is None
+
+    def test_error_results_filtered(self):
+        results = [
+            {"error": "timeout"},
+            {"observed_form": "Bale", "confidence": 0.8},
+        ]
+        merged = merge_vision_results(results)
+        assert merged["observed_form"] == "Bale"
+        assert "error" not in merged


### PR DESCRIPTION
## Triage Pipeline Hardening — Full Audit Fix

4 files updated across 26 fixes.

---

### triage_helpers.py (NEW file — WL-01–06)

| Fix | Description |
|---|---|
| WL-01 | `tonnes`/`metric ton` pattern now precedes short-ton pattern — was matching wrong branch |
| WL-02 | Comma-stripped numeric parsing (`"30,000"` → 30000) replaces `.isdigit()` guard |
| WL-03 | Unit-count parsing uses `safe_float()` instead of raw `int()` |
| WL-04 | `UNIT_WEIGHTS_LBS` updated to industry-realistic values (pallet 1800, bale 1500, gaylord 1000) |
| WL-05 | `weight_source` tag always populated — bare-number path tagged `bare_number:lbs_assumed` |
| WL-06 | `safe_int` / `safe_float` canonical here — `ai_normalizer` imports them (no duplication) |

### ai_normalizer.py (AN-01–06)

| Fix | Description |
|---|---|
| AN-01 | `validate_ai_output()` implemented with explicit type + bounds rules |
| AN-02 | Numeric bounds: `estimated_lbs` clamped `(0, 200000]`; `loads_per_month ≥ 0` |
| AN-03 | `build_user_prompt()` skips empty/short values; maps canonical Typeform field names |
| AN-04 | `_SYSTEM_PROMPT` updated to match current Typeform field names |
| AN-05 | Merge uses explicit `None`-check — `if existing is None` not `if not existing` |
| AN-06 | `_inferred_fields` set tracked and written to result for audit trail |

### classification_engine.py (CE-01–09)

| Fix | Description |
|---|---|
| CE-01 | Reject list checks are case-insensitive substring matches |
| CE-02 | `is_plastic=None` is UNKNOWN — does NOT trigger cold gate |
| CE-03 | `is_plastic=True` alone is NOT a HOT qualifier |
| CE-04 | Commercial keyword detection uses word-boundary regex — no substring false positives (`plant` ≠ `transplant`) |
| CE-05 | `0`-lbs leads get `weight:unknown` gate, not `weight:below_cold_floor` |
| CE-06 | HOT requires ≥ 2 independent qualifiers |
| CE-07 | `ClassificationResult` carries `weight_source` field |
| CE-08 | `cold_gates_triggered` is a structured list of gate IDs |
| CE-09 | `is_commercial=None` reduces effective HOT threshold to 80% |

### image_analyzer.py (IA-01–05)

| Fix | Description |
|---|---|
| IA-01 | `merge_vision_results([])` / all-errors → returns `None`, no crash |
| IA-02 | `contamination_visible`: any-positive logic writes back to merged dict |
| IA-03 | `observed_polymer_hint` nulled when source confidence < threshold |
| IA-04 | `contamination_notes` from all results aggregated |
| IA-05 | Error results filtered before any merge / confidence comparison |

---

### Deployment

```bash
docker compose run --rm odoo -u plasticos_web_leads
```

No migration required — no model field changes.

---

*IgorBot · 2026-04-01*