### PR TITLE
feat(gate): plasticos_gate client + matcher Gate-primary fallback (Track A)

### DIFF
--- a/config/odoo_module_order.yaml
+++ b/config/odoo_module_order.yaml
@@ -84,6 +84,7 @@ docker_enterprise_modules:
 default_install_order:
   - plasticos_accounting
   - plasticos_base
+  - plasticos_gate
   - plasticos_material_profile
   - plasticos_logistics
   - plasticos_facility_profile

--- a/docs/roadmap/registry.yaml
+++ b/docs/roadmap/registry.yaml
@@ -28,19 +28,19 @@ items:
   phase: 1
   kind: scope_in
   title: Gate client at `plasticos.buyer.matcher` seam
-  status: pending
+  status: complete
 - id: ROAD-GATE-011
   domain: gate-autonomy
   phase: 1
   kind: scope_in
   title: try Gate → fallback local matcher + Neo4j
-  status: pending
+  status: complete
 - id: ROAD-GATE-012
   domain: gate-autonomy
   phase: 1
   kind: scope_in
   title: 'Match audit: `plasticos.match.result`, correlation IDs'
-  status: pending
+  status: complete
 - id: ROAD-GATE-013
   domain: gate-autonomy
   phase: 1
@@ -52,13 +52,13 @@ items:
   phase: 1
   kind: scope_in
   title: 'ICP: `plasticos.gate.url`, `plasticos.gate.matching_enabled`'
-  status: pending
+  status: complete
 - id: ROAD-GATE-015
   domain: gate-autonomy
   phase: 1
   kind: scope_in
   title: '`external_dependencies`: `constellation-node-sdk` (match module)'
-  status: pending
+  status: complete
 - id: ROAD-GATE-020
   domain: gate-autonomy
   phase: 1

--- a/plasticos_buyer_match_engine/__manifest__.py
+++ b/plasticos_buyer_match_engine/__manifest__.py
@@ -21,6 +21,7 @@
     "depends": [
         "base_setup",
         "plasticos_base",
+        "plasticos_gate",
         "plasticos_security_base",
         "plasticos_intake",
         "plasticos_material_profile",

--- a/plasticos_buyer_match_engine/models/match_result_writer.py
+++ b/plasticos_buyer_match_engine/models/match_result_writer.py
@@ -68,6 +68,9 @@ class MatchResultWriter(models.AbstractModel):
                 "gates_passed": m.get("gates_passed", 0),
                 "gates_failed": gates_failed,
                 "typical_price": m.get("typical_price", 0.0),
+                "match_source": m.get("match_source", "local"),
+                "gate_packet_id": m.get("gate_packet_id"),
+                "gate_correlation_id": m.get("gate_correlation_id"),
             }
             if m.get("match_details"):
                 score_breakdown["match_details"] = m["match_details"]

--- a/plasticos_buyer_match_engine/models/matcher.py
+++ b/plasticos_buyer_match_engine/models/matcher.py
@@ -38,6 +38,50 @@ class BuyerMatcher(models.Model):
         return not matching_engine_is_enabled(self.env) or matching_engine_is_stubbed(self.env)
 
     @api.model
+    def _should_try_gate_matching(self):
+        """Return True when Gate URL is configured and SDK is available."""
+        from odoo.addons.plasticos_gate.services.gate_config import gate_matching_enabled
+
+        return gate_matching_enabled(self.env)
+
+    @api.model
+    def _find_matches_via_gate(self, supplier_partner_id, intake_id=None, max_results=20, mode="strict"):
+        """Route match request through Constellation Gate (CEG worker)."""
+        from odoo.addons.plasticos_gate.services.gate_builders import build_match_request
+        from odoo.addons.plasticos_gate.services.gate_client import send_match_action
+        from odoo.addons.plasticos_gate.services.gate_mappers import (
+            extract_audit_metadata,
+            map_match_response,
+            map_match_response_to_matcher_dicts,
+        )
+
+        supplier = self.env["res.partner"].browse(supplier_partner_id)
+        if not supplier.exists():
+            raise ValidationError(_("Supplier partner %s not found") % supplier_partner_id)
+
+        intake = None
+        if intake_id:
+            intake = self.env["plasticos.intake"].browse(intake_id)
+            if not intake.exists() or intake.partner_id.id != supplier_partner_id:
+                raise ValidationError(_("Intake %s not found or doesn't match supplier") % intake_id)
+
+        if intake and intake.exists():
+            request = build_match_request(self.env, intake=intake, top_n=max_results, mode=mode)
+        else:
+            request = build_match_request(self.env, supplier=supplier, top_n=max_results, mode=mode)
+
+        correlation_id = request.odoo.get("correlation_id") if request.odoo else None
+        gate_result = send_match_action(
+            self.env,
+            payload=request.to_dict(),
+            correlation_id=correlation_id,
+        )
+        mapped = map_match_response(gate_result["payload"])
+        audit = extract_audit_metadata(gate_result["packet"])
+        matches = map_match_response_to_matcher_dicts(mapped, audit_metadata=audit)
+        return matches[:max_results]
+
+    @api.model
     def find_matches_for_supplier(self, supplier_partner_id, intake_id=None, max_results=20, mode="strict"):
         """
         Find buyer matches for a supplier based on material requirements.
@@ -50,18 +94,6 @@ class BuyerMatcher(models.Model):
 
         Returns:
             list[dict]: Match results with buyer info and scores, sorted by score descending
-            [
-                {
-                    'buyer_id': 123,
-                    'buyer_name': 'Acme Recycling',
-                    'total_score': 0.85,
-                    'gates_passed': 8,
-                    'gates_failed': ['gate_3', 'gate_7'],
-                    'match_details': {...},  # From graph service
-                    'facility_profile_id': 456
-                },
-                ...
-            ]
         """
         if self._matching_stub_enabled():
             _logger.warning(
@@ -71,6 +103,31 @@ class BuyerMatcher(models.Model):
             )
             return []
 
