### PR TITLE
[plasticos_geolocalize] fix: configurable Nominatim throttle/batch + debug cleanup

### DIFF
--- a/plasticos_geolocalize/__manifest__.py
+++ b/plasticos_geolocalize/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "PlasticOS Geolocalize",
-    "version": "19.0.1.0.0",
+    "version": "19.0.1.1.0",
     "summary": "Auto-geocode partners on create/write + nightly backfill cron",
     "author": "Igor Beylin",
     "depends": [
@@ -11,6 +11,7 @@
     ],
     "data": [
         "security/ir.model.access.csv",
+        "data/geolocalize_config_params.xml",
         "data/cron_geo_backfill.xml",
         "views/intake_geo_views.xml",
     ],

--- a/plasticos_geolocalize/data/geolocalize_config_params.xml
+++ b/plasticos_geolocalize/data/geolocalize_config_params.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo noupdate="1">
+
+    <!-- Geo backfill tuning. Read fail-soft by res_partner_geo.cron_geo_backfill;
+         noupdate="1" seeds defaults once and never clobbers operator-tuned values. -->
+    <record id="param_nominatim_delay" model="ir.config_parameter">
+        <field name="key">plasticos_geolocalize.nominatim_delay</field>
+        <field name="value">1.1</field>
+    </record>
+    <record id="param_failure_delay" model="ir.config_parameter">
+        <field name="key">plasticos_geolocalize.failure_delay</field>
+        <field name="value">5.0</field>
+    </record>
+    <record id="param_batch_size" model="ir.config_parameter">
+        <field name="key">plasticos_geolocalize.batch_size</field>
+        <field name="value">25</field>
+    </record>
+    <record id="param_max_consecutive_failures" model="ir.config_parameter">
+        <field name="key">plasticos_geolocalize.max_consecutive_failures</field>
+        <field name="value">3</field>
+    </record>
+
+</odoo>

--- a/plasticos_geolocalize/models/res_partner_geo.py
+++ b/plasticos_geolocalize/models/res_partner_geo.py
@@ -1,35 +1,11 @@
 """Nightly geocode backfill for partners."""
 
-import json
 import logging
 import time
 
 from odoo import api, models
 
 _logger = logging.getLogger(__name__)
-
-_LOG_PATH = "/Users/macm2/IB_Odoo-19 (MacMini)/IB-Odoo_19/.cursor/debug-75e499.log"
-_SESSION = "75e499"
-
-
-def _dbg(msg, data=None, hypothesis=None):
-    import time as _t
-
-    entry = {
-        "sessionId": _SESSION,
-        "location": "res_partner_geo.py",
-        "message": msg,
-        "data": data or {},
-        "timestamp": int(_t.time() * 1000),
-    }
-    if hypothesis:
-        entry["hypothesisId"] = hypothesis
-    try:
-        with open(_LOG_PATH, "a") as f:
-            f.write(json.dumps(entry) + "\n")
-    except Exception:
-        pass
-
 
 _NOMINATIM_DELAY = 1.1
 _FAILURE_DELAY = 5.0
@@ -62,10 +38,6 @@ class ResPartnerGeo(models.Model):
                 _logger.info("Geo backfill: no partners need geocoding.")
                 return
 
-            # #region agent log
-            _dbg("batch start", {"partner_ids": partners.ids, "count": len(partners)}, "H-A")
-            # #endregion
-
             success = 0
             failed = 0
             consecutive_failures = 0
@@ -77,41 +49,13 @@ class ResPartnerGeo(models.Model):
                         consecutive_failures = 0
                         self.env.cr.commit()  # pylint: disable=invalid-commit
                     time.sleep(_NOMINATIM_DELAY)
-                except Exception as exc:
+                except Exception:
                     failed += 1
                     consecutive_failures += 1
-                    # #region agent log
-                    _dbg(
-                        "geo_localize exception",
-                        {
-                            "partner_id": partner.id,
-                            "partner_name": partner.name,
-                            "street": partner.street,
-                            "city": partner.city,
-                            "zip": partner.zip,
-                            "country": partner.country_id.name if partner.country_id else None,
-                            "exc_type": type(exc).__name__,
-                            "exc_msg": str(exc)[:300],
-                            "consecutive": consecutive_failures,
-                        },
-                        "H-B" if "429" in str(exc) or "rate" in str(exc).lower() else "H-C",
-                    )
-                    # #endregion
                     _logger.warning(
                         "Geo backfill: failed for partner %s (%s).", partner.id, partner.name, exc_info=True
                     )
                     if consecutive_failures >= _MAX_CONSECUTIVE_FAIL:
