### PR TITLE
fix(ci): Python 3.9 compat for cron invariant checker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,7 +115,8 @@ check-typed-exception = false
 "**/forbidden/*.py" = ["UP031", "UP030", "F841", "W291", "W293"]
 # Dev tools - relaxed rules (includes complex analysis functions). "S" ignored: dev tooling
 # runs subprocess and parses the repo's own (trusted) XML — not a production attack surface.
-"**/tools/*.py" = ["UP031", "F821", "C901", "S"]
+# UP045 ignored so Optional[] survives when hooks invoke tools with macOS system Python 3.9.
+"**/tools/*.py" = ["UP031", "F821", "C901", "S", "UP045"]
 # Scripts - utility dev/CI scripts with complex main() functions. "S" ignored: subprocess +
 # url-open to known endpoints are inherent to these tools, not runtime code.
 "scripts/*.py" = ["C901", "S"]

--- a/tools/cron_invariant_check.py
+++ b/tools/cron_invariant_check.py
@@ -6,6 +6,7 @@ import ast
 import xml.etree.ElementTree as ET
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Optional
 
 
 @dataclass
@@ -23,7 +24,7 @@ def _is_cron_method(node: ast.FunctionDef) -> bool:
     return node.name.startswith(("cron_", "_cron_", "action_cron_")) or node.name in {"run_monthly_audit"}
 
 
-def _attr_name(call: ast.Call) -> str | None:
+def _attr_name(call: ast.Call) -> Optional[str]:
     if isinstance(call.func, ast.Attribute):
         return call.func.attr
     return None


### PR DESCRIPTION
Use Optional[str] and suppress UP045 in tools/ so pre-commit hooks
work when python3 resolves to macOS system 3.9; CI remains on 3.12.

Co-authored-by: Cursor <cursoragent@cursor.com>