+        if self._should_try_gate_matching():
+            try:
+                return self._find_matches_via_gate(
+                    supplier_partner_id,
+                    intake_id=intake_id,
+                    max_results=max_results,
+                    mode=mode,
+                )
+            except Exception as exc:
+                _logger.warning(
+                    "Gate match failed; falling back to local matcher: %s",
+                    exc,
+                    exc_info=True,
+                )
+
+        return self._find_matches_local(
+            supplier_partner_id,
+            intake_id=intake_id,
+            max_results=max_results,
+            mode=mode,
+        )
+
+    @api.model
+    def _find_matches_local(self, supplier_partner_id, intake_id=None, max_results=20, mode="strict"):
+        """Local Stage-1 gates + Neo4j scoring (pre-Gate fallback path)."""
         # Validate supplier exists and has intake data
         supplier = self.env["res.partner"].browse(supplier_partner_id)
         if not supplier.exists():

--- a/plasticos_gate/__init__.py
+++ b/plasticos_gate/__init__.py
@@ -1,0 +1,1 @@
+from . import services

--- a/plasticos_gate/__manifest__.py
+++ b/plasticos_gate/__manifest__.py
@@ -1,0 +1,18 @@
+{
+    "name": "PlasticOS Gate Client",
+    "version": "19.0.1.0.0",
+    "category": "Plasticos/Integration",
+    "summary": "Constellation Gate TransportPacket client seam for Odoo intelligence routing.",
+    "author": "Igor Beylin",
+    "depends": [
+        "base",
+        "plasticos_base",
+    ],
+    "data": [
+        "data/gate_icp_seed.xml",
+    ],
+    "external_dependencies": {"python": ["constellation_node_sdk"]},
+    "installable": True,
+    "application": False,
+    "license": "LGPL-3",
+}

--- a/plasticos_gate/data/gate_icp_seed.xml
+++ b/plasticos_gate/data/gate_icp_seed.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo noupdate="1">
+
+    <record id="param_gate_url" model="ir.config_parameter">
+        <field name="key">plasticos.gate.url</field>
+        <field name="value"></field>
+    </record>
+    <record id="param_gate_local_node" model="ir.config_parameter">
+        <field name="key">plasticos.gate.local_node</field>
+        <field name="value">odoo</field>
+    </record>
+    <record id="param_gate_matching_enabled" model="ir.config_parameter">
+        <field name="key">plasticos.gate.matching_enabled</field>
+        <field name="value">1</field>
+    </record>
+    <record id="param_gate_matching_action" model="ir.config_parameter">
+        <field name="key">plasticos.gate.matching_action</field>
+        <field name="value">match</field>
+    </record>
+    <record id="param_gate_timeout_seconds" model="ir.config_parameter">
+        <field name="key">plasticos.gate.timeout_seconds</field>
+        <field name="value">30</field>
+    </record>
+    <record id="param_gate_org_id" model="ir.config_parameter">
+        <field name="key">plasticos.gate.org_id</field>
+        <field name="value"></field>
+    </record>
+
+</odoo>

--- a/plasticos_gate/services/__init__.py
+++ b/plasticos_gate/services/__init__.py
@@ -1,0 +1,4 @@
+from . import gate_allowlists
+from . import gate_config
+from . import gate_contracts
+from . import gate_mappers

--- a/plasticos_gate/services/gate_allowlists.py
+++ b/plasticos_gate/services/gate_allowlists.py
@@ -1,0 +1,66 @@
+"""Field allowlists and mappings for Odoo <-> Gate payloads."""
+
+from __future__ import annotations
+
+PARTNER_SNAPSHOT_FIELD_MAP = {
+    "name": "name",
+    "website": "website",
+    "city": "city",
+    "zip": "zip",
+    "street": "street",
+    "street2": "street2",
+    "comment": "comment",
+    "email": "email",
+    "phone": "phone",
+}
+
+PARTNER_WRITEBACK_FIELD_ALLOWLIST = {
+    "name",
+    "website",
+    "city",
+    "zip",
+    "street",
+    "street2",
+    "email",
+    "phone",
+}
+
+WEB_LEAD_SEED_FIELD_MAP = {
+    "company_name": "company",
+    "contact_name": "contact",
+    "contact_email": "email",
+    "contact_phone": "phone",
+    "material_description": "material_desc",
+    "quantity_text": "quantity_text",
+    "contaminant_notes": "contaminants",
+}
+
+WEB_LEAD_WRITEBACK_FIELD_MAP = {
+    "company": "company_name",
+    "contact": "contact_name",
+    "email": "contact_email",
+    "phone": "contact_phone",
+    "material_desc": "material_description",
+    "quantity_text": "quantity_text",
+}
+
+INTAKE_SNAPSHOT_FIELD_MAP = {
+    "quantity_per_load_lbs": "quantity_per_load_lbs",
+    "contamination_pct": "contamination_pct",
+    "mfi_value": "mfi",
+    "lat": "lat",
+    "lon": "lon",
+}
+
+INTAKE_WRITEBACK_FIELD_MAP = {
+    "quantity_per_load_lbs": "quantity_per_load_lbs",
+    "contamination_pct": "contamination_pct",
+    "mfi": "mfi_value",
+}
+
+MATCH_RESULT_FIELD_MAP = {
+    "buyer_partner_id": "buyer_id",
+    "score": "match_score",
+    "reason": "match_reason",
+    "typical_price": "typical_price",
+}