-                        # #region agent log
-                        _dbg(
-                            "aborting — consecutive failure limit reached",
-                            {
-                                "consecutive": consecutive_failures,
-                                "last_partner_id": partner.id,
-                                "last_exc": str(exc)[:300],
-                            },
-                            "H-A",
-                        )
-                        # #endregion
                         _logger.error(
                             "Geo backfill: %d consecutive failures — aborting (likely rate-limited or banned).",
                             consecutive_failures,

--- a/plasticos_geolocalize/models/res_partner_geo.py
+++ b/plasticos_geolocalize/models/res_partner_geo.py
@@ -7,14 +7,33 @@ from odoo import api, models
 
 _logger = logging.getLogger(__name__)
 
+# Defaults; overridable at runtime via ir.config_parameter (see _geo_backfill_param).
 _NOMINATIM_DELAY = 1.1
 _FAILURE_DELAY = 5.0
 _MAX_CONSECUTIVE_FAIL = 3
-_BATCH_SIZE = 50
+_BATCH_SIZE = 25
 
 
 class ResPartnerGeo(models.Model):
     _inherit = "res.partner"
+
+    @api.model
+    def _geo_backfill_param(self, key, default, cast, minimum):
+        """Read a geo-backfill tuning value from ir.config_parameter, fail-soft.
+
+        Falls back to the module default on a missing or malformed value and
+        clamps to a safe minimum (e.g. Nominatim's >=1 req/s usage policy).
+        """
+        # sudo: reading a global System Parameter from an unattended cron — no record-level data exposure.
+        raw = self.env["ir.config_parameter"].sudo().get_param(key)
+        if raw in (None, False, ""):
+            return max(default, minimum)
+        try:
+            value = cast(raw)
+        except (TypeError, ValueError):
+            _logger.warning("Geo backfill: malformed %s=%r — falling back to default %s.", key, raw, default)
+            value = default
+        return max(value, minimum)
 
     @api.model
     def cron_geo_backfill(self):
@@ -24,6 +43,15 @@ class ResPartnerGeo(models.Model):
             return
 
         try:
+            nominatim_delay = self._geo_backfill_param(
+                "plasticos_geolocalize.nominatim_delay", _NOMINATIM_DELAY, float, 1.0
+            )
+            failure_delay = self._geo_backfill_param("plasticos_geolocalize.failure_delay", _FAILURE_DELAY, float, 0.0)
+            batch_size = self._geo_backfill_param("plasticos_geolocalize.batch_size", _BATCH_SIZE, int, 1)
+            max_consecutive_failures = self._geo_backfill_param(
+                "plasticos_geolocalize.max_consecutive_failures", _MAX_CONSECUTIVE_FAIL, int, 1
+            )
+
             partners = self.search(
                 [
                     ("partner_latitude", "in", [0.0, False]),
@@ -32,7 +60,7 @@ class ResPartnerGeo(models.Model):
                     ("city", "!=", False),
                 ],
                 order="id ASC",
-                limit=_BATCH_SIZE,
+                limit=batch_size,
             )
             if not partners:
                 _logger.info("Geo backfill: no partners need geocoding.")
@@ -41,6 +69,9 @@ class ResPartnerGeo(models.Model):
             success = 0
             failed = 0
             consecutive_failures = 0
+            # Nominatim usage policy: >=1 req/s (enforced via the nominatim_delay floor of 1.0s).
+            # The User-Agent and geocoder provider are core-controlled (base_geolocalize); a durable
+            # fix for a persistent 429 is a keyed provider — tracked as a separate follow-up GMP.
             for partner in partners:
                 try:
                     partner.geo_localize()
@@ -48,20 +79,20 @@ class ResPartnerGeo(models.Model):
                         success += 1
                         consecutive_failures = 0
                         self.env.cr.commit()  # pylint: disable=invalid-commit
-                    time.sleep(_NOMINATIM_DELAY)
+                    time.sleep(nominatim_delay)
                 except Exception:
                     failed += 1
                     consecutive_failures += 1
                     _logger.warning(
                         "Geo backfill: failed for partner %s (%s).", partner.id, partner.name, exc_info=True
                     )
-                    if consecutive_failures >= _MAX_CONSECUTIVE_FAIL:
+                    if consecutive_failures >= max_consecutive_failures:
                         _logger.error(
                             "Geo backfill: %d consecutive failures — aborting (likely rate-limited or banned).",
                             consecutive_failures,
                         )
                         break
-                    time.sleep(_FAILURE_DELAY)
+                    time.sleep(failure_delay)
             _logger.info("Geo backfill complete: %d/%d geocoded, %d failed.", success, len(partners), failed)
         finally:
             self.env.cr.execute(


### PR DESCRIPTION
Now scoped to plasticos_geolocalize only; logistics and repo-hygiene split into #93 and #94.

- Remove leftover agent debug instrumentation (_dbg(), hardcoded local log path, #region blocks) from the nightly geo-backfill cron.
- Make Nominatim pacing runtime-configurable via ir.config_parameter (nominatim_delay floored at 1.0s, failure_delay, batch_size default 50->25, max_consecutive_failures), fail-soft; seed via data/geolocalize_config_params.xml (noupdate=1). Advisory-lock try/finally + 3-failure abort guard preserved.
- Version bump 19.0.1.0.0 -> 19.0.1.1.0.

429 root cause is IP/UA-level on the shared egress IP; throttling is a mitigation. Durable fix (keyed geocoder provider) is a separate follow-up.