--- a/plasticos_gate/services/gate_builders.py
+++ b/plasticos_gate/services/gate_builders.py
@@ -1,0 +1,130 @@
+"""Typed allowlisted request builders for Gate payloads."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .gate_allowlists import INTAKE_SNAPSHOT_FIELD_MAP, PARTNER_SNAPSHOT_FIELD_MAP, WEB_LEAD_SEED_FIELD_MAP
+from .gate_contracts import (
+    ConvergeRequest,
+    MatchRequest,
+    OdooContext,
+    ProcessIntakeRequest,
+    ProcessWebLeadRequest,
+)
+
+
+def _get_relation_value(record, field_name: str) -> Any:
+    if field_name not in record._fields:
+        return None
+    value = record[field_name]
+    if hasattr(value, "id"):
+        if field_name == "state_id":
+            return getattr(value, "code", None) or getattr(value, "name", None)
+        if field_name == "country_id":
+            return getattr(value, "code", None) or getattr(value, "name", None)
+        return getattr(value, "id", None)
+    return value
+
+
+def build_odoo_context(env, *, model: str, record_id: int) -> OdooContext:
+    return OdooContext(
+        model=model,
+        record_id=record_id,
+        company_id=getattr(env.company, "id", None),
+        user_id=getattr(env.user, "id", None),
+        db_name=getattr(env.cr, "dbname", None),
+        correlation_id=f"{model}:{record_id}",
+    )
+
+
+def build_converge_request(
+    env, run_rec, *, domain: str = "plasticos", max_passes: int | None = None
+) -> ConvergeRequest:
+    partner = run_rec.partner_id
+    snapshot: dict[str, Any] = {}
+    for src_field, payload_field in PARTNER_SNAPSHOT_FIELD_MAP.items():
+        value = _get_relation_value(partner, src_field)
+        if value not in (None, False, ""):
+            snapshot[payload_field] = value
+    if getattr(run_rec, "source_ids", False):
+        urls = [s.url for s in run_rec.source_ids if getattr(s, "url", None)]
+        if urls:
+            snapshot["source_urls"] = urls
+    odoo = build_odoo_context(env, model=run_rec._name, record_id=run_rec.id).to_dict()
+    return ConvergeRequest(
+        entity_id=f"res.partner:{partner.id}",
+        domain=domain,
+        entity_snapshot=snapshot,
+        odoo=odoo,
+        max_passes=max_passes,
+    )
+
+
+def build_match_request(env, *, intake=None, supplier=None, top_n: int = 20, mode: str = "strict") -> MatchRequest:
+    query: dict[str, Any] = {}
+    odoo: dict[str, Any] = {}
+    if intake is not None:
+        if "polymer_id" in intake._fields and intake.polymer_id:
+            query["polymer_type"] = intake.polymer_id.code or intake.polymer_id.name
+        if "form_id" in intake._fields and intake.form_id:
+            query["form"] = intake.form_id.code or intake.form_id.name
+        if "color_id" in intake._fields and intake.color_id:
+            query["color"] = intake.color_id.code or intake.color_id.name
+        for src, dst in INTAKE_SNAPSHOT_FIELD_MAP.items():
+            value = _get_relation_value(intake, src)
+            if value not in (None, False, ""):
+                query[dst] = value
+        if "source_type_id" in intake._fields and intake.source_type_id:
+            query["source_type"] = intake.source_type_id.code or intake.source_type_id.name
+        odoo = build_odoo_context(env, model=intake._name, record_id=intake.id).to_dict()
+        query["intake_id"] = intake.id
+        if getattr(intake, "partner_id", False):
+            query["supplier_partner_id"] = intake.partner_id.id
+    elif supplier is not None:
+        odoo = build_odoo_context(env, model=supplier._name, record_id=supplier.id).to_dict()
+        query["supplier_partner_id"] = supplier.id
+    else:
+        raise ValueError("build_match_request requires intake or supplier")
+    if mode:
+        query["mode"] = mode
+    return MatchRequest(query=query, top_n=top_n, odoo=odoo)
+
+
+def build_web_lead_request(env, lead_rec, *, raw_payload: dict[str, Any] | None = None) -> ProcessWebLeadRequest:
+    seed: dict[str, Any] = {}
+    for src_field, payload_field in WEB_LEAD_SEED_FIELD_MAP.items():
+        if src_field in lead_rec._fields:
+            value = lead_rec[src_field]
+            if value not in (None, False, ""):
+                seed[payload_field] = value
+    images = lead_rec.image_urls if "image_urls" in lead_rec._fields and lead_rec.image_urls else []
+    if images:
+        seed["image_urls"] = images
+    odoo = build_odoo_context(env, model=lead_rec._name, record_id=lead_rec.id).to_dict()
+    return ProcessWebLeadRequest(
+        lead_id=lead_rec.lead_id,
+        domain="plasticos",
+        source=lead_rec.source or "cognito_form",
+        raw_payload=raw_payload or (lead_rec.raw_payload or {}),
+        normalized_seed=seed,
+        odoo=odoo,
+    )
+
+
+def build_intake_request(env, intake_rec) -> ProcessIntakeRequest:
+    snapshot: dict[str, Any] = {}
+    if "partner_id" in intake_rec._fields and intake_rec.partner_id:
+        snapshot["supplier_partner_id"] = intake_rec.partner_id.id
+    if "polymer_id" in intake_rec._fields and intake_rec.polymer_id:
+        snapshot["polymer_type"] = intake_rec.polymer_id.code or intake_rec.polymer_id.name
+    if "form_id" in intake_rec._fields and intake_rec.form_id:
+        snapshot["form"] = intake_rec.form_id.code or intake_rec.form_id.name
+    if "color_id" in intake_rec._fields and intake_rec.color_id:
+        snapshot["color"] = intake_rec.color_id.code or intake_rec.color_id.name
+    for src, dst in INTAKE_SNAPSHOT_FIELD_MAP.items():
+        value = _get_relation_value(intake_rec, src)
+        if value not in (None, False, ""):
+            snapshot[dst] = value
+    odoo = build_odoo_context(env, model=intake_rec._name, record_id=intake_rec.id).to_dict()
+    return ProcessIntakeRequest(intake_id=intake_rec.id, domain="plasticos", intake_snapshot=snapshot, odoo=odoo)

--- a/plasticos_gate/services/gate_client.py
+++ b/plasticos_gate/services/gate_client.py
@@ -1,0 +1,107 @@
+"""Canonical Odoo -> Gate SDK bridge (sole constellation_node_sdk import site)."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from typing import Any
+
+from .gate_config import GateIntegrationError, build_gate_client_config, get_matching_action, resolve_tenant
+
+try:
+    from constellation_node_sdk import GateClient, create_transport_packet
+except Exception as exc:  # pragma: no cover
+    GateClient = None
+    create_transport_packet = None
+    _SDK_IMPORT_ERROR = exc
+else:  # pragma: no cover
+    _SDK_IMPORT_ERROR = None
+
+
+def _require_sdk() -> None:
+    if GateClient is None or create_transport_packet is None:
+        raise GateIntegrationError(f"constellation_node_sdk not installed: {_SDK_IMPORT_ERROR}")
+
+
+def _run_async(coro):
+    """Bridge async GateClient.send_to_gate for synchronous Odoo workers."""
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coro)
+
+    box: dict[str, Any] = {}
+    err: dict[str, BaseException] = {}
+
+    def runner() -> None:
+        try:
+            box["result"] = asyncio.run(coro)
+        except BaseException as exc:  # pragma: no cover
+            err["error"] = exc
+
+    thread = threading.Thread(target=runner, daemon=True)
+    thread.start()
+    thread.join()
+    if "error" in err:
+        raise err["error"]
+    return box.get("result")
+
+
+def send_action(
+    env,
+    *,
+    action: str,
+    payload: dict[str, Any],
+    correlation_id: str | None = None,
+    compliance_tags: tuple[str, ...] = (),
+) -> dict[str, Any]:
+    """Send a TransportPacket to Gate and return packet + payload dicts."""
+    _require_sdk()
+    config = build_gate_client_config(env)
+    client = GateClient(config)
+    icp = env["ir.config_parameter"].sudo()
+    local_node = (icp.get_param("plasticos.gate.local_node") or "odoo").strip().lower()
+    tenant = resolve_tenant(env)
+    user = env.user
+    tenant_ctx = {
+        "actor": tenant,
+        "on_behalf_of": tenant,
+        "originator": local_node,
+        "org_id": tenant,
+        "user_id": str(user.id) if user and user.id else None,
+    }
+    packet = create_transport_packet(
+        action=action,
+        payload=payload,
+        tenant=tenant_ctx,
+        source_node=local_node,
+        destination_node="gate",
+        reply_to=local_node,
+        correlation_id=correlation_id,
+        classification="internal",
+        compliance_tags=compliance_tags,
+    )
+    try:
+        response_packet = _run_async(client.send_to_gate(packet))
+    except Exception as exc:
+        raise GateIntegrationError(str(exc)) from exc
+    return {
+        "packet": response_packet,
+        "payload": dict(response_packet.payload),
+    }
+
+
+def send_match_action(
+    env,
+    *,
+    payload: dict[str, Any],
+    correlation_id: str | None = None,
+) -> dict[str, Any]:
+    action = get_matching_action(env)
+    return send_action(
+        env,
+        action=action,
+        payload=payload,
+        correlation_id=correlation_id,
+        compliance_tags=("ERP", "MATCHING"),
+    )

--- a/plasticos_gate/services/gate_config.py
+++ b/plasticos_gate/services/gate_config.py
@@ -1,0 +1,51 @@
+"""Gate ICP helpers and integration exceptions — no UserError on fallback path."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from constellation_node_sdk import GateClientConfig
+
+
+class GateIntegrationError(Exception):
+    """Raised when Gate transport fails; matcher catches and falls back locally."""
+
+
+def gate_matching_enabled(env) -> bool:
+    """Return True when Gate matching should be attempted (never raises)."""
+    icp = env["ir.config_parameter"].sudo()
+    url = (icp.get_param("plasticos.gate.url") or "").strip()
+    if not url.startswith(("http://", "https://")):
+        return False
+    if (icp.get_param("plasticos.gate.matching_enabled", "1") or "").strip() in {"0", "false", "False"}:
+        return False
+    try:
+        import constellation_node_sdk  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+def get_matching_action(env) -> str:
+    icp = env["ir.config_parameter"].sudo()
+    return (icp.get_param("plasticos.gate.matching_action") or "match").strip().lower()
+
+
+def build_gate_client_config(env) -> GateClientConfig:
+    """Build SDK config — call only after gate_matching_enabled() passes."""
+    from constellation_node_sdk import GateClientConfig
+
+    icp = env["ir.config_parameter"].sudo()
+    return GateClientConfig(
+        gate_url=(icp.get_param("plasticos.gate.url") or "").strip(),
+        local_node=(icp.get_param("plasticos.gate.local_node") or "odoo").strip().lower(),
+        timeout_seconds=float(icp.get_param("plasticos.gate.timeout_seconds") or "30"),
+        allowed_gate_destination="gate",
+    )
+
+
+def resolve_tenant(env) -> str:
+    icp = env["ir.config_parameter"].sudo()
+    org_id = (icp.get_param("plasticos.gate.org_id") or "").strip()
+    return org_id or env.cr.dbname

--- a/plasticos_gate/services/gate_contracts.py
+++ b/plasticos_gate/services/gate_contracts.py
@@ -1,0 +1,161 @@
+"""Typed Odoo client-side contracts for Gate-routed intelligence calls."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(slots=True)
+class OdooContext:
+    model: str
+    record_id: int
+    company_id: int | None = None
+    user_id: int | None = None
+    db_name: str | None = None
+    correlation_id: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        data = {
+            "model": self.model,
+            "record_id": self.record_id,
+            "company_id": self.company_id,
+            "user_id": self.user_id,
+            "db_name": self.db_name,
+            "correlation_id": self.correlation_id,
+        }
+        return {k: v for k, v in data.items() if v not in (None, "")}
+
+
+@dataclass(slots=True)
+class ConvergeRequest:
+    entity_id: str
+    domain: str
+    entity_snapshot: dict[str, Any] = field(default_factory=dict)
+    odoo: dict[str, Any] = field(default_factory=dict)
+    profile_id: str | None = None
+    max_passes: int | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        data: dict[str, Any] = {
+            "entity_id": self.entity_id,
+            "domain": self.domain,
+            "entity_snapshot": self.entity_snapshot,
+            "odoo": self.odoo,
+        }
+        if self.profile_id:
+            data["profile_id"] = self.profile_id
+        if self.max_passes is not None:
+            data["max_passes"] = self.max_passes
+        return data
+
+
+@dataclass(slots=True)
+class ConvergeResponse:
+    run_id: str | None = None
+    status: str | None = None
+    pass_count: int | None = None
+    final_fields: dict[str, Any] = field(default_factory=dict)
+    writeback: dict[str, Any] = field(default_factory=dict)
+    total_tokens: int | None = None
+    total_cost_usd: float | None = None
+    raw: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class MatchRequest:
+    query: dict[str, Any]
+    match_direction: str = "intake_to_buyer"
+    top_n: int = 20
+    odoo: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        data: dict[str, Any] = {
+            "query": self.query,
+            "match_direction": self.match_direction,
+            "top_n": self.top_n,
+        }
+        if self.odoo:
+            data["odoo"] = self.odoo
+        return data
+
+
+@dataclass(slots=True)
+class MatchCandidate:
+    buyer_partner_id: int | None = None
+    buyer_name: str | None = None
+    facility_profile_id: int | None = None
+    score: float | None = None
+    reason: str | None = None
+    typical_price: float | None = None
+    gates_passed: list[str] = field(default_factory=list)
+    gates_failed: list[str] = field(default_factory=list)
+    raw: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class MatchResponse:
+    status: str | None = None
+    match_direction: str | None = None
+    top_n: int | None = None
+    results: list[MatchCandidate] = field(default_factory=list)
+    raw: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class ProcessWebLeadRequest:
+    lead_id: str
+    domain: str
+    source: str
+    raw_payload: dict[str, Any]
+    normalized_seed: dict[str, Any]
+    odoo: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        data = {
+            "lead_id": self.lead_id,
+            "domain": self.domain,
+            "source": self.source,
+            "raw_payload": self.raw_payload,
+            "normalized_seed": self.normalized_seed,
+        }
+        if self.odoo:
+            data["odoo"] = self.odoo
+        return data
+
+
+@dataclass(slots=True)
+class ProcessWebLeadResponse:
+    status: str | None = None
+    classification: dict[str, Any] = field(default_factory=dict)
+    normalized: dict[str, Any] = field(default_factory=dict)
+    intake_candidate: dict[str, Any] = field(default_factory=dict)
+    recommended_action: str | None = None
+    raw: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class ProcessIntakeRequest:
+    intake_id: int
+    domain: str
+    intake_snapshot: dict[str, Any]
+    odoo: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        data = {
+            "intake_id": self.intake_id,
+            "domain": self.domain,
+            "intake_snapshot": self.intake_snapshot,
+        }
+        if self.odoo:
+            data["odoo"] = self.odoo
+        return data
+
+
+@dataclass(slots=True)
+class ProcessIntakeResponse:
+    status: str | None = None
+    normalized: dict[str, Any] = field(default_factory=dict)
+    match_query: dict[str, Any] = field(default_factory=dict)
+    recommended_next_action: str | None = None
+    raw: dict[str, Any] = field(default_factory=dict)

--- a/plasticos_gate/services/gate_mappers.py
+++ b/plasticos_gate/services/gate_mappers.py
@@ -1,0 +1,153 @@
+"""Typed response mappers for Gate payloads -> Odoo matcher shapes."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .gate_allowlists import PARTNER_WRITEBACK_FIELD_ALLOWLIST, WEB_LEAD_WRITEBACK_FIELD_MAP
+from .gate_contracts import (
+    ConvergeResponse,
+    MatchCandidate,
+    MatchResponse,
+    ProcessIntakeResponse,
+    ProcessWebLeadResponse,
+)
+
+
+def extract_audit_metadata(response_packet) -> dict[str, Any]:
+    """Read correlation IDs from TransportPacket header, not flat payload."""
+    header = response_packet.header
+    return {
+        "gate_packet_id": str(header.packet_id),
+        "gate_correlation_id": header.correlation_id,
+    }
+
+
+def _normalize_score(score: float | None) -> float:
+    if score is None:
+        return 0.0
+    value = float(score)
+    if value > 1.0:
+        return value / 100.0
+    return value
+
+
+def map_match_response(payload: dict[str, Any]) -> MatchResponse:
+    results: list[MatchCandidate] = []
+    for item in payload.get("results") or []:
+        gates_passed = item.get("gates_passed") or []
+        gates_failed = item.get("gates_failed") or []
+        if isinstance(gates_passed, int):
+            gates_passed = []
+        if isinstance(gates_failed, int):
+            gates_failed = []
+        results.append(
+            MatchCandidate(
+                buyer_partner_id=item.get("buyer_partner_id") or item.get("buyer_id"),
+                buyer_name=item.get("buyer_name"),
+                facility_profile_id=item.get("facility_profile_id"),
+                score=item.get("score"),
+                reason=item.get("reason") or item.get("match_reason"),
+                typical_price=item.get("typical_price") or item.get("price_anchor"),
+                gates_passed=list(gates_passed),
+                gates_failed=list(gates_failed),
+                raw=item,
+            )
+        )
+    return MatchResponse(
+        status=payload.get("status"),
+        match_direction=payload.get("match_direction"),
+        top_n=payload.get("top_n"),
+        results=results,
+        raw=payload,
+    )
+
+
+def map_match_response_to_matcher_dicts(
+    mapped: MatchResponse,
+    *,
+    audit_metadata: dict[str, Any] | None = None,
+) -> list[dict[str, Any]]:
+    """Convert Gate match response to plasticos.buyer.matcher result dicts."""
+    audit = audit_metadata or {}
+    results: list[dict[str, Any]] = []
+    for item in mapped.results:
+        if not item.buyer_partner_id:
+            continue
+        results.append(
+            {
+                "buyer_id": int(item.buyer_partner_id),
+                "buyer_name": item.buyer_name,
+                "total_score": _normalize_score(item.score),
+                "typical_price": item.typical_price or 0.0,
+                "gates_passed": item.gates_passed,
+                "gates_failed": item.gates_failed,
+                "match_details": item.raw,
+                "facility_profile_id": item.facility_profile_id,
+                "reason": item.reason,
+                "match_source": "gate",
+                "gate_packet_id": audit.get("gate_packet_id"),
+                "gate_correlation_id": audit.get("gate_correlation_id"),
+            }
+        )
+    results.sort(key=lambda row: row.get("total_score") or 0.0, reverse=True)
+    return results
+
+
+def map_converge_response(payload: dict[str, Any]) -> ConvergeResponse:
+    return ConvergeResponse(
+        run_id=payload.get("run_id"),
+        status=payload.get("status"),
+        pass_count=payload.get("pass_count"),
+        final_fields=payload.get("final_fields") or {},
+        writeback=payload.get("writeback") or {},
+        total_tokens=payload.get("total_tokens"),
+        total_cost_usd=payload.get("total_cost_usd"),
+        raw=payload,
+    )
+
+
+def partner_writeback_from_converge(resp: ConvergeResponse) -> dict[str, Any]:
+    writeback = resp.writeback or {}
+    partner_fields = writeback.get("partner_fields") if isinstance(writeback, dict) else None
+    source = partner_fields if isinstance(partner_fields, dict) and partner_fields else resp.final_fields
+    return {k: v for k, v in source.items() if k in PARTNER_WRITEBACK_FIELD_ALLOWLIST and v not in (None, False, "")}
+
+
+def map_web_lead_response(payload: dict[str, Any]) -> ProcessWebLeadResponse:
+    return ProcessWebLeadResponse(
+        status=payload.get("status"),
+        classification=payload.get("classification") or {},
+        normalized=payload.get("normalized") or {},
+        intake_candidate=payload.get("intake_candidate") or {},
+        recommended_action=payload.get("recommended_action"),
+        raw=payload,
+    )
+
+
+def web_lead_writeback(resp: ProcessWebLeadResponse, lead_model) -> dict[str, Any]:
+    vals: dict[str, Any] = {}
+    for payload_key, field_name in WEB_LEAD_WRITEBACK_FIELD_MAP.items():
+        if field_name in lead_model._fields:
+            value = resp.normalized.get(payload_key)
+            if value not in (None, False, ""):
+                vals[field_name] = value
+    if "ai_normalized" in lead_model._fields:
+        vals["ai_normalized"] = resp.normalized
+    if "ai_analysis" in lead_model._fields:
+        vals["ai_analysis"] = resp.raw
+    if "decision" in lead_model._fields:
+        temp = resp.classification.get("temperature")
+        if temp in {"hot", "cold"}:
+            vals["decision"] = temp
+    return vals
+
+
+def map_intake_response(payload: dict[str, Any]) -> ProcessIntakeResponse:
+    return ProcessIntakeResponse(
+        status=payload.get("status"),
+        normalized=payload.get("normalized") or {},
+        match_query=payload.get("match_query") or {},
+        recommended_next_action=payload.get("recommended_next_action"),
+        raw=payload,
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,9 @@ requests>=2.28.0
 # Required for plasticos_buyer_match_engine Neo4j graph traversal
 neo4j>=5.0.0
 
+# Constellation Gate TransportPacket client (plasticos_gate)
+constellation-node-sdk @ git+https://github.com/cryptoxdog/Gate_SDK.git@ab9df5f15c1ba433c3f072a1ca01052584682758
+
 # PR Repair engine — pr_repair_adapter.py uses this for state-machine-governed
 # CI repair loop (Issue→Finding conversion, approval gates, repeated-failure guard).
 # Pinned to a specific commit SHA for reproducible builds.

--- a/tests/test_gate_match_contract.py
+++ b/tests/test_gate_match_contract.py
@@ -1,0 +1,161 @@
+"""Pure-Python contract tests for plasticos_gate match builders, mappers, and config."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+from plasticos_gate.services.gate_builders import build_match_request  # noqa: E402
+from plasticos_gate.services.gate_config import gate_matching_enabled  # noqa: E402
+from plasticos_gate.services.gate_mappers import (  # noqa: E402
+    extract_audit_metadata,
+    map_match_response,
+    map_match_response_to_matcher_dicts,
+)
+
+
+class _MockICP:
+    def __init__(self, params: dict[str, str]):
+        self._params = params
+
+    def get_param(self, key: str, default=None):
+        return self._params.get(key, default)
+
+
+class _MockEnv:
+    def __init__(self, params: dict[str, str] | None = None):
+        self.cr = SimpleNamespace(dbname="testdb")
+        self.company = SimpleNamespace(id=1)
+        self.user = SimpleNamespace(id=2)
+        self._params = params or {}
+        self._icp = _MockICP(self._params)
+
+    def __getitem__(self, key: str):
+        if key == "ir.config_parameter":
+            return self
+        raise KeyError(key)
+
+    def sudo(self):
+        return self
+
+    def get_param(self, key: str, default=None):
+        return self._icp.get_param(key, default)
+
+
+class _FieldProxy:
+    def __init__(self, *, code=None, name=None, record_id=None):
+        self.code = code
+        self.name = name
+        self.id = record_id
+
+
+class _IntakeStub:
+    _name = "plasticos.intake"
+
+    def __init__(self):
+        self.id = 42
+        self._fields = {
+            "polymer_id",
+            "form_id",
+            "color_id",
+            "source_type_id",
+            "quantity_per_load_lbs",
+            "contamination_pct",
+            "mfi_value",
+            "lat",
+            "lon",
+            "partner_id",
+        }
+        self.polymer_id = _FieldProxy(code="HDPE", name="HDPE", record_id=10)
+        self.form_id = _FieldProxy(code="PELLET", name="Pellet", record_id=11)
+        self.color_id = _FieldProxy(code="NAT", name="Natural", record_id=12)
+        self.source_type_id = _FieldProxy(code="PCR", name="Post Consumer", record_id=13)
+        self.quantity_per_load_lbs = 40000.0
+        self.contamination_pct = 2.5
+        self.mfi_value = 0.8
+        self.lat = 35.0
+        self.lon = -80.0
+        self.partner_id = SimpleNamespace(id=99)
+
+    def __getitem__(self, key):
+        return getattr(self, key)
+
+
+def test_gate_matching_enabled_false_when_url_empty():
+    env = _MockEnv({"plasticos.gate.matching_enabled": "1"})
+    assert gate_matching_enabled(env) is False
+
+
+def test_gate_matching_enabled_false_when_flag_off():
+    env = _MockEnv(
+        {
+            "plasticos.gate.url": "https://gate.example.com",
+            "plasticos.gate.matching_enabled": "0",
+        }
+    )
+    assert gate_matching_enabled(env) is False
+
+
+def test_build_match_request_maps_intake_fields():
+    env = _MockEnv()
+    intake = _IntakeStub()
+    request = build_match_request(env, intake=intake, top_n=5, mode="strict")
+    assert request.query["polymer_type"] == "HDPE"
+    assert request.query["form"] == "PELLET"
+    assert request.query["color"] == "NAT"
+    assert request.query["quantity_per_load_lbs"] == 40000.0
+    assert request.query["contamination_pct"] == 2.5
+    assert request.query["intake_id"] == 42
+    assert request.query["supplier_partner_id"] == 99
+    assert request.query["mode"] == "strict"
+    assert request.top_n == 5
+    assert request.odoo["model"] == "plasticos.intake"
+    assert request.odoo["record_id"] == 42
+
+
+def test_map_match_response_to_matcher_dicts():
+    payload = {
+        "status": "ok",
+        "results": [
+            {
+                "buyer_partner_id": 7,
+                "buyer_name": "Buyer Co",
+                "score": 85,
+                "facility_profile_id": 3,
+                "reason": "Strong fit",
+                "typical_price": 0.42,
+                "gates_passed": 8,
+                "gates_failed": ["gate_3"],
+            }
+        ],
+    }
+    mapped = map_match_response(payload)
+    rows = map_match_response_to_matcher_dicts(
+        mapped,
+        audit_metadata={"gate_packet_id": "pkt-1", "gate_correlation_id": "corr-1"},
+    )
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["buyer_id"] == 7
+    assert row["buyer_name"] == "Buyer Co"
+    assert row["total_score"] == pytest.approx(0.85)
+    assert row["match_source"] == "gate"
+    assert row["gate_packet_id"] == "pkt-1"
+    assert row["gate_correlation_id"] == "corr-1"
+    assert row["gates_failed"] == ["gate_3"]
+
+
+def test_extract_audit_metadata_reads_packet_header():
+    packet = MagicMock()
+    packet.header.packet_id = "abc-123"
+    packet.header.correlation_id = "corr-xyz"
+    audit = extract_audit_metadata(packet)
+    assert audit["gate_packet_id"] == "abc-123"
+    assert audit["gate_correlation_id"] == "corr-xyz"

--- a/tests/test_gate_matcher_fallback.py
+++ b/tests/test_gate_matcher_fallback.py
@@ -1,0 +1,94 @@
+"""Odoo runtime tests for Gate-primary matcher fallback ordering."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from odoo.addons.plasticos_base.test_common import PlasticosTestCase
+from odoo.tests.common import tagged
+
+
+@tagged("post_install", "-at_install", "plasticos", "matching", "gate")
+class TestGateMatcherFallback(PlasticosTestCase):
+    """Verify stub → gate → local call order on plasticos.buyer.matcher."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls._skip_if_model_missing("plasticos.buyer.matcher")
+        cls.matcher = cls.env["plasticos.buyer.matcher"]
+        cls.supplier = cls._create_partner("Gate Fallback Supplier", supplier_rank=1)
+
+    def test_stub_runs_before_gate_and_returns_empty(self):
+        local_payload = [{"buyer_id": 1, "total_score": 0.5, "gates_passed": 1, "gates_failed": []}]
+        with (
+            patch.object(type(self.matcher), "_matching_stub_enabled", return_value=True),
+            patch(
+                "odoo.addons.plasticos_gate.services.gate_client.send_match_action",
+                side_effect=AssertionError("Gate must not run when stub enabled"),
+            ) as gate_call,
+            patch.object(type(self.matcher), "_find_matches_local", return_value=local_payload) as local_call,
+        ):
+            result = self.matcher.find_matches_for_supplier(self.supplier.id)
+        self.assertEqual(result, [])
+        gate_call.assert_not_called()
+        local_call.assert_not_called()
+
+    def test_gate_disabled_uses_local_only(self):
+        local_payload = [
+            {
+                "buyer_id": self.supplier.id,
+                "buyer_name": self.supplier.name,
+                "total_score": 0.4,
+                "gates_passed": 2,
+                "gates_failed": [],
+                "match_details": {},
+                "facility_profile_id": False,
+                "typical_price": 0.0,
+            }
+        ]
+        with (
+            patch.object(type(self.matcher), "_matching_stub_enabled", return_value=False),
+            patch(
+                "odoo.addons.plasticos_gate.services.gate_config.gate_matching_enabled",
+                return_value=False,
+            ),
+            patch(
+                "odoo.addons.plasticos_gate.services.gate_client.send_match_action",
+                side_effect=AssertionError("Gate must not run when disabled"),
+            ) as gate_call,
+            patch.object(type(self.matcher), "_find_matches_local", return_value=local_payload) as local_call,
+        ):
+            result = self.matcher.find_matches_for_supplier(self.supplier.id)
+        self.assertEqual(result, local_payload)
+        gate_call.assert_not_called()
+        local_call.assert_called_once()
+
+    def test_gate_failure_falls_back_to_local(self):
+        local_payload = [
+            {
+                "buyer_id": self.supplier.id,
+                "buyer_name": self.supplier.name,
+                "total_score": 0.6,
+                "gates_passed": 3,
+                "gates_failed": [],
+                "match_details": {},
+                "facility_profile_id": False,
+                "typical_price": 0.0,
+            }
+        ]
+        with (
+            patch.object(type(self.matcher), "_matching_stub_enabled", return_value=False),
+            patch(
+                "odoo.addons.plasticos_gate.services.gate_config.gate_matching_enabled",
+                return_value=True,
+            ),
+            patch(
+                "odoo.addons.plasticos_gate.services.gate_client.send_match_action",
+                side_effect=RuntimeError("gate down"),
+            ),
+            patch.object(type(self.matcher), "_find_matches_local", return_value=local_payload) as local_call,
+        ):
+            result = self.matcher.find_matches_for_supplier(self.supplier.id)
+        self.assertEqual(result, local_payload)
+        local_call.assert_called_once()

--- a/tests/test_repo_dependency_integrity.py
+++ b/tests/test_repo_dependency_integrity.py
@@ -40,6 +40,7 @@ EXPECTED_CATEGORY = "Plasticos/Matching"
 EXPECTED_DEPENDS = [
     "base_setup",
     "plasticos_base",
+    "plasticos_gate",
     "plasticos_security_base",
     "plasticos_intake",
     "plasticos_material_profile",
@@ -57,6 +58,7 @@ LAYER_ORDER = [
     "contacts",
     "account",
     "plasticos_base",
+    "plasticos_gate",
     "plasticos_security_base",
     "plasticos_intake",
     "plasticos_material_profile",

--- a/tests/tests_init.py
+++ b/tests/tests_init.py
@@ -26,6 +26,7 @@ ODOO_TEST_MODULES = [
     "test_cron_runtime",
     "test_depends_transaction_claims_bridge",
     "test_error_handling",
+    "test_gate_matcher_fallback",
     "test_golden_flows",
     "test_integration_flows",
     "test_onchange_purchase_order_line_plasticos",
@@ -39,6 +40,7 @@ ODOO_TEST_MODULES = [
 PURE_PYTHON_MODULES = [
     "test_cron_invariants",
     "test_cypher_schema_alignment",
+    "test_gate_match_contract",
     "test_odoo19_compat",
     "test_odoo_test_setup_validity",
     "test_phantom_enum_values",


### PR DESCRIPTION
## Summary
Track A — Odoo-only Gate client seam. Adds `plasticos_gate` as the sole TransportPacket client and wires the buyer matcher to try Gate first, then fall back to the existing local Stage-1 + Neo4j matcher. No Gate hub / CEG / EIE in this PR (Track B, external).

- **`plasticos_gate` addon**: `gate_config`, `gate_client`, `gate_builders`, `gate_mappers`, `gate_contracts`, `gate_allowlists` + ICP seed (`plasticos.gate.*`, `noupdate=1`). `gate_matching_enabled()` never constructs `GateClientConfig` (safe fallback on blank URL); `gate_client` preserves the async `_run()` bridge for synchronous Odoo workers.
- **SDK pin**: `constellation-node-sdk` in `requirements.txt`; manifest `external_dependencies` uses import name `constellation_node_sdk`.
- **Matcher seam**: `find_matches_for_supplier` order is **stub → Gate → local**; existing local body renamed `_find_matches_local` (unchanged logic). Return contract preserved.
- **Audit**: `match_result_writer` `score_breakdown` adds `match_source`, `gate_packet_id`, `gate_correlation_id`.
- **Roadmap**: ROAD-GATE-010/011/012/014/015 marked complete (013 enrichment + Phase 3 remain deferred).

## Test plan
- [x] `make pr-check` (local): ruff, XML, wiring, circular-deps, semgrep, pipeline_v2 guard, 298 pure-Python tests pass
- [x] Pure-Python contract tests: `tests/test_gate_match_contract.py` (builders/mappers/config)
- [ ] Odoo runtime tests: `tests/test_gate_matcher_fallback.py` (stub ordering, Gate disabled, Gate failure → local) — run under Odoo.sh `--test-enable`
- [ ] Docker staging: `pip install -r requirements.txt && pip check` (SDK pulls fastapi/starlette/prometheus-client/pyyaml)
- [ ] Post-Track-B smoke: set `plasticos.gate.url`, run Match to Buyers, verify `score_breakdown.match_source == "gate"` and `gate_packet_id` populated; unset URL → `local`

## Notes
- Local fallback is always available, so this is safe to merge before Track B Gate hub is live.
- Does not touch `pipeline_v2.py`, web-lead Gate bridge, or enrichment `converge`.

Made with [Cursor](https://cursor.com